### PR TITLE
ci: fix codecov reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,7 @@ jobs:
         - run: pnpm test:ci
         - name: Upload coverage reports to Codecov
           uses: codecov/codecov-action@v3
+          with: 
+            files: ./coverage/coverage-final.json
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The codecov action doesn't seem to be updating the base url, perhaps `files` is needed to be set even though its an optional parameter?
