### PR TITLE
refactor(sheets): manage spreadsheetId through guild settings

### DIFF
--- a/src/settings/commands/handlers/edit-settings-command.handler.spec.ts
+++ b/src/settings/commands/handlers/edit-settings-command.handler.spec.ts
@@ -28,6 +28,7 @@ describe('Edit Settings Command Handler', () => {
     const guildId = '12345';
     const reviewerRole = '67890';
     const reviewChannel = '09876';
+    const spreadsheetId = 'spreadsheetId';
 
     const upsertSpy = jest.spyOn(settingsService, 'upsertSettings');
 
@@ -37,6 +38,7 @@ describe('Edit Settings Command Handler', () => {
         options: {
           getRole: () => createMock({ id: reviewerRole }),
           getChannel: () => createMock({ id: reviewChannel }),
+          getString: () => 'spreadsheetId',
         },
         valueOf: () => '',
       }),
@@ -45,6 +47,7 @@ describe('Edit Settings Command Handler', () => {
     expect(upsertSpy).toHaveBeenCalledWith(guildId, {
       reviewerRole,
       reviewChannel,
+      spreadsheetId,
     });
   });
 });

--- a/src/settings/commands/handlers/edit-settings-command.handler.ts
+++ b/src/settings/commands/handlers/edit-settings-command.handler.ts
@@ -22,10 +22,13 @@ class EditSettingsCommandHandler
       const reviewChannel = interaction.options.getChannel(
         'signup-review-channel',
       );
+      const spreadsheetId =
+        interaction.options.getString('spreadsheet-id') ?? undefined;
 
       await this.service.upsertSettings(guildId, {
         reviewerRole: reviewerRole?.id,
         reviewChannel: reviewChannel?.id,
+        spreadsheetId,
       });
 
       await interaction.editReply('Settings updated!');

--- a/src/settings/settings.interfaces.ts
+++ b/src/settings/settings.interfaces.ts
@@ -3,4 +3,5 @@ import { DocumentData } from 'firebase-admin/firestore';
 export interface Settings extends DocumentData {
   reviewerRole?: string;
   reviewChannel: string;
+  spreadsheetId?: string;
 }

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -3,9 +3,10 @@ import { EditSettingsCommandHandler } from './commands/handlers/edit-settings-co
 import { SettingsService } from './settings.service.js';
 import { FirebaseModule } from '../firebase/firebase.module.js';
 import { ViewSettingsCommandHandler } from './commands/handlers/view-settings-command.handler.js';
+import { SheetsModule } from '../sheets/sheets.module.js';
 
 @Module({
-  imports: [FirebaseModule],
+  imports: [FirebaseModule, SheetsModule],
   providers: [
     EditSettingsCommandHandler,
     SettingsService,

--- a/src/settings/settings.service.spec.ts
+++ b/src/settings/settings.service.spec.ts
@@ -8,6 +8,7 @@ import { FIRESTORE } from '../firebase/firebase.consts.js';
 describe('SettingsService', () => {
   let service: SettingsService;
   let firestore: DeepMocked<Firestore>;
+  const guildId = 'guildId';
 
   beforeEach(async () => {
     const docMock = {
@@ -33,7 +34,6 @@ describe('SettingsService', () => {
   });
 
   it('should call upsertSettings with correct arguments', async () => {
-    const guildId = 'guildId';
     const settings = { reviewChannel: 'channel', reviewerRole: 'role' };
 
     await service.upsertSettings(guildId, settings);
@@ -46,8 +46,6 @@ describe('SettingsService', () => {
   });
 
   it('should call getReviewChannel with correct arguments', async () => {
-    const guildId = 'guildId';
-
     await service.getReviewChannel(guildId);
 
     expect(firestore.collection).toHaveBeenCalledWith('settings');
@@ -56,8 +54,6 @@ describe('SettingsService', () => {
   });
 
   it('should call getReviewerRole with correct arguments', async () => {
-    const guildId = 'guildId';
-
     await service.getReviewerRole(guildId);
 
     expect(firestore.collection).toHaveBeenCalledWith('settings');
@@ -66,11 +62,16 @@ describe('SettingsService', () => {
   });
 
   it('should call getSettings with correct arguments', async () => {
-    const guildId = 'guildId';
-
     await service.getSettings(guildId);
 
     expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
+    expect(firestore.collection('').doc().get).toHaveBeenCalled();
+  });
+
+  it('should call getSpreadsheetId with correct arguments', async () => {
+    await service.getSpreadsheetId(guildId);
+
     expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
     expect(firestore.collection('').doc().get).toHaveBeenCalled();
   });

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -31,6 +31,11 @@ class SettingsService {
     const doc = await this.collection.doc(guildId).get();
     return doc.data()?.reviewerRole;
   }
+
+  public async getSpreadsheetId(guildId: string) {
+    const doc = await this.collection.doc(guildId).get();
+    return doc.data()?.spreadsheetId;
+  }
 }
 
 export { SettingsService };

--- a/src/sheets/sheets.config.ts
+++ b/src/sheets/sheets.config.ts
@@ -2,12 +2,10 @@ import { registerAs } from '@nestjs/config';
 import Joi from 'joi';
 
 export interface SheetsConfig {
-  GOOGLE_SPREADSHEET_ID: string;
   GOOGLE_UNIVERSE_DOMAIN: string;
 }
 
 const schema = Joi.object({
-  GOOGLE_SPREADSHEET_ID: Joi.string().required(),
   GOOGLE_UNIVERSE_DOMAIN: Joi.string().default('googleapis.com'),
 });
 

--- a/src/sheets/sheets.service.spec.ts
+++ b/src/sheets/sheets.service.spec.ts
@@ -1,0 +1,21 @@
+import { Test } from '@nestjs/testing';
+import { SheetsService } from './sheets.service.js';
+import { createMock } from '@golevelup/ts-jest';
+
+describe('Sheets Service', () => {
+  let service: SheetsService;
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [SheetsService],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    service = fixture.get(SheetsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/signups/signup-review.service.spec.ts
+++ b/src/signups/signup-review.service.spec.ts
@@ -1,0 +1,97 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { SignupReviewService } from './signup-review.service.js';
+import { Message, MessageReaction, ReactionEmoji, User } from 'discord.js';
+import { Signup } from './signup.interfaces.js';
+import { Settings } from '../settings/settings.interfaces.js';
+import { SIGNUP_REVIEW_REACTIONS } from './signup.consts.js';
+import { SignupRepository } from './signup.repository.js';
+
+describe('SignupReviewService', () => {
+  let service: SignupReviewService;
+  let messageReaction: DeepMocked<MessageReaction>;
+  let user: DeepMocked<User>;
+  let settings: DeepMocked<Settings>;
+  let signup: DeepMocked<Signup>;
+  let repository: DeepMocked<SignupRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SignupReviewService],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    service = module.get(SignupReviewService);
+    repository = module.get(SignupRepository);
+
+    messageReaction = createMock<MessageReaction>({
+      message: createMock<Message>({ id: 'messageId', valueOf: () => '' }),
+      emoji: createMock<ReactionEmoji>({
+        name: 'emojiName',
+        valueOf: () => '',
+      }),
+      valueOf: () => '',
+    });
+
+    user = createMock<User>();
+    settings = createMock<Settings>();
+    signup = createMock<Signup>({
+      reviewMessageId: 'messageId',
+      reviewedBy: undefined,
+    });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Add more tests here
+  it('should handle approved reaction', async () => {
+    repository.findByReviewId.mockResolvedValue(signup);
+
+    messageReaction.emoji.name = SIGNUP_REVIEW_REACTIONS.APPROVED;
+
+    const spy = jest
+      .spyOn(service, 'handleApprovedReaction' as any)
+      .mockResolvedValue({});
+
+    await service['handleReaction'](messageReaction, user, settings);
+
+    expect(spy).toHaveBeenCalledWith(
+      signup,
+      messageReaction.message,
+      user,
+      settings,
+    );
+  });
+
+  it('should handle a declined reaction', async () => {
+    repository.findByReviewId.mockResolvedValue(signup);
+
+    messageReaction.emoji.name = SIGNUP_REVIEW_REACTIONS.DECLINED;
+
+    const spy = jest
+      .spyOn(service, 'handleDeclinedReaction' as any)
+      .mockResolvedValue({});
+
+    await service['handleReaction'](messageReaction, user, settings);
+
+    expect(spy).toHaveBeenCalledWith(signup, messageReaction.message, user);
+  });
+
+  it('should return early if a signup has been reviewed', async () => {
+    repository.findByReviewId.mockResolvedValue({
+      ...signup,
+      reviewedBy: user.id,
+    });
+
+    messageReaction.emoji.name = SIGNUP_REVIEW_REACTIONS.APPROVED;
+
+    await service['handleReaction'](messageReaction, user, settings);
+
+    const spy = jest.spyOn(service, 'handleApprovedReaction' as any);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/slash-commands/settings-slash-command.ts
+++ b/src/slash-commands/settings-slash-command.ts
@@ -27,6 +27,13 @@ export const SettingsSlashCommand = new SlashCommandBuilder()
           .setDescription(
             'an optional role that is allowed to review signups. If not set, anyone can review signups',
           ),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('spreadsheet-id')
+          .setDescription(
+            'The id of the spreadsheet to use for persistence modifications',
+          ),
       ),
   )
   .addSubcommand((subcommand) =>


### PR DESCRIPTION
Migrate management of the spreadsheet to guild specific settings instead of env var. Allows for multi-server management.

Additionally, it will only attempt to persist/modify sheets if the value is present on the settings.

Includes a miscellaneous fix on double hydration that was occurring for message reaction handling 
