### PR TITLE
ci: only run on ubuntu in CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ on: [pull_request]
 
 jobs:
   test:
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [macos-latest, ubuntu-latest, windows-latest]
+        runs-on: ubuntu-latest
+        # runs-on: ${{ matrix.os }}
+        # strategy:
+        #   matrix:
+        #     os: [macos-latest, ubuntu-latest, windows-latest]
         steps:
         - uses: actions/checkout@v4
         - uses: pnpm/action-setup@v2


### PR DESCRIPTION
Only run CI against Ubuntu for now to alleviate monthly usage limits.

Windows/Mac not really needed since it will be deployed on linux architecture
