### PR TITLE
refactor: use discordId as document key

### DIFF
--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -55,7 +55,7 @@ class SheetsService {
    * @param spreadsheetId
    */
   public async removeSignup(
-    signup: SignupCompositeKeyProps,
+    signup: SignupCompositeKeyProps & Pick<Signup, 'character' | 'world'>,
     spreadsheetId: string,
   ) {
     const requests = await Promise.all([
@@ -89,7 +89,10 @@ class SheetsService {
   }
 
   private async createRemoveProgSignupRequest(
-    { encounter, character }: SignupCompositeKeyProps,
+    {
+      encounter,
+      character,
+    }: SignupCompositeKeyProps & Pick<Signup, 'character' | 'world'>,
     spreadsheetId: string,
   ): Promise<sheets_v4.Schema$Request | undefined> {
     const range = ProgSheetRanges[encounter];
@@ -127,7 +130,11 @@ class SheetsService {
   }
 
   private async createRemoveClearSignupRequest(
-    { encounter, world, character }: SignupCompositeKeyProps,
+    {
+      encounter,
+      world,
+      character,
+    }: SignupCompositeKeyProps & Pick<Signup, 'character' | 'world'>,
     spreadsheetId: string,
   ): Promise<sheets_v4.Schema$Request | undefined> {
     const clearPartyValues = await this.getSheetValues({
@@ -169,6 +176,7 @@ class SheetsService {
       character,
       role,
       world,
+      discordId,
       progPoint = '',
     }: Omit<Signup, 'partyType'>,
     spreadsheetId: string,
@@ -177,7 +185,7 @@ class SheetsService {
 
     // remove prog signup if it exists
     const request = await this.createRemoveProgSignupRequest(
-      { encounter, character, world },
+      { encounter, character, world, discordId },
       spreadsheetId,
     );
 

--- a/src/signups/commands/handlers/remove-signup-command.handler.ts
+++ b/src/signups/commands/handlers/remove-signup-command.handler.ts
@@ -23,7 +23,10 @@ class RemoveSignupCommandHandler
   async execute({ interaction }: RemoveSignupCommand): Promise<any> {
     await interaction.deferReply({ ephemeral: true });
 
-    const options = this.getOptions(interaction);
+    const options = {
+      ...this.getOptions(interaction),
+      discordId: interaction.user.id,
+    };
 
     const settings = await this.settingsService.getSettings(
       interaction.guildId,

--- a/src/signups/signup.interfaces.ts
+++ b/src/signups/signup.interfaces.ts
@@ -9,7 +9,4 @@ export interface Signup extends Omit<SignupRequestDto, 'screenshot'> {
   status: SignupStatus;
 }
 
-export type SignupCompositeKeyProps = Pick<
-  Signup,
-  'character' | 'world' | 'encounter'
->;
+export type SignupCompositeKeyProps = Pick<Signup, 'discordId' | 'encounter'>;

--- a/src/signups/signup.repository.spec.ts
+++ b/src/signups/signup.repository.spec.ts
@@ -19,8 +19,7 @@ import { SignupStatus } from './signup.consts.js';
 import { SignupRequestDto } from './dto/signup-request.dto.js';
 
 const SIGNUP_KEY = {
-  character: 'some name',
-  world: 'someworld',
+  discordId: '12345',
   encounter: Encounter.DSR,
 };
 

--- a/src/signups/signup.repository.ts
+++ b/src/signups/signup.repository.ts
@@ -103,8 +103,8 @@ class SignupRepository {
     return this.collection.doc(key).delete();
   }
 
-  private getKeyForSignup({ character, world, encounter }: SignupCompositeKey) {
-    return `${character.toLowerCase()}-${world.toLowerCase()}-${encounter}`;
+  private getKeyForSignup({ discordId, encounter }: SignupCompositeKey) {
+    return `${discordId.toLowerCase()}-${encounter}`;
   }
 
   /**


### PR DESCRIPTION
using the discordId as the key can help prevent bad-faith actors from overflowing the database
