### PR TITLE
refactor: support dynamic databases

### DIFF
--- a/src/firebase/firebase.config.ts
+++ b/src/firebase/firebase.config.ts
@@ -1,0 +1,16 @@
+import { registerAs } from '@nestjs/config';
+import Joi from 'joi';
+
+export interface FirebaseConfig {
+  FIRESTORE_DATABASE_ID?: string;
+}
+
+const schema = Joi.object({
+  FIRESTORE_DATABASE_ID: Joi.string().optional(),
+});
+
+export const firebaseConfig = registerAs<FirebaseConfig>('firebase', () => {
+  const res = schema.validate(process.env, { stripUnknown: true });
+  if (res.error) throw res.error;
+  return res.value;
+});

--- a/src/firebase/firebase.module.ts
+++ b/src/firebase/firebase.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule, ConfigService, ConfigType } from '@nestjs/config';
 import { App, cert, initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { AppConfig } from '../app.config.js';
+import { firebaseConfig } from './firebase.config.js';
 import { FIREBASE_APP, FIRESTORE } from './firebase.consts.js';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule.forFeature(firebaseConfig)],
   providers: [
     {
       provide: FIREBASE_APP,
@@ -23,9 +24,14 @@ import { FIREBASE_APP, FIRESTORE } from './firebase.consts.js';
     },
     {
       provide: FIRESTORE,
-      inject: [FIREBASE_APP],
-      useFactory: (app: App) => {
-        const firestore = getFirestore(app);
+      inject: [FIREBASE_APP, firebaseConfig.KEY],
+      useFactory: (
+        app: App,
+        { FIRESTORE_DATABASE_ID }: ConfigType<typeof firebaseConfig>,
+      ) => {
+        const firestore = FIRESTORE_DATABASE_ID
+          ? getFirestore(app, FIRESTORE_DATABASE_ID)
+          : getFirestore(app);
         firestore.settings({ ignoreUndefinedProperties: true });
         return firestore;
       },

--- a/src/status/commands/handlers/status-command.handler.ts
+++ b/src/status/commands/handlers/status-command.handler.ts
@@ -5,10 +5,7 @@ import {
   ChatInputCommandInteraction,
   EmbedBuilder,
 } from 'discord.js';
-import {
-  EncounterEmoji,
-  EncounterFriendlyDescription,
-} from '../../../app.consts.js';
+import { EncounterFriendlyDescription } from '../../../app.consts.js';
 import {
   SIGNUP_REVIEW_REACTIONS,
   SignupStatus,


### PR DESCRIPTION
Supports providing different database ids, mainly for development vs production. 

The default DB will be production, development will provide an id via env vars.

This may seem inverse of how it should be but its done for simplicity sake via firestore console management since only the default
DB can be managed through the firestore console instead of the cloud console (unless thats a free tier limitation?) 
