### PR TITLE
chore(jest): update coverage configuration

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,4 +6,5 @@ module.exports = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   extensionsToTreatAsEsm: ['.ts'],
+  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**'],
 };


### PR DESCRIPTION
Turns out we weren't collecting coverage on untested files. Oopsies
