### PR TITLE
feat(settings): implement `/settings` command

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { firestoreSchema } from './firebase/firebase.config.js';
 import { FirebaseModule } from './firebase/firebase.module.js';
 import { SignupModule } from './signups/signup.module.js';
 import { StatusModule } from './status/status.module.js';
+import { SettingsModule } from './settings/settings.module.js';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { StatusModule } from './status/status.module.js';
     SlashCommandsModule,
     CqrsModule,
     FirebaseModule,
+    SettingsModule,
     SignupModule,
     StatusModule,
     ConfigModule.forRoot({

--- a/src/commands/settings-slash-command.ts
+++ b/src/commands/settings-slash-command.ts
@@ -1,0 +1,16 @@
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+
+export const SettingsSlashCommand = new SlashCommandBuilder()
+  .setName('settings')
+  .setDescription('Configure the bots roles and channel settings')
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+  .addRoleOption((option) =>
+    option
+      .setName('reviewer-role')
+      .setDescription('the role that is allowed to review signups'),
+  )
+  .addChannelOption((option) =>
+    option
+      .setName('signup-review-channel')
+      .setDescription('The channel in which reviews will be posted'),
+  );

--- a/src/commands/slash-commands.module.ts
+++ b/src/commands/slash-commands.module.ts
@@ -10,6 +10,8 @@ import { StatusCommand } from '../status/commands/status.command.js';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
 import { StatusSlashCommand } from './status-slash-command.js';
 import { SignupSlashCommand } from './signup-slash-command.js';
+import { SettingsSlashCommand } from './settings-slash-command.js';
+import { SettingsCommand } from '../settings/settings.command.js';
 
 @Module({
   imports: [DiscordModule, ConfigModule, CqrsModule],
@@ -24,12 +26,13 @@ export class SlashCommandsModule implements OnApplicationBootstrap {
 
   async onApplicationBootstrap() {
     this.client.on(Events.InteractionCreate, (interaction) => {
-      if (!interaction.isChatInputCommand()) return;
+      if (!interaction.isChatInputCommand() || !interaction.inGuild()) return;
 
       // TODO: This could be more generic somehow
       const command = match(interaction.commandName)
         .with(SignupSlashCommand.name, () => new SignupCommand(interaction))
         .with(StatusSlashCommand.name, () => new StatusCommand(interaction))
+        .with(SettingsSlashCommand.name, () => new SettingsCommand(interaction))
         .run();
 
       this.commandBus.execute(command);

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,4 +1,9 @@
+import { SettingsSlashCommand } from './settings-slash-command.js';
 import { SignupSlashCommand } from './signup-slash-command.js';
 import { StatusSlashCommand } from './status-slash-command.js';
 
-export const SLASH_COMMANDS = [SignupSlashCommand, StatusSlashCommand];
+export const SLASH_COMMANDS = [
+  SignupSlashCommand,
+  StatusSlashCommand,
+  SettingsSlashCommand,
+];

--- a/src/firebase/firebase.module.ts
+++ b/src/firebase/firebase.module.ts
@@ -18,7 +18,11 @@ import { FIREBASE_APP, FIRESTORE } from './firebase.consts.js';
     {
       provide: FIRESTORE,
       inject: [FIREBASE_APP],
-      useFactory: (app: App) => getFirestore(app),
+      useFactory: (app: App) => {
+        const firestore = getFirestore(app);
+        firestore.settings({ ignoreUndefinedProperties: true });
+        return firestore;
+      },
     },
   ],
   exports: [FIRESTORE],

--- a/src/settings/settings-command.handler.ts
+++ b/src/settings/settings-command.handler.ts
@@ -1,0 +1,41 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { SettingsCommand } from './settings.command.js';
+import { SettingsService } from './settings.service.js';
+import { Logger } from '@nestjs/common';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+@CommandHandler(SettingsCommand)
+class SettingsCommandHandler implements ICommandHandler<SettingsCommand> {
+  private readonly logger = new Logger(SettingsCommandHandler.name);
+
+  constructor(private readonly service: SettingsService) {}
+
+  async execute({ interaction }: SettingsCommand) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const guildId = interaction.guildId;
+
+    try {
+      const reviewerRole = interaction.options.getRole('reviewer-role');
+      const reviewChannel = interaction.options.getChannel(
+        'signup-review-channel',
+      );
+
+      await this.service.upsertSettings(guildId, {
+        reviewerRole: reviewerRole?.id,
+        reviewChannel: reviewChannel?.id,
+      });
+
+      await interaction.editReply('Settings updated!');
+    } catch (e: unknown) {
+      await this.handleError(e, interaction);
+    }
+  }
+
+  private handleError(e: unknown, interaction: ChatInputCommandInteraction) {
+    this.logger.error(e);
+    return interaction.editReply('Something went wrong!');
+  }
+}
+
+export { SettingsCommandHandler };

--- a/src/settings/settings.command.ts
+++ b/src/settings/settings.command.ts
@@ -1,0 +1,8 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { DiscordCommand } from '../commands/slash-commands.interfaces.js';
+
+export class SettingsCommand implements DiscordCommand {
+  constructor(
+    public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
+  ) {}
+}

--- a/src/settings/settings.interfaces.ts
+++ b/src/settings/settings.interfaces.ts
@@ -1,0 +1,4 @@
+export interface Settings {
+  reviewerRole?: string;
+  reviewChannel?: string;
+}

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SettingsCommandHandler } from './settings-command.handler.js';
+import { SettingsService } from './settings.service.js';
+import { FirebaseModule } from '../firebase/firebase.module.js';
+
+@Module({
+  imports: [FirebaseModule],
+  providers: [SettingsCommandHandler, SettingsService],
+  exports: [SettingsService],
+})
+export class SettingsModule {}

--- a/src/settings/settings.service.spec.ts
+++ b/src/settings/settings.service.spec.ts
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { Firestore } from 'firebase-admin/firestore';
+import { SettingsService } from './settings.service.js';
+import { FIRESTORE } from '../firebase/firebase.consts.js';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let firestore: DeepMocked<Firestore>;
+
+  beforeEach(async () => {
+    const docMock = {
+      set: jest.fn(),
+      get: jest.fn<any>().mockResolvedValue({
+        data: () => ({ reviewChannel: 'channel', reviewerRole: 'role' }),
+      }),
+    };
+
+    const collectionMock = {
+      doc: jest.fn().mockReturnValue(docMock),
+    };
+
+    firestore = createMock<Firestore>({
+      collection: jest.fn<any>().mockReturnValue(collectionMock),
+    });
+
+    const module = await Test.createTestingModule({
+      providers: [SettingsService, { provide: FIRESTORE, useValue: firestore }],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+  });
+
+  it('should call upsertSettings with correct arguments', async () => {
+    const guildId = 'guildId';
+    const settings = { reviewChannel: 'channel', reviewerRole: 'role' };
+
+    await service.upsertSettings(guildId, settings);
+
+    expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
+    expect(firestore.collection('').doc().set).toHaveBeenCalledWith(settings);
+  });
+
+  it('should call getReviewChannel with correct arguments', async () => {
+    const guildId = 'guildId';
+
+    await service.getReviewChannel(guildId);
+
+    expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
+    expect(firestore.collection('').doc().get).toHaveBeenCalled();
+  });
+
+  it('should call getReviewerRole with correct arguments', async () => {
+    const guildId = 'guildId';
+
+    await service.getReviewerRole(guildId);
+
+    expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
+    expect(firestore.collection('').doc().get).toHaveBeenCalled();
+  });
+});

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectFirestore } from '../firebase/firebase.decorators.js';
+import { CollectionReference, Firestore } from 'firebase-admin/firestore';
+import { Settings } from './settings.interfaces.js';
+
+@Injectable()
+class SettingsService {
+  private readonly collection: CollectionReference<Settings>;
+
+  constructor(@InjectFirestore() firestore: Firestore) {
+    this.collection = firestore.collection('settings');
+  }
+
+  public upsertSettings(guildId: string, settings: Settings) {
+    return this.collection.doc(guildId).set(settings);
+  }
+
+  public async getReviewChannel(guildId: string) {
+    const doc = await this.collection.doc(guildId).get();
+    return doc.data()?.reviewChannel;
+  }
+
+  public async getReviewerRole(guildId: string) {
+    const doc = await this.collection.doc(guildId).get();
+    return doc.data()?.reviewerRole;
+  }
+}
+
+export { SettingsService };


### PR DESCRIPTION
Implements a `/settings` command, which was going to be called `/configure` but the naming of the code was awkward when doing that (i.e. configuration.module conflicting with @nestjs/config's stuff looks weird)

Settings can set the allowed reviewer role and review channel

Resolves #14 
