### PR TITLE
refactor: setup json logging for production

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -5,6 +5,7 @@ export interface AppConfig {
   DISCORD_TOKEN: string;
   GUILD_ID: string;
   LOG_LEVEL: string;
+  NODE_ENV: string;
   PORT: number;
   PUBLIC_KEY: string;
 }
@@ -16,6 +17,9 @@ export const configSchema = Joi.object({
   LOG_LEVEL: Joi.string()
     .allow('debug', 'info', 'warn', 'error', 'silent', 'fatal')
     .default('info'),
+  NODE_ENV: Joi.string()
+    .allow('development', 'production', 'test')
+    .default('development'),
   PORT: Joi.number().default(3000),
   PUBLIC_KEY: Joi.string().optional(),
 });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,7 +32,10 @@ import { SettingsModule } from './settings/settings.module.js';
       inject: [ConfigService],
       useFactory: (configService: ConfigService<AppConfig, true>) => ({
         pinoHttp: {
-          transport: { target: 'pino-pretty' },
+          transport:
+            configService.get('NODE_ENV') === 'production'
+              ? undefined
+              : { target: 'pino-pretty' },
           level: configService.get('LOG_LEVEL'),
         },
       }),


### PR DESCRIPTION
does not set the `pino-pretty` transport if the `NODE_ENV` is production

Resolves #15
