### PR TITLE
fix(signups): reset status when updating a signup

### DIFF
--- a/src/signups/signup.interfaces.ts
+++ b/src/signups/signup.interfaces.ts
@@ -13,7 +13,7 @@ export interface SignupRequest {
 
 export interface Signup extends SignupRequest {
   status: SignupStatus;
-  reviewedBy?: string;
+  reviewedBy?: string | null;
   reviewMessageId?: string;
 }
 

--- a/src/signups/signup.repository.spec.ts
+++ b/src/signups/signup.repository.spec.ts
@@ -69,9 +69,19 @@ describe('Signup Repository', () => {
 
     await repository.createSignup(signupRequest);
 
-    expect(doc.set).toHaveBeenCalledWith(signupRequest, {
-      mergeFields: ['fflogsLink', 'character', 'world', 'availability'],
-    });
+    expect(doc.set).toHaveBeenCalledWith(
+      { ...signupRequest, status: SignupStatus.PENDING, reviewedBy: null },
+      {
+        mergeFields: [
+          'fflogsLink',
+          'character',
+          'world',
+          'availability',
+          'status',
+          'reviewedBy',
+        ],
+      },
+    );
 
     expect(doc.create).not.toHaveBeenCalled();
   });

--- a/src/signups/signup.repository.ts
+++ b/src/signups/signup.repository.ts
@@ -30,10 +30,20 @@ class SignupRepository {
     const snapshot = await document.get();
 
     if (snapshot.exists) {
-      await document.set(signup, {
-        // only update these fields if the document already exists. This allows approvals that were made to remain intact
-        mergeFields: ['fflogsLink', 'character', 'world', 'availability'],
-      });
+      await document.set(
+        { ...signup, status: SignupStatus.PENDING, reviewedBy: null },
+        {
+          // only update these fields if the document already exists. This allows approvals that were made to remain intact
+          mergeFields: [
+            'fflogsLink',
+            'character',
+            'world',
+            'availability',
+            'status',
+            'reviewedBy',
+          ],
+        },
+      );
     } else {
       await document.create({ ...signup, status: SignupStatus.PENDING });
     }


### PR DESCRIPTION
When updating a signup we should unset the reviewer and put the status back to Pending so it can be reviewed again
