### PR TITLE
refactor(settings): split settings into view/edit subcommands

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,5 +6,9 @@ module.exports = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   extensionsToTreatAsEsm: ['.ts'],
-  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**'],
+  collectCoverageFrom: [
+    '**/*.{ts,tsx}',
+    '!**/node_modules/**',
+    '!src/slash-commands/**/*-command.ts',
+  ],
 };

--- a/src/settings/commands/edit-settings.command.ts
+++ b/src/settings/commands/edit-settings.command.ts
@@ -1,7 +1,7 @@
 import { ChatInputCommandInteraction } from 'discord.js';
 import { DiscordCommand } from '../../slash-commands/slash-commands.interfaces.js';
 
-export class SettingsCommand implements DiscordCommand {
+export class EditSettingsCommand implements DiscordCommand {
   constructor(
     public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
   ) {}

--- a/src/settings/commands/handlers/edit-settings-command.handler.spec.ts
+++ b/src/settings/commands/handlers/edit-settings-command.handler.spec.ts
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { EditSettingsCommandHandler } from './edit-settings-command.handler.js';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { SettingsService } from '../../settings.service.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+describe('Edit Settings Command Handler', () => {
+  let handler: EditSettingsCommandHandler;
+  let settingsService: DeepMocked<SettingsService>;
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [EditSettingsCommandHandler],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    handler = fixture.get(EditSettingsCommandHandler);
+    settingsService = fixture.get(SettingsService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('should upsert given settings', async () => {
+    const guildId = '12345';
+    const reviewerRole = '67890';
+    const reviewChannel = '09876';
+
+    const upsertSpy = jest.spyOn(settingsService, 'upsertSettings');
+
+    await handler.execute({
+      interaction: createMock<ChatInputCommandInteraction<'raw' | 'cached'>>({
+        guildId,
+        options: {
+          getRole: () => createMock({ id: reviewerRole }),
+          getChannel: () => createMock({ id: reviewChannel }),
+        },
+        valueOf: () => '',
+      }),
+    });
+
+    expect(upsertSpy).toHaveBeenCalledWith(guildId, {
+      reviewerRole,
+      reviewChannel,
+    });
+  });
+});

--- a/src/settings/commands/handlers/edit-settings-command.handler.ts
+++ b/src/settings/commands/handlers/edit-settings-command.handler.ts
@@ -1,16 +1,18 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { SettingsCommand } from '../settings.command.js';
+import { EditSettingsCommand } from '../edit-settings.command.js';
 import { SettingsService } from '../../settings.service.js';
 import { Logger } from '@nestjs/common';
 import { ChatInputCommandInteraction } from 'discord.js';
 
-@CommandHandler(SettingsCommand)
-class SettingsCommandHandler implements ICommandHandler<SettingsCommand> {
-  private readonly logger = new Logger(SettingsCommandHandler.name);
+@CommandHandler(EditSettingsCommand)
+class EditSettingsCommandHandler
+  implements ICommandHandler<EditSettingsCommand>
+{
+  private readonly logger = new Logger(EditSettingsCommandHandler.name);
 
   constructor(private readonly service: SettingsService) {}
 
-  async execute({ interaction }: SettingsCommand) {
+  async execute({ interaction }: EditSettingsCommand) {
     await interaction.deferReply({ ephemeral: true });
 
     const guildId = interaction.guildId;
@@ -38,4 +40,4 @@ class SettingsCommandHandler implements ICommandHandler<SettingsCommand> {
   }
 }
 
-export { SettingsCommandHandler };
+export { EditSettingsCommandHandler };

--- a/src/settings/commands/handlers/view-settings-command.handler.spec.ts
+++ b/src/settings/commands/handlers/view-settings-command.handler.spec.ts
@@ -1,0 +1,44 @@
+import { jest } from '@jest/globals';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { ViewSettingsCommandHandler } from './view-settings-command.handler.js';
+import { Test } from '@nestjs/testing';
+import { SettingsService } from '../../settings.service.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+describe('View Settings Command Handler', () => {
+  let handler: ViewSettingsCommandHandler;
+  let settingsService: DeepMocked<SettingsService>;
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [ViewSettingsCommandHandler],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    handler = fixture.get(ViewSettingsCommandHandler);
+    settingsService = fixture.get(SettingsService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('should reply with the configured settings', async () => {
+    const interaction =
+      createMock<ChatInputCommandInteraction<'cached' | 'raw'>>();
+
+    const deferSpy = jest.spyOn(interaction, 'deferReply');
+    const replySpy = jest.spyOn(interaction, 'editReply');
+
+    settingsService.getSettings.mockResolvedValueOnce({
+      reviewChannel: '12345',
+      reviewerRole: '67890',
+    });
+
+    await handler.execute({ interaction });
+
+    expect(deferSpy).toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalled();
+  });
+});

--- a/src/settings/commands/handlers/view-settings-command.handler.ts
+++ b/src/settings/commands/handlers/view-settings-command.handler.ts
@@ -1,0 +1,31 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { ViewSettingsCommand } from '../view-settings.command.js';
+import { SettingsService } from '../../settings.service.js';
+
+@CommandHandler(ViewSettingsCommand)
+class ViewSettingsCommandHandler
+  implements ICommandHandler<ViewSettingsCommand>
+{
+  constructor(private readonly settingsService: SettingsService) {}
+
+  async execute({ interaction }: ViewSettingsCommand) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const settings = await this.settingsService.getSettings(
+      interaction.guildId,
+    );
+
+    if (!settings) {
+      return interaction.editReply('No settings found!');
+    }
+
+    const { reviewChannel, reviewerRole } = settings;
+    const role = reviewerRole ? `<@&${reviewerRole}>` : 'No Role Set';
+
+    await interaction.editReply(
+      `**Review Channel:** <#${reviewChannel}>\n**Reviewer Role:** ${role}`,
+    );
+  }
+}
+
+export { ViewSettingsCommandHandler };

--- a/src/settings/commands/view-settings.command.ts
+++ b/src/settings/commands/view-settings.command.ts
@@ -1,0 +1,8 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { DiscordCommand } from '../../slash-commands/slash-commands.interfaces.js';
+
+export class ViewSettingsCommand implements DiscordCommand {
+  constructor(
+    public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
+  ) {}
+}

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,11 +1,16 @@
 import { Module } from '@nestjs/common';
-import { SettingsCommandHandler } from './commands/handlers/settings-command.handler.js';
+import { EditSettingsCommandHandler } from './commands/handlers/edit-settings-command.handler.js';
 import { SettingsService } from './settings.service.js';
 import { FirebaseModule } from '../firebase/firebase.module.js';
+import { ViewSettingsCommandHandler } from './commands/handlers/view-settings-command.handler.js';
 
 @Module({
   imports: [FirebaseModule],
-  providers: [SettingsCommandHandler, SettingsService],
+  providers: [
+    EditSettingsCommandHandler,
+    SettingsService,
+    ViewSettingsCommandHandler,
+  ],
   exports: [SettingsService],
 })
 export class SettingsModule {}

--- a/src/slash-commands/settings-slash-command.ts
+++ b/src/slash-commands/settings-slash-command.ts
@@ -6,21 +6,29 @@ import {
 
 export const SettingsSlashCommand = new SlashCommandBuilder()
   .setName('settings')
-  .setDescription('Configure the bots roles and channel settings')
+  .setDescription('Configure/Review the bots roles and channel settings')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
-  .addChannelOption((option) =>
-    option
-      .setName('signup-review-channel')
-      .setRequired(true)
-      .setDescription(
-        'The channel in which reviews will be posted. This must be set to a text channel',
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName('edit')
+      .setDescription('Edit the bot settings')
+      .addChannelOption((option) =>
+        option
+          .setName('signup-review-channel')
+          .setRequired(true)
+          .setDescription(
+            'The channel in which reviews will be posted. This must be set to a text channel',
+          )
+          .addChannelTypes(ChannelType.GuildText),
       )
-      .addChannelTypes(ChannelType.GuildText),
-  )
-  .addRoleOption((option) =>
-    option
-      .setName('reviewer-role')
-      .setDescription(
-        'an optional role that is allowed to review signups. If not set, anyone can review signups',
+      .addRoleOption((option) =>
+        option
+          .setName('reviewer-role')
+          .setDescription(
+            'an optional role that is allowed to review signups. If not set, anyone can review signups',
+          ),
       ),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand.setName('view').setDescription('view the current bot settings'),
   );

--- a/src/slash-commands/slash-commands.service.ts
+++ b/src/slash-commands/slash-commands.service.ts
@@ -11,7 +11,8 @@ import { SignupSlashCommand } from './signup-slash-command.js';
 import { SLASH_COMMANDS } from './slash-commands.js';
 import { StatusSlashCommand } from './status-slash-command.js';
 import { CommandBus } from '@nestjs/cqrs';
-import { SettingsCommand } from '../settings/commands/settings.command.js';
+import { EditSettingsCommand } from '../settings/commands/edit-settings.command.js';
+import { ViewSettingsCommand } from '../settings/commands/view-settings.command.js';
 
 @Injectable()
 class SlashCommandsService {
@@ -31,7 +32,13 @@ class SlashCommandsService {
       const command = match(interaction.commandName)
         .with(SignupSlashCommand.name, () => new SignupCommand(interaction))
         .with(StatusSlashCommand.name, () => new StatusCommand(interaction))
-        .with(SettingsSlashCommand.name, () => new SettingsCommand(interaction))
+        .with(SettingsSlashCommand.name, () => {
+          const subcommand = interaction.options.getSubcommand();
+          return match(subcommand)
+            .with('edit', () => new EditSettingsCommand(interaction))
+            .with('view', () => new ViewSettingsCommand(interaction))
+            .run();
+        })
         .run();
 
       this.commandBus.execute(command);


### PR DESCRIPTION
Splits `/settings` into `/settings view` and `/settings edit`. 

They are self-explanatory subcommands