### PR TITLE
refactor(signups): adds freeform job/role field

### DIFF
--- a/src/signups/commands/handlers/send-signup-review-command.handler.spec.ts
+++ b/src/signups/commands/handlers/send-signup-review-command.handler.spec.ts
@@ -24,6 +24,7 @@ describe('Send Signup Review Command Handler', () => {
     world: 'bar',
     availability: 'baz',
     screenshot: 'http://somelinksurely',
+    role: 'healer',
   });
 
   beforeEach(async () => {

--- a/src/signups/commands/handlers/send-signup-review-command.handler.ts
+++ b/src/signups/commands/handlers/send-signup-review-command.handler.ts
@@ -80,6 +80,7 @@ class SendSignupReviewCommandHandler
     fflogsLink,
     screenshot,
     world,
+    role,
   }: Signup) {
     let embed = new EmbedBuilder()
       .setDescription(
@@ -94,6 +95,7 @@ class SendSignupReviewCommandHandler
         { name: 'Character', value: character, inline: true },
         { name: 'Home World', value: world, inline: true },
         { name: 'Availability', value: availability, inline: true },
+        { name: 'Role', value: role, inline: true },
       ]);
 
     if (fflogsLink) {

--- a/src/signups/commands/handlers/signup-command.handler.spec.ts
+++ b/src/signups/commands/handlers/signup-command.handler.spec.ts
@@ -50,6 +50,8 @@ describe('Signup Command Handler', () => {
               return 'Monday, Wednesday, Friday';
             case 'world':
               return 'Jenova';
+            case 'role':
+              return 'tank';
           }
         },
         getAttachment: () => null,

--- a/src/signups/commands/handlers/signup-command.handler.ts
+++ b/src/signups/commands/handlers/signup-command.handler.ts
@@ -150,9 +150,10 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
       discordId: user.id,
       encounter: options.getString('encounter')! as Encounter,
       fflogsLink: options.getString('fflogs'),
-      world: options.getString('world')!,
-      username: user.username,
+      role: options.getString('role'),
       screenshot: options.getAttachment('screenshot')?.url,
+      username: user.username,
+      world: options.getString('world')!,
     };
 
     const transformed = plainToInstance(SignupRequestDto, request);
@@ -172,14 +173,16 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
     screenshot,
     fflogsLink,
     world,
+    role,
   }: SignupRequestDto) {
     let embed = new EmbedBuilder()
       .setTitle(`${EncounterFriendlyDescription[encounter]} Signup`)
       .setDescription("Here's a summary of your request")
       .addFields([
-        { name: 'Character', value: character },
-        { name: 'Home World', value: world },
-        { name: 'Availability', value: availability },
+        { name: 'Character', value: character, inline: true },
+        { name: 'Home World', value: world, inline: true },
+        { name: 'Availability', value: availability, inline: true },
+        { name: 'Role', value: role, inline: true },
       ]);
 
     if (fflogsLink) {

--- a/src/signups/dto/signup-request.dto.ts
+++ b/src/signups/dto/signup-request.dto.ts
@@ -11,6 +11,9 @@ class SignupRequestDto {
   @IsString()
   discordId: string;
 
+  @IsString()
+  role: string; // freeform for now but could be restricted via enum
+
   @IsEnum(Encounter)
   encounter: Encounter;
 

--- a/src/signups/signup.repository.spec.ts
+++ b/src/signups/signup.repository.spec.ts
@@ -29,6 +29,7 @@ describe('Signup Repository', () => {
     discordId: 'discordId',
     encounter: Encounter.DSR,
     fflogsLink: 'fflogsLink',
+    role: 'tank',
     username: 'username',
     world: 'world',
   };

--- a/src/slash-commands/signup-slash-command.ts
+++ b/src/slash-commands/signup-slash-command.ts
@@ -27,6 +27,9 @@ export const SignupSlashCommand = new SlashCommandBuilder()
     option.setRequired(true).setDescription('Home World').setName('world'),
   )
   .addStringOption((option) =>
+    option.setRequired(true).setDescription('Job/Role').setName('role'),
+  )
+  .addStringOption((option) =>
     option
       .setRequired(true)
       .setDescription('Availability. Ex: M-F 8pm-12am EST')


### PR DESCRIPTION
Adds job/role freeform field to the signup, since the current spreadsheets expects to see the proggers role/job with their signup. 

It could be managed as a restrictive enum but slash commands don't allow for multi-select choices, so doing things like `RDM/WAR` would be annoying to validate. 
