### PR TITLE
feat(signups): implement remove-signup command

### DIFF
--- a/src/settings/commands/handlers/view-settings-command.handler.ts
+++ b/src/settings/commands/handlers/view-settings-command.handler.ts
@@ -33,7 +33,7 @@ class ViewSettingsCommandHandler
 
     if (spreadsheetId) {
       const { title, url } =
-        await this.sheetsService.getSheetTitle(spreadsheetId);
+        await this.sheetsService.getSheetMetadata(spreadsheetId);
 
       messages.push(`**Managaed Spreadsheet:** [${title}](${url})`);
     }

--- a/src/sheets/sheets.consts.spec.ts
+++ b/src/sheets/sheets.consts.spec.ts
@@ -1,0 +1,10 @@
+import { columnToIndex } from './sheets.consts.js';
+
+describe('#columnToIndex', () => {
+  it('should convert an alphabetic column to an index', () => {
+    const columns = ['A', 'Z', 'AA'];
+    const results = columns.map(columnToIndex);
+
+    expect(results).toEqual([0, 25, 26]);
+  });
+});

--- a/src/sheets/sheets.consts.ts
+++ b/src/sheets/sheets.consts.ts
@@ -25,3 +25,11 @@ export const ProgSheetRanges = {
     end: 'H',
   },
 };
+
+export function columnToIndex(column: string) {
+  let index = 0;
+  for (let i = 0; i < column.length; i++) {
+    index = index * 26 + column.charCodeAt(i) - 'A'.charCodeAt(0) + 1;
+  }
+  return index - 1; // Convert to zero-based index
+}

--- a/src/signups/commands/handlers/remove-signup-command.handler.spec.ts
+++ b/src/signups/commands/handlers/remove-signup-command.handler.spec.ts
@@ -1,0 +1,100 @@
+import { Test } from '@nestjs/testing';
+import { RemoveSignupCommandHandler } from './remove-signup-command.handler.js';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { SettingsService } from '../../../settings/settings.service.js';
+import { ChatInputCommandInteraction, User } from 'discord.js';
+import { SIGNUP_MESSAGES } from '../../signup.consts.js';
+import { DiscordService } from '../../../discord/discord.service.js';
+import { SignupRepository } from '../../signup.repository.js';
+import { SheetsService } from '../../../sheets/sheets.service.js';
+
+describe('Remove Signup Command Handler', () => {
+  let discordService: DeepMocked<DiscordService>;
+  let handler: RemoveSignupCommandHandler;
+  let interaction: DeepMocked<ChatInputCommandInteraction<'cached' | 'raw'>>;
+  let settingsService: DeepMocked<SettingsService>;
+  let sheetsService: DeepMocked<SheetsService>;
+  let signupsRepository: DeepMocked<SignupRepository>;
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [RemoveSignupCommandHandler],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    discordService = fixture.get(DiscordService);
+    handler = fixture.get(RemoveSignupCommandHandler);
+    settingsService = fixture.get(SettingsService);
+    sheetsService = fixture.get(SheetsService);
+    signupsRepository = fixture.get(SignupRepository);
+
+    interaction = createMock<ChatInputCommandInteraction<'cached' | 'raw'>>({
+      member: {
+        user: createMock<User>({ id: '1', toString: () => '<@1>' }),
+      },
+      options: createMock({}),
+      valueOf: () => '',
+    });
+  });
+
+  it('is defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('replies with missing settings if no settings are set', async () => {
+    settingsService.getSettings.mockResolvedValue(undefined);
+
+    await handler.execute({ interaction });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      SIGNUP_MESSAGES.MISSING_SETTINGS,
+    );
+  });
+
+  it('checks if the user role is allowed to remove signups', async () => {
+    settingsService.getSettings.mockResolvedValue({
+      reviewerRole: 'reviewer',
+      reviewChannel: '1234',
+    });
+
+    discordService.userHasRole.mockResolvedValue(false);
+
+    await handler.execute({ interaction });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      'You do not have permission to remove signups',
+    );
+  });
+
+  it('replies with missing role if no role is set', async () => {
+    settingsService.getSettings.mockResolvedValue({
+      reviewChannel: '1234',
+    });
+
+    await handler.execute({ interaction });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      'No role has been configured to be allowed to run this command.',
+    );
+  });
+
+  it('removes the signup from the spreadsheet', async () => {
+    settingsService.getSettings.mockResolvedValue({
+      reviewerRole: 'reviewer',
+      reviewChannel: '1234',
+    });
+
+    await handler.execute({ interaction });
+    expect(signupsRepository.removeSignup).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith('Signup removed');
+  });
+
+  it('calls removeSignup from SheetService if spreadsheetId is set', async () => {
+    settingsService.getSettings.mockResolvedValue({
+      spreadsheetId: '1234',
+      reviewerRole: 'reviewer',
+      reviewChannel: '1234',
+    });
+
+    await handler.execute({ interaction });
+    expect(sheetsService.removeSignup).toHaveBeenCalled();
+  });
+});

--- a/src/signups/commands/handlers/remove-signup-command.handler.ts
+++ b/src/signups/commands/handlers/remove-signup-command.handler.ts
@@ -1,0 +1,77 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { RemoveSignupCommand } from '../remove-signup.command.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { Encounter } from '../../../app.consts.js';
+import { SignupRepository } from '../../signup.repository.js';
+import { SheetsService } from '../../../sheets/sheets.service.js';
+import { SettingsService } from '../../../settings/settings.service.js';
+import { DiscordService } from '../../../discord/discord.service.js';
+import { SIGNUP_MESSAGES } from '../../signup.consts.js';
+
+@CommandHandler(RemoveSignupCommand)
+class RemoveSignupCommandHandler
+  implements ICommandHandler<RemoveSignupCommand>
+{
+  constructor(
+    private readonly discordService: DiscordService,
+    private readonly settingsService: SettingsService,
+    private readonly sheetsService: SheetsService,
+    private readonly signupsRepository: SignupRepository,
+  ) {}
+
+  async execute({ interaction }: RemoveSignupCommand): Promise<any> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const options = this.getOptions(interaction);
+
+    const settings = await this.settingsService.getSettings(
+      interaction.guildId,
+    );
+
+    if (!settings) {
+      return interaction.editReply(SIGNUP_MESSAGES.MISSING_SETTINGS);
+    }
+
+    const { spreadsheetId, reviewerRole } = settings;
+
+    // TODO: Abstract into some authorization mechanism?
+    if (reviewerRole) {
+      const {
+        member: { user },
+      } = interaction;
+
+      const hasRole = await this.discordService.userHasRole(
+        user.id,
+        reviewerRole,
+      );
+
+      if (!hasRole) {
+        return interaction.editReply(
+          'You do not have permission to remove signups',
+        );
+      }
+    } else {
+      return interaction.editReply(
+        'No role has been configured to be allowed to run this command.',
+      );
+    }
+
+    if (spreadsheetId) {
+      await this.sheetsService.removeSignup(options, spreadsheetId);
+    }
+
+    await this.signupsRepository.removeSignup(options);
+
+    await interaction.editReply('Signup removed');
+  }
+
+  private getOptions({ options }: ChatInputCommandInteraction) {
+    return {
+      character: options.getString('character')!,
+      world: options.getString('world')!,
+      encounter: options.getString('encounter')! as Encounter,
+    };
+  }
+}
+
+export { RemoveSignupCommandHandler };

--- a/src/signups/commands/remove-signup.command.ts
+++ b/src/signups/commands/remove-signup.command.ts
@@ -1,0 +1,8 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { DiscordCommand } from '../../slash-commands/slash-commands.interfaces.js';
+
+export class RemoveSignupCommand implements DiscordCommand {
+  constructor(
+    public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
+  ) {}
+}

--- a/src/signups/signup.consts.ts
+++ b/src/signups/signup.consts.ts
@@ -7,6 +7,8 @@ export const SIGNUP_MESSAGES = {
     'Confirmed! A coordinator will review your submission and reach out to you soon. You can use `/status` to review the state of your signups.',
   MISSING_SIGNUP_REVIEW_CHANNEL:
     'A review channel has not been configured for this bot. Please contact an administrator',
+  MISSING_SETTINGS:
+    'No settings have been configured for this bot. Commands may not function until properly configured',
 };
 
 export const SIGNUP_REVIEW_REACTIONS: Record<

--- a/src/signups/signup.module.ts
+++ b/src/signups/signup.module.ts
@@ -9,6 +9,7 @@ import { SignupReviewService } from './signup-review.service.js';
 import { SignupRepository } from './signup.repository.js';
 import { SettingsModule } from '../settings/settings.module.js';
 import { SheetsModule } from '../sheets/sheets.module.js';
+import { RemoveSignupCommandHandler } from './commands/handlers/remove-signup-command.handler.js';
 
 @Module({
   imports: [
@@ -19,11 +20,12 @@ import { SheetsModule } from '../sheets/sheets.module.js';
     SheetsModule,
   ],
   providers: [
+    RemoveSignupCommandHandler,
     SendSignupReviewCommandHandler,
-    SignupReviewService,
     SignupCommandHandler,
-    SignupSagas,
     SignupRepository,
+    SignupReviewService,
+    SignupSagas,
   ],
 })
 class SignupModule {}

--- a/src/signups/signup.repository.ts
+++ b/src/signups/signup.repository.ts
@@ -1,7 +1,10 @@
 import { CollectionReference, Firestore } from 'firebase-admin/firestore';
 import { InjectFirestore } from '../firebase/firebase.decorators.js';
 import { Injectable } from '@nestjs/common';
-import { Signup, SignupCompositeKeyProps } from './signup.interfaces.js';
+import {
+  Signup,
+  SignupCompositeKeyProps as SignupCompositeKey,
+} from './signup.interfaces.js';
 import { SignupStatus } from './signup.consts.js';
 import { SignupRequestDto } from './dto/signup-request.dto.js';
 
@@ -62,7 +65,7 @@ class SignupRepository {
 
   public updateSignupStatus(
     status: SignupStatus,
-    key: SignupCompositeKeyProps,
+    key: SignupCompositeKey,
     reviewedBy: string,
   ) {
     return this.collection.doc(this.getKeyForSignup(key)).update({
@@ -71,10 +74,7 @@ class SignupRepository {
     });
   }
 
-  public setReviewMessageId(
-    signup: SignupCompositeKeyProps,
-    messageId: string,
-  ) {
+  public setReviewMessageId(signup: SignupCompositeKey, messageId: string) {
     const key = this.getKeyForSignup(signup);
 
     return this.collection.doc(key).update({
@@ -82,11 +82,13 @@ class SignupRepository {
     });
   }
 
-  private getKeyForSignup({
-    character,
-    world,
-    encounter,
-  }: SignupCompositeKeyProps) {
+  public removeSignup(signup: SignupCompositeKey) {
+    const key = this.getKeyForSignup(signup);
+
+    return this.collection.doc(key).delete();
+  }
+
+  private getKeyForSignup({ character, world, encounter }: SignupCompositeKey) {
     return `${character.toLowerCase()}-${world.toLowerCase()}-${encounter}`;
   }
 }

--- a/src/slash-commands/remove-signup-slash-command.ts
+++ b/src/slash-commands/remove-signup-slash-command.ts
@@ -1,0 +1,22 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { ENCOUNTER_CHOICES } from './slash-commands.consts.js';
+
+export const RemoveSignupSlashCommand = new SlashCommandBuilder()
+  .setName('remove-signup')
+  .setDescription('remove a player from signups')
+  .addStringOption((option) =>
+    option
+      .setName('character')
+      .setDescription('Character Name')
+      .setRequired(true),
+  )
+  .addStringOption((option) =>
+    option.setRequired(true).setDescription('Home World').setName('world'),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('Select an encounter')
+      .setName('encounter')
+      .addChoices(...ENCOUNTER_CHOICES),
+  );

--- a/src/slash-commands/signup-slash-command.ts
+++ b/src/slash-commands/signup-slash-command.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Encounter } from '../app.consts.js';
 import { PartyType } from '../signups/signup.consts.js';
+import { ENCOUNTER_CHOICES } from './slash-commands.consts.js';
 
 export const SignupSlashCommand = new SlashCommandBuilder()
   .setName('signup')
@@ -10,16 +10,7 @@ export const SignupSlashCommand = new SlashCommandBuilder()
       .setRequired(true)
       .setDescription('Select an encounter')
       .setName('encounter')
-      .addChoices(
-        { name: 'The Epic of Alexander (Ultimate)', value: Encounter.TEA },
-        { name: 'The Omega Protocol (Ultimate)', value: Encounter.TOP },
-        {
-          name: 'The Unending Coil of Bahamut (Ultimate)',
-          value: Encounter.UCOB,
-        },
-        { name: 'The Weapons Refrain (Ultimate)', value: Encounter.UWU },
-        { name: `Dragonsong Reprise (Ultimate)`, value: Encounter.DSR },
-      ),
+      .addChoices(...ENCOUNTER_CHOICES),
   )
   .addStringOption((option) =>
     option

--- a/src/slash-commands/slash-commands.consts.ts
+++ b/src/slash-commands/slash-commands.consts.ts
@@ -1,0 +1,12 @@
+import { Encounter } from '../app.consts.js';
+
+export const ENCOUNTER_CHOICES = [
+  { name: 'The Epic of Alexander (Ultimate)', value: Encounter.TEA },
+  { name: 'The Omega Protocol (Ultimate)', value: Encounter.TOP },
+  {
+    name: 'The Unending Coil of Bahamut (Ultimate)',
+    value: Encounter.UCOB,
+  },
+  { name: 'The Weapons Refrain (Ultimate)', value: Encounter.UWU },
+  { name: `Dragonsong Reprise (Ultimate)`, value: Encounter.DSR },
+];

--- a/src/slash-commands/slash-commands.service.ts
+++ b/src/slash-commands/slash-commands.service.ts
@@ -13,6 +13,8 @@ import { StatusSlashCommand } from './status-slash-command.js';
 import { CommandBus } from '@nestjs/cqrs';
 import { EditSettingsCommand } from '../settings/commands/edit-settings.command.js';
 import { ViewSettingsCommand } from '../settings/commands/view-settings.command.js';
+import { RemoveSignupSlashCommand } from './remove-signup-slash-command.js';
+import { RemoveSignupCommand } from '../signups/commands/remove-signup.command.js';
 
 @Injectable()
 class SlashCommandsService {
@@ -39,9 +41,15 @@ class SlashCommandsService {
             .with('view', () => new ViewSettingsCommand(interaction))
             .run();
         })
-        .run();
+        .with(
+          RemoveSignupSlashCommand.name,
+          () => new RemoveSignupCommand(interaction),
+        )
+        .otherwise(() => undefined);
 
-      this.commandBus.execute(command);
+      if (command) {
+        this.commandBus.execute(command);
+      }
     });
   }
 

--- a/src/slash-commands/slash-commands.ts
+++ b/src/slash-commands/slash-commands.ts
@@ -1,9 +1,11 @@
+import { RemoveSignupSlashCommand } from './remove-signup-slash-command.js';
 import { SettingsSlashCommand } from './settings-slash-command.js';
 import { SignupSlashCommand } from './signup-slash-command.js';
 import { StatusSlashCommand } from './status-slash-command.js';
 
 export const SLASH_COMMANDS = [
+  RemoveSignupSlashCommand,
+  SettingsSlashCommand,
   SignupSlashCommand,
   StatusSlashCommand,
-  SettingsSlashCommand,
 ];


### PR DESCRIPTION
implements `/remove-signup` which 
- allows the reviewer role to remove a signup across all signups (both clear and prog party)
- removes the entry from the firebase db
- removes the entry from the managed spreadsheet if applicable
