### PR TITLE
refactor(signups): update collection key

### DIFF
--- a/src/signups/signup.interfaces.ts
+++ b/src/signups/signup.interfaces.ts
@@ -8,4 +8,7 @@ export interface Signup extends Omit<SignupRequestDto, 'screenshot'> {
   screenshot?: string | null;
 }
 
-export type SignupCompositeKeyProps = Pick<Signup, 'username' | 'encounter'>;
+export type SignupCompositeKeyProps = Pick<
+  Signup,
+  'character' | 'world' | 'encounter'
+>;

--- a/src/signups/signup.repository.spec.ts
+++ b/src/signups/signup.repository.spec.ts
@@ -18,14 +18,18 @@ import { Signup } from './signup.interfaces.js';
 import { SignupStatus } from './signup.consts.js';
 import { SignupRequestDto } from './dto/signup-request.dto.js';
 
+const SIGNUP_KEY = {
+  character: 'some name',
+  world: 'someworld',
+  encounter: Encounter.DSR,
+};
+
 describe('Signup Repository', () => {
   let repository: SignupRepository;
   let firestore: DeepMocked<Firestore>;
   let collection: DeepMocked<CollectionReference<DocumentData>>;
   let doc: DeepMocked<DocumentReference<DocumentData>>;
-  const signupRequest = createMock<SignupRequestDto>({
-    encounter: Encounter.DSR,
-  });
+  const signupRequest = createMock<SignupRequestDto>(SIGNUP_KEY);
 
   beforeEach(async () => {
     doc = createMock<DocumentReference>();
@@ -89,14 +93,9 @@ describe('Signup Repository', () => {
   });
 
   it('should call updateSignupStatus with the correct arguments', async () => {
-    const key = {
-      username: 'username',
-      encounter: Encounter.DSR,
-    };
-
     await repository.updateSignupStatus(
       SignupStatus.APPROVED,
-      key,
+      SIGNUP_KEY,
       'reviewedBy',
     );
 
@@ -107,12 +106,7 @@ describe('Signup Repository', () => {
   });
 
   it('should call setReviewMessageId with the correct arguments', async () => {
-    const key = {
-      username: 'username',
-      encounter: Encounter.DSR,
-    };
-
-    await repository.setReviewMessageId(key, 'messageId');
+    await repository.setReviewMessageId(SIGNUP_KEY, 'messageId');
 
     expect(doc.update).toHaveBeenCalledWith({
       reviewMessageId: 'messageId',

--- a/src/signups/signup.repository.ts
+++ b/src/signups/signup.repository.ts
@@ -82,10 +82,12 @@ class SignupRepository {
     });
   }
 
-  private getKeyForSignup({ username, encounter }: SignupCompositeKeyProps) {
-    // usernames are supposed to be unique right? The recent change discord
-    // made to remove #discriminator from the username might make this wonky
-    return `${username}-${encounter}`;
+  private getKeyForSignup({
+    character,
+    world,
+    encounter,
+  }: SignupCompositeKeyProps) {
+    return `${character.toLowerCase()}-${world.toLowerCase()}-${encounter}`;
   }
 }
 


### PR DESCRIPTION
The key prior to this change was using the discord username (friendly name), but I can't guarantee that'll be unique, and alternatively users may have multiple characters so signing up by character seems like the better alternative? This will also aid in having other people (like coordinators) signup on behalf of other players. 

Signups are still linked by discordID though, so the onBehalfOf stuff isn't fully fleshed out if needed. Its not _really_ expected that users will signup for other users outside of the beta testing phase
