### PR TITLE
refactor(signups): improve error handling around prog point selection

### DIFF
--- a/src/sentry/sentry.consts.ts
+++ b/src/sentry/sentry.consts.ts
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/node';
+
+interface ReportOptions {
+  userId?: string;
+  extra?: Record<string, any>;
+}
+
+export const sentryReport = (
+  error: unknown,
+  { userId, extra }: ReportOptions,
+) => {
+  Sentry.withScope((scope) => {
+    userId && scope.setUser({ id: userId });
+    Sentry.captureException(error, { extra });
+  });
+};


### PR DESCRIPTION
Direct Messages for prog point selection will now amend the existing
message when the response times out, removing the prog selection and
updating the message directing them to fill out the signup on the
google sheet manually
