### PR TITLE
refactor(signups): add approval status to signup documents

### DIFF
--- a/src/signups/handlers/signup-command.handler.ts
+++ b/src/signups/handlers/signup-command.handler.ts
@@ -15,7 +15,7 @@ import {
   ConfirmButton,
   SIGNUP_MESSAGES,
 } from '../signup.consts.js';
-import { Signup } from '../signup.interfaces.js';
+import { SignupRequest } from '../signup.interfaces.js';
 import { SignupCommand } from '../signup.command.js';
 import { SignupService } from '../signup.service.js';
 
@@ -40,7 +40,7 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
 
     // the fields are marked required so they should come in with values. empty strings are not allowed
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const signup: Signup = {
+    const signup: SignupRequest = {
       availability: interaction.options.getString('availability')!,
       character: interaction.options.getString('character')!,
       discordId: interaction.user.id,
@@ -100,7 +100,7 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
     encounter,
     fflogsLink,
     world,
-  }: Signup) {
+  }: SignupRequest) {
     const embed = new EmbedBuilder()
       .setTitle(`${EncounterFriendlyDescription[encounter]} Signup`)
       .setDescription("Here's a summary of your selections")

--- a/src/signups/signup.interfaces.ts
+++ b/src/signups/signup.interfaces.ts
@@ -1,6 +1,6 @@
 import { Encounter } from '../app.consts.js';
 
-export interface Signup {
+export interface SignupRequest {
   availability: string;
   character: string;
   discordId: string;
@@ -8,4 +8,8 @@ export interface Signup {
   fflogsLink: string;
   username: string;
   world: string;
+}
+
+export interface Signup extends SignupRequest {
+  approved: boolean;
 }

--- a/src/signups/signup.service.spec.ts
+++ b/src/signups/signup.service.spec.ts
@@ -1,0 +1,80 @@
+import { jest } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { SignupService } from './signup.service.js';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import {
+  CollectionReference,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  Firestore,
+} from 'firebase-admin/firestore';
+import { FIRESTORE } from '../firebase/firebase.consts.js';
+import { Encounter } from '../app.consts.js';
+import { SignupRequest } from './signup.interfaces.js';
+
+describe('Signup Service', () => {
+  let service: SignupService;
+  let firestore: DeepMocked<Firestore>;
+  let collection: DeepMocked<CollectionReference<DocumentData>>;
+  let doc: DeepMocked<DocumentReference<DocumentData>>;
+  const signup: SignupRequest = {
+    availability: 'availability',
+    character: 'character',
+    discordId: 'discordId',
+    encounter: Encounter.DSR,
+    fflogsLink: 'fflogsLink',
+    username: 'username',
+    world: 'world',
+  };
+
+  beforeEach(async () => {
+    doc = createMock<DocumentReference>();
+
+    // TODO: Why do we need to cast `as any` in jest ESM configuration? Without this TSC fails
+    collection = createMock<CollectionReference<DocumentData>>({
+      doc: jest.fn().mockReturnValue(doc) as any,
+    });
+
+    firestore = createMock<Firestore>({
+      collection: jest.fn().mockReturnValue(collection) as any,
+    });
+
+    const fixture = await Test.createTestingModule({
+      providers: [
+        SignupService,
+        {
+          provide: FIRESTORE,
+          useValue: firestore,
+        },
+      ],
+    }).compile();
+
+    service = fixture.get(SignupService);
+  });
+
+  it('should call set if document exists', async () => {
+    doc.get.mockResolvedValueOnce(
+      createMock<DocumentSnapshot>({ exists: true }),
+    );
+
+    await service.upsertSignup(signup);
+
+    expect(doc.set).toHaveBeenCalledWith(signup, {
+      mergeFields: ['fflogsLink', 'character', 'world', 'availability'],
+    });
+
+    expect(doc.create).not.toHaveBeenCalled();
+  });
+
+  it('should call create if document does not exist', async () => {
+    doc.get.mockResolvedValueOnce(
+      createMock<DocumentSnapshot>({ exists: false }),
+    );
+
+    await service.upsertSignup(signup);
+
+    expect(doc.create).toHaveBeenCalledWith({ ...signup, approved: false });
+    expect(doc.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/signups/signup.service.ts
+++ b/src/signups/signup.service.ts
@@ -1,22 +1,34 @@
 import { Injectable } from '@nestjs/common';
 import { InjectFirestore } from '../firebase/firebase.decorators.js';
-import { Firestore } from 'firebase-admin/firestore';
-import { Signup } from './signup.interfaces.js';
+import { CollectionReference, Firestore } from 'firebase-admin/firestore';
+import { Signup, SignupRequest } from './signup.interfaces.js';
 
 @Injectable()
 class SignupService {
-  constructor(@InjectFirestore() private readonly firestore: Firestore) {}
-
-  public upsertSignup(signup: Signup) {
-    const key = this.getKeyForSignup(signup);
-
-    return this.firestore
-      .collection('signups')
-      .doc(key)
-      .set(signup, { merge: true });
+  private readonly collection: CollectionReference<Signup>;
+  constructor(@InjectFirestore() private readonly firestore: Firestore) {
+    this.collection = this.firestore.collection(
+      'signups',
+    ) as CollectionReference<Signup>;
   }
 
-  private getKeyForSignup({ username, encounter }: Signup) {
+  public async upsertSignup(signup: SignupRequest) {
+    const key = this.getKeyForSignup(signup);
+
+    const document = this.collection.doc(key);
+    const snapshot = await document.get();
+
+    if (snapshot.exists) {
+      return document.set(signup, {
+        // only update these fields if the document already exists. This allows approvals that were made to remain intact
+        mergeFields: ['fflogsLink', 'character', 'world', 'availability'],
+      });
+    }
+
+    return document.create({ ...signup, approved: false });
+  }
+
+  private getKeyForSignup({ username, encounter }: SignupRequest) {
     // usernames are supposed to be unique right? The recent change discord
     // made to remove #discriminator from the username might make this wonky
     return `${username}-${encounter}`;


### PR DESCRIPTION
Adds an `approved` field to track the approval status of a signup document.