### PR TITLE
refactor: party type support

### DIFF
--- a/src/sheets/sheets.consts.ts
+++ b/src/sheets/sheets.consts.ts
@@ -1,1 +1,27 @@
+import { Encounter } from '../app.consts.js';
+
 export const SHEETS_CLIENT = '@goolge/sheets-client';
+
+// brittle, requires to be in sync with the sheet
+export const ProgSheetRanges = {
+  [Encounter.DSR]: {
+    start: 'N',
+    end: 'P',
+  },
+  [Encounter.TEA]: {
+    start: 'J',
+    end: 'L',
+  },
+  [Encounter.TOP]: {
+    start: 'R',
+    end: 'T',
+  },
+  [Encounter.UCOB]: {
+    start: 'B',
+    end: 'D',
+  },
+  [Encounter.UWU]: {
+    start: 'F',
+    end: 'H',
+  },
+};

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -1,71 +1,144 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { sheets_v4 } from 'googleapis';
+import { PartyType } from '../signups/signup.consts.js';
 import { Signup } from '../signups/signup.interfaces.js';
 import { sheetsConfig } from './sheets.config.js';
+import { ProgSheetRanges } from './sheets.consts.js';
 import { InjectSheetsClient } from './sheets.decorators.js';
 
 // TODO: Needs unit testing but mocking the google client is a PITA
 @Injectable()
 class SheetsService {
+  private readonly logger: Logger = new Logger(SheetsService.name);
+  private static readonly PROG_SHEET_NAME = 'Ulti Proj: Prog Parties';
   constructor(
     @InjectSheetsClient() private readonly client: sheets_v4.Sheets,
     @Inject(sheetsConfig.KEY)
     private readonly config: ConfigType<typeof sheetsConfig>,
   ) {}
 
-  public async upsertSignup({
-    encounter,
-    character,
-    role,
-    fflogsLink,
-    world,
-    screenshot,
-  }: Signup) {
-    const proofOfProg =
-      fflogsLink || screenshot
-        ? this.createHyperLinkCell('Proof of Prog', (fflogsLink || screenshot)!)
-        : '';
+  public async upsertSignup({ partyType, ...signup }: Signup) {
+    switch (partyType) {
+      case PartyType.CLEAR_PARTY:
+        return this.upsertClearParty(signup);
+      case PartyType.PROG_PARTY:
+        return this.upsertProgParty(signup);
 
-    const {
-      data: { values },
-    } = await this.client.spreadsheets.values.get({
-      spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
-      range: encounter,
-    });
-
-    // depends on knowing that character is at the 2nd index of th row
-    const row = values?.findIndex((row) => row.at(2) === character) ?? -1;
-
-    // This depends on knowing the structure of the spreadsheet
-    // Current non-automated iterations of the spreadsheet have a progpoint dropdown. We don't currently
-    // capture this as part of the signup so we'll replace that value with the proof of prog link
-    if (row === -1) {
-      await this.client.spreadsheets.values.append({
-        spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
-        // the encounter value should match the sheet name and is used as the range
-        // this used to work without needing to specify column range but on the actual ulti-project sheet it needs this I believe due to empty columns at the start of the document
-        range: `${encounter}!C:F`,
-        valueInputOption: 'USER_ENTERED',
-        requestBody: {
-          values: [[character, world, role, proofOfProg]],
-        },
-      });
-    } else {
-      // If the row was found, update the existing data
-      await this.client.spreadsheets.values.update({
-        spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
-        range: `${encounter}!C${row + 1}:F${row + 1}`,
-        valueInputOption: 'USER_ENTERED',
-        requestBody: {
-          values: [[character, world, role, proofOfProg]],
-        },
-      });
+      default:
+        this.logger.error(
+          `Unknown party type: ${partyType} for user: ${signup.discordId}`,
+        );
     }
   }
 
   public createHyperLinkCell(name: string, url: string): string {
     return `=HYPERLINK("${url}","${name}")`;
+  }
+
+  private async upsertClearParty({
+    encounter,
+    character,
+    role,
+    world,
+    ...rest
+  }: Omit<Signup, 'partyType'>) {
+    const proofOfProg = this.getProgProof(rest);
+    const cellValues = [character, world, role, proofOfProg];
+
+    const sheetValues = await this.getSheetValues(encounter);
+
+    const row =
+      sheetValues?.findIndex((row: string[]) =>
+        row.find((value) => value.toLowerCase() === character.toLowerCase()),
+      ) ?? -1;
+
+    // This depends on knowing the structure of the spreadsheet
+    // Current non-automated iterations of the spreadsheet have a progpoint dropdown. We don't currently
+    // capture this as part of the signup so we'll replace that value with the proof of prog link
+    if (row === -1) {
+      return this.updateSheet(`${encounter}!C:F`, cellValues, 'append');
+    } else {
+      return this.updateSheet(
+        `${encounter}!C${row + 1}:F${row + 1}`,
+        cellValues,
+        'update',
+      );
+    }
+  }
+
+  private async upsertProgParty({
+    encounter,
+    character,
+    role,
+    ...rest
+  }: Omit<Signup, 'partyType'>) {
+    const range = ProgSheetRanges[encounter];
+    const progProof = this.getProgProof(rest);
+
+    const values = await this.getSheetValues(
+      `${SheetsService.PROG_SHEET_NAME}!${range.start}:${range.end}`,
+    );
+
+    const row =
+      values?.findIndex((row: string[]) => {
+        return row.find(
+          (value) => value.toLowerCase() === character.toLowerCase(),
+        );
+      }) ?? -1;
+
+    // This is needed to find the right row in the sub-group to update. Append will not work
+    // with how the prog sheet is setup visually with multiple column groups spanning different row lengths
+    const rowOffset = values ? values.length + 1 : 15;
+    const cellValues = [character, role, progProof];
+
+    const updateRange =
+      row === -1
+        ? `${SheetsService.PROG_SHEET_NAME}!${range.start}${rowOffset}:${range.end}`
+        : `${SheetsService.PROG_SHEET_NAME}!${range.start}${row + 1}:${
+            range.end
+          }${row + 1}`;
+
+    return this.updateSheet(updateRange, cellValues, 'update');
+  }
+
+  private getProgProof({
+    fflogsLink,
+    screenshot,
+  }: Pick<Signup, 'fflogsLink' | 'screenshot'>) {
+    return fflogsLink || screenshot
+      ? this.createHyperLinkCell('Proof of Prog', (fflogsLink || screenshot)!)
+      : '';
+  }
+
+  private async getSheetValues(range: string) {
+    const {
+      data: { values },
+    } = await this.client.spreadsheets.values.get({
+      spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
+      range,
+    });
+
+    return values;
+  }
+
+  private updateSheet(
+    range: string,
+    values: string[],
+    type: 'update' | 'append',
+  ) {
+    const payload = {
+      spreadsheetId: this.config.GOOGLE_SPREADSHEET_ID,
+      range,
+      valueInputOption: 'USER_ENTERED',
+      requestBody: {
+        values: [values],
+      },
+    };
+
+    return type === 'update'
+      ? this.client.spreadsheets.values.update(payload)
+      : this.client.spreadsheets.values.append(payload);
   }
 }
 

--- a/src/signups/commands/handlers/send-signup-review-command.handler.spec.ts
+++ b/src/signups/commands/handlers/send-signup-review-command.handler.spec.ts
@@ -5,7 +5,7 @@ import { Channel, Client, TextChannel } from 'discord.js';
 import { Encounter } from '../../../app.consts.js';
 import { DISCORD_CLIENT } from '../../../discord/discord.decorators.js';
 import { SettingsService } from '../../../settings/settings.service.js';
-import { SignupStatus } from '../../signup.consts.js';
+import { PartyType, SignupStatus } from '../../signup.consts.js';
 import { Signup } from '../../signup.interfaces.js';
 import { SendSignupReviewCommandHandler } from './send-signup-review-command.handler.js';
 import {
@@ -18,13 +18,14 @@ describe('Send Signup Review Command Handler', () => {
   let settingsService: DeepMocked<SettingsService>;
   let get: jest.Mock<() => Channel | undefined>;
   const signup = createMock<Signup>({
-    encounter: Encounter.DSR,
-    status: SignupStatus.PENDING,
-    character: 'foo',
-    world: 'bar',
     availability: 'baz',
-    screenshot: 'http://somelinksurely',
+    character: 'foo',
+    encounter: Encounter.DSR,
+    partyType: PartyType.CLEAR_PARTY,
     role: 'healer',
+    screenshot: 'http://somelinksurely',
+    status: SignupStatus.PENDING,
+    world: 'bar',
   });
 
   beforeEach(async () => {

--- a/src/signups/commands/handlers/send-signup-review-command.handler.ts
+++ b/src/signups/commands/handlers/send-signup-review-command.handler.ts
@@ -81,6 +81,7 @@ class SendSignupReviewCommandHandler
     screenshot,
     world,
     role,
+    partyType,
   }: Signup) {
     let embed = new EmbedBuilder()
       .setDescription(
@@ -91,7 +92,9 @@ class SendSignupReviewCommandHandler
         {
           name: 'Encounter',
           value: EncounterFriendlyDescription[encounter],
+          inline: true,
         },
+        { name: 'Party Type', value: partyType, inline: true },
         { name: 'Character', value: character, inline: true },
         { name: 'Home World', value: world, inline: true },
         { name: 'Availability', value: availability, inline: true },

--- a/src/signups/commands/handlers/signup-command.handler.spec.ts
+++ b/src/signups/commands/handlers/signup-command.handler.spec.ts
@@ -10,7 +10,7 @@ import {
 } from 'discord.js';
 import { SignupCommandHandler } from './signup-command.handler.js';
 import { SignupCommand } from '../signup.commands.js';
-import { SIGNUP_MESSAGES } from '../../signup.consts.js';
+import { PartyType, SIGNUP_MESSAGES } from '../../signup.consts.js';
 import { SettingsService } from '../../../settings/settings.service.js';
 import { Encounter } from '../../../app.consts.js';
 import { UnhandledButtonInteractionException } from '../../signup.exceptions.js';
@@ -52,6 +52,8 @@ describe('Signup Command Handler', () => {
               return 'Jenova';
             case 'role':
               return 'tank';
+            case 'party-type':
+              return PartyType.CLEAR_PARTY;
           }
         },
         getAttachment: () => null,

--- a/src/signups/commands/handlers/signup-command.handler.ts
+++ b/src/signups/commands/handlers/signup-command.handler.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../common/components/buttons.js';
 import { SettingsService } from '../../../settings/settings.service.js';
 import { SignupRequestDto } from '../../dto/signup-request.dto.js';
-import { SIGNUP_MESSAGES } from '../../signup.consts.js';
+import { PartyType, SIGNUP_MESSAGES } from '../../signup.consts.js';
 import { SignupEvent } from '../../signup.events.js';
 import { UnhandledButtonInteractionException } from '../../signup.exceptions.js';
 import { SignupRepository } from '../../signup.repository.js';
@@ -144,14 +144,15 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
   > {
     // the fields that are marked required should come in with values. empty strings are not allowed
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const request = {
+    const request: SignupRequestDto = {
       availability: options.getString('availability')!,
       character: options.getString('character')!,
       discordId: user.id,
       encounter: options.getString('encounter')! as Encounter,
       fflogsLink: options.getString('fflogs'),
-      role: options.getString('role'),
+      role: options.getString('role')!,
       screenshot: options.getAttachment('screenshot')?.url,
+      partyType: options.getString('party-type')! as PartyType,
       username: user.username,
       world: options.getString('world')!,
     };
@@ -170,13 +171,14 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
     availability,
     character,
     encounter,
-    screenshot,
     fflogsLink,
-    world,
+    partyType,
     role,
+    screenshot,
+    world,
   }: SignupRequestDto) {
     let embed = new EmbedBuilder()
-      .setTitle(`${EncounterFriendlyDescription[encounter]} Signup`)
+      .setTitle(`${EncounterFriendlyDescription[encounter]} ${partyType}`)
       .setDescription("Here's a summary of your request")
       .addFields([
         { name: 'Character', value: character, inline: true },

--- a/src/signups/dto/signup-request.dto.ts
+++ b/src/signups/dto/signup-request.dto.ts
@@ -1,5 +1,6 @@
 import { IsEnum, IsString, IsUrl, ValidateIf } from 'class-validator';
 import { Encounter } from '../../app.consts.js';
+import { PartyType } from '../signup.consts.js';
 
 class SignupRequestDto {
   @IsString()
@@ -32,6 +33,9 @@ class SignupRequestDto {
   })
   @ValidateIf(({ fflogsLink }) => !fflogsLink)
   screenshot?: string | null;
+
+  @IsEnum(PartyType)
+  partyType: PartyType;
 
   @IsString()
   username: string;

--- a/src/signups/signup.consts.ts
+++ b/src/signups/signup.consts.ts
@@ -23,3 +23,8 @@ export enum SignupStatus {
   APPROVED = 'APPROVED',
   DECLINED = 'DECLINED',
 }
+
+export enum PartyType {
+  PROG_PARTY = 'Prog Party',
+  CLEAR_PARTY = 'Clear Party',
+}

--- a/src/signups/signup.repository.spec.ts
+++ b/src/signups/signup.repository.spec.ts
@@ -23,16 +23,9 @@ describe('Signup Repository', () => {
   let firestore: DeepMocked<Firestore>;
   let collection: DeepMocked<CollectionReference<DocumentData>>;
   let doc: DeepMocked<DocumentReference<DocumentData>>;
-  const signupRequest: SignupRequestDto = {
-    availability: 'availability',
-    character: 'character',
-    discordId: 'discordId',
+  const signupRequest = createMock<SignupRequestDto>({
     encounter: Encounter.DSR,
-    fflogsLink: 'fflogsLink',
-    role: 'tank',
-    username: 'username',
-    world: 'world',
-  };
+  });
 
   beforeEach(async () => {
     doc = createMock<DocumentReference>();

--- a/src/signups/signup.repository.ts
+++ b/src/signups/signup.repository.ts
@@ -16,8 +16,7 @@ class SignupRepository {
   }
 
   /**
-   * Upserts a signup request into the database. If the signup already exists, it will update the
-   * fflogsLink, character, world, and availability fields. Otherwise, it will create a new signup
+   * Upserts a signup request into the database
    * @param signup
    */
   public async createSignup({ ...signup }: SignupRequestDto): Promise<Signup> {

--- a/src/slash-commands/signup-slash-command.ts
+++ b/src/slash-commands/signup-slash-command.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { Encounter } from '../app.consts.js';
+import { PartyType } from '../signups/signup.consts.js';
 
 export const SignupSlashCommand = new SlashCommandBuilder()
   .setName('signup')
@@ -18,6 +19,19 @@ export const SignupSlashCommand = new SlashCommandBuilder()
         },
         { name: 'The Weapons Refrain (Ultimate)', value: Encounter.UWU },
         { name: `Dragonsong Reprise (Ultimate)`, value: Encounter.DSR },
+      ),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setName('party-type')
+      .setDescription('Signing up for a Prog or Clear party?')
+      .addChoices(
+        {
+          name: 'Prog Party',
+          value: PartyType.PROG_PARTY,
+        },
+        { name: 'Clear Party', value: PartyType.CLEAR_PARTY },
       ),
   )
   .addStringOption((option) =>

--- a/src/status/commands/handlers/status-command.handler.ts
+++ b/src/status/commands/handlers/status-command.handler.ts
@@ -36,7 +36,7 @@ class StatusCommandHandler implements ICommandHandler<StatusCommand> {
   }
 
   private createStatusEmbed(signups: Signup[]) {
-    const fields = signups.reduce((acc, { encounter, status }) => {
+    const fields = signups.reduce((acc, { encounter, status, partyType }) => {
       return acc.concat([
         {
           name: 'Encounter',
@@ -48,7 +48,7 @@ class StatusCommandHandler implements ICommandHandler<StatusCommand> {
           value: `${SIGNUP_REVIEW_REACTIONS[status]} ${SignupStatus[status]}`,
           inline: true,
         },
-        { name: '\u200B', value: '\u200B' },
+        { name: 'Party Type', value: partyType, inline: true },
       ]);
     }, [] as APIEmbedField[]);
 


### PR DESCRIPTION
Support distinction between Prog/Clear parties and update the google sheet accordingly.

Note: Does not account for `world` being part of the prog party sheet, so there can be a character name conflict when looking up rows. Needs to be discussed. 
