### PR TITLE
refactor(signups): separate world from character

### DIFF
--- a/src/commands/signups/signup.consts.ts
+++ b/src/commands/signups/signup.consts.ts
@@ -19,11 +19,18 @@ export const SignupCommandData = new SlashCommandBuilder()
   .addStringOption((option) =>
     option
       .setRequired(true)
-      .setDescription('Character Name @ World')
+      .setDescription('Character Name')
       .setName('character'),
   )
   .addStringOption((option) =>
-    option.setRequired(true).setDescription('FF Logs Link').setName('fflogs'),
+    // TODO: Could use FFLogs API to create validated autocomplete list of choices?
+    option.setRequired(true).setDescription('Home World').setName('world'),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('FF Logs Link showing prog point')
+      .setName('fflogs'),
   )
   .addStringOption((option) =>
     option

--- a/src/commands/signups/signup.interfaces.ts
+++ b/src/commands/signups/signup.interfaces.ts
@@ -3,6 +3,8 @@ import { Encounter } from '../../app.consts.js';
 export interface Signup {
   availability: string;
   character: string;
+  discordId: string;
   encounter: Encounter;
   fflogsLink: string;
+  world: string;
 }

--- a/src/commands/signups/signups-command.handler.spec.ts
+++ b/src/commands/signups/signups-command.handler.spec.ts
@@ -35,6 +35,8 @@ describe('Signups Command Handler', () => {
               return 'https://www.fflogs.com';
             case 'availability':
               return 'Monday, Wednesday, Friday';
+            case 'world':
+              return 'Jenova';
           }
         },
       },


### PR DESCRIPTION
Separate Home World from Character. Without this, we'd need to do some parsing to extract the world in order to validate it. 

There's still no validation on actually providing both first/last name in character, but that can come later
