### PR TITLE
feat(signups): integrate google sheets signup tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "discord-interactions": "^3.4.0",
     "discord.js": "^14.14.1",
     "firebase-admin": "^12.0.0",
+    "googleapis": "^129.0.0",
     "joi": "^17.11.0",
     "nestjs-pino": "^3.5.0",
     "pino-http": "^8.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   firebase-admin:
     specifier: ^12.0.0
     version: 12.0.0
+  googleapis:
+    specifier: ^129.0.0
+    version: 129.0.0
   joi:
     specifier: ^17.11.0
     version: 17.11.0
@@ -2791,7 +2794,6 @@ packages:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
     requiresBuild: true
     dev: false
-    optional: true
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -4072,7 +4074,6 @@ packages:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     requiresBuild: true
     dev: false
-    optional: true
 
   /external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -4423,7 +4424,6 @@ packages:
       - encoding
       - supports-color
     dev: false
-    optional: true
 
   /gcp-metadata@6.1.0:
     resolution: {integrity: sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==}
@@ -4436,7 +4436,6 @@ packages:
       - encoding
       - supports-color
     dev: false
-    optional: true
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4451,7 +4450,7 @@ packages:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
       function-bind: 1.1.1
-      has: 1.0.3
+      has: 1.0.4
       has-proto: 1.0.1
       has-symbols: 1.0.3
 
@@ -4629,7 +4628,6 @@ packages:
       - encoding
       - supports-color
     dev: false
-    optional: true
 
   /google-gax@4.0.5:
     resolution: {integrity: sha512-yLoYtp4zE+8OQA74oBEbNkbzI6c95W01JSL7RqC8XERKpRvj3ytZp1dgnbA6G9aRsc8pZB25xWYBcCmrbYOEhA==}
@@ -4653,6 +4651,32 @@ packages:
     dev: false
     optional: true
 
+  /googleapis-common@7.0.1:
+    resolution: {integrity: sha512-mgt5zsd7zj5t5QXvDanjWguMdHAcJmmDrF9RkInCecNsyV7S7YtGqm5v2IWONNID88osb7zmx5FtrAP12JfD0w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      extend: 3.0.2
+      gaxios: 6.1.1
+      google-auth-library: 9.4.1
+      qs: 6.11.2
+      url-template: 2.0.8
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /googleapis@129.0.0:
+    resolution: {integrity: sha512-gFatrzby+oh/GxEeMhJOKzgs9eG7yksRcTon9b+kPie4ZnDSgGQ85JgtUaBtLSBkcKpUKukdSP6Km1aCjs4y4Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      google-auth-library: 9.4.1
+      googleapis-common: 7.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -4672,7 +4696,6 @@ packages:
       - encoding
       - supports-color
     dev: false
-    optional: true
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -4701,16 +4724,9 @@ packages:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
 
-  /has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: 1.1.1
-
   /has@1.0.4:
     resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
     engines: {node: '>= 0.4.0'}
-    dev: true
 
   /help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -4995,7 +5011,7 @@ packages:
   /is-core-module@2.12.1:
     resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
     dependencies:
-      has: 1.0.3
+      has: 1.0.4
     dev: true
 
   /is-core-module@2.13.0:
@@ -5728,7 +5744,6 @@ packages:
     dependencies:
       bignumber.js: 9.1.2
     dev: false
-    optional: true
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -5813,7 +5828,6 @@ packages:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
     dev: false
-    optional: true
 
   /jwks-rsa@3.1.0:
     resolution: {integrity: sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==}
@@ -5843,7 +5857,6 @@ packages:
       jwa: 2.0.0
       safe-buffer: 5.2.1
     dev: false
-    optional: true
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -6987,7 +7000,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
-    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -8147,6 +8159,10 @@ packages:
     dependencies:
       punycode: 2.3.0
     dev: true
+
+  /url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,11 +11,13 @@ import { FirebaseModule } from './firebase/firebase.module.js';
 import { SignupModule } from './signups/signup.module.js';
 import { StatusModule } from './status/status.module.js';
 import { SettingsModule } from './settings/settings.module.js';
+import { SheetsModule } from './sheets/sheets.module.js';
 
 @Module({
   imports: [
     CqrsModule,
     DiscordModule,
+    SheetsModule,
     FirebaseModule,
     SettingsModule,
     SignupModule,

--- a/src/sheets/sheets.config.ts
+++ b/src/sheets/sheets.config.ts
@@ -1,0 +1,18 @@
+import { registerAs } from '@nestjs/config';
+import Joi from 'joi';
+
+export interface SheetsConfig {
+  GOOGLE_SPREADSHEET_ID: string;
+  GOOGLE_UNIVERSE_DOMAIN: string;
+}
+
+const schema = Joi.object({
+  GOOGLE_SPREADSHEET_ID: Joi.string().required(),
+  GOOGLE_UNIVERSE_DOMAIN: Joi.string().default('googleapis.com'),
+});
+
+export const sheetsConfig = registerAs<SheetsConfig>('sheets', () => {
+  const res = schema.validate(process.env, { stripUnknown: true });
+  if (res.error) throw res.error;
+  return res.value;
+});

--- a/src/sheets/sheets.consts.ts
+++ b/src/sheets/sheets.consts.ts
@@ -1,0 +1,1 @@
+export const SHEETS_CLIENT = '@goolge/sheets-client';

--- a/src/sheets/sheets.decorators.ts
+++ b/src/sheets/sheets.decorators.ts
@@ -1,0 +1,4 @@
+import { Inject } from '@nestjs/common';
+import { SHEETS_CLIENT } from './sheets.consts.js';
+
+export const InjectSheetsClient = () => Inject(SHEETS_CLIENT);

--- a/src/sheets/sheets.module.ts
+++ b/src/sheets/sheets.module.ts
@@ -1,0 +1,41 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Auth, google } from 'googleapis';
+import { SheetsConfig, sheetsConfig } from './sheets.config.js';
+import { SHEETS_CLIENT } from './sheets.consts.js';
+import { SheetsService } from './sheets.service.js';
+import { AppConfig } from '../app.config.js';
+
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+
+@Module({
+  imports: [ConfigModule.forFeature(sheetsConfig)],
+  providers: [
+    SheetsService,
+    {
+      provide: SHEETS_CLIENT,
+      inject: [ConfigService],
+      useFactory: async (
+        configService: ConfigService<
+          AppConfig & { sheets: SheetsConfig },
+          true
+        >,
+      ) => {
+        const client = new Auth.GoogleAuth({
+          scopes: SCOPES,
+          credentials: {
+            client_email: configService.get('GCP_ACCOUNT_EMAIL'),
+            private_key: configService.get('GCP_PRIVATE_KEY'),
+            universe_domain: configService.get('sheets').GOOGLE_UNIVERSE_DOMAIN,
+          },
+        });
+
+        // TODO: Unsure about type cast here
+        const auth = (await client.getClient()) as Auth.Compute;
+        return google.sheets({ version: 'v4', auth });
+      },
+    },
+  ],
+  exports: [SheetsService],
+})
+export class SheetsModule {}

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectSheetsClient } from './sheets.decorators.js';
+import { sheets_v4 } from 'googleapis';
+import { Signup } from '../signups/signup.interfaces.js';
+import { sheetsConfig } from './sheets.config.js';
+import { ConfigType } from '@nestjs/config';
+
+// TODO: Needs unit testing but mocking the google client is a PITA
+@Injectable()
+class SheetsService {
+  constructor(
+    @InjectSheetsClient() private readonly client: sheets_v4.Sheets,
+    @Inject(sheetsConfig.KEY)
+    private readonly config: ConfigType<typeof sheetsConfig>,
+  ) {}
+
+  public async upsertSignup({
+    encounter,
+    character,
+    role,
+    fflogsLink,
+    world,
+    screenshot,
+  }: Signup) {
+    const proofOfProg =
+      fflogsLink || screenshot
+        ? this.createHyperLinkCell('Proof of Prog', (fflogsLink || screenshot)!)
+        : '';
+
+    const {
+      data: { values },
+    } = await this.client.spreadsheets.values.get({
+      spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
+      range: encounter,
+    });
+
+    const row = values?.findIndex((row) => row.at(1) === character) ?? -1;
+
+    // This depends on knowing the structure of the spreadsheet
+    // Current non-automated iterations of the spreadsheet have a progpoint dropdown. We don't currently
+    // capture this as part of the signup so we'll replace that value with the proof of prog link
+    if (row === -1) {
+      await this.client.spreadsheets.values.append({
+        spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
+        // the encounter value should match the Sheet name and is used as the range
+        range: encounter,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values: [[character, world, role, proofOfProg]],
+        },
+      });
+    } else {
+      // If the row was found, update the existing data
+      await this.client.spreadsheets.values.update({
+        spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
+        range: `${encounter}!B${row + 1}:E${row + 1}`,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values: [[character, world, role, proofOfProg]],
+        },
+      });
+    }
+  }
+
+  public createHyperLinkCell(name: string, url: string): string {
+    return `=HYPERLINK("${url}","${name}")`;
+  }
+}
+
+export { SheetsService };

--- a/src/signups/signup.module.ts
+++ b/src/signups/signup.module.ts
@@ -8,9 +8,16 @@ import { SendSignupReviewCommandHandler } from './commands/handlers/send-signup-
 import { SignupReviewService } from './signup-review.service.js';
 import { SignupRepository } from './signup.repository.js';
 import { SettingsModule } from '../settings/settings.module.js';
+import { SheetsModule } from '../sheets/sheets.module.js';
 
 @Module({
-  imports: [CqrsModule, FirebaseModule, DiscordModule, SettingsModule],
+  imports: [
+    CqrsModule,
+    DiscordModule,
+    FirebaseModule,
+    SettingsModule,
+    SheetsModule,
+  ],
   providers: [
     SendSignupReviewCommandHandler,
     SignupReviewService,


### PR DESCRIPTION
## Google Sheets Integration

Integrates signups with the existing google sheet format currently managing ulti-project signups, with the caveat that instead of a prog point dropdown, it has been replaced by the proof of prog. 

Attempts to upsert a signup if it can. Publishing to the sheet successfully is now a prerequisite for updating the database and the discord message embed. If any error occurs, the reaction will be removed and a DM will be sent to the person saying there was a problem with the signup and a link to the signup in question. 

### Known Issues

Testing the Sheets API is annoying. The mocks are cumbersome so its omitted for the time being. Also the mere fact of having `googleapis` increases test execution time by nearly 200%. Google does not seem to expose individual packages for APIs but there are some 3rd party alternatives to look at, or worst case make http calls ourselves. 