### PR TITLE
refactor(sheets): queue sheets operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "husky": "^9.0.11",
     "hygen": "^6.2.11",
     "inquirer": "^9.2.15",
+    "jest-extended": "^4.0.2",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ devDependencies:
   inquirer:
     specifier: ^9.2.15
     version: 9.2.15
+  jest-extended:
+    specifier: ^4.0.2
+    version: 4.0.2
   source-map-support:
     specifier: ^0.5.21
     version: 0.5.21
@@ -4371,6 +4374,34 @@ packages:
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
+    dev: true
+
+  /jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-extended@4.0.2:
+    resolution: {integrity: sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: '>=27.2.5'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+    dependencies:
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+    dev: true
+
+  /jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /jest-worker@27.5.1:

--- a/src/common/async-queue/async-queue.spec.ts
+++ b/src/common/async-queue/async-queue.spec.ts
@@ -1,0 +1,56 @@
+import { AsyncQueue } from './async-queue.js';
+
+describe('Async Queue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('AsyncQueue should run tasks in order', async () => {
+    const queue = new AsyncQueue();
+
+    const task1 = vi.fn(async () => 'task1');
+    const task2 = vi.fn(async () => 'task2');
+    const task3 = vi.fn(async () => 'task3');
+
+    const result1 = queue.add(task1);
+    const result2 = queue.add(task2);
+    const result3 = queue.add(task3);
+
+    const results = await Promise.all([result1, result2, result3]);
+
+    expect(results).toEqual(['task1', 'task2', 'task3']);
+    expect(task1).toHaveBeenCalledBefore(task2);
+    expect(task2).toHaveBeenCalledBefore(task3);
+  });
+
+  test('AsyncQueue should handle errors', () => {
+    expect.assertions(3);
+
+    const queue = new AsyncQueue();
+
+    const task1 = async () => {
+      // workaround for vitest/sinon not supporting fakeTime on the node:timers/promises module
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return 'task1';
+    };
+    const task2 = async () => {
+      throw new Error('task2 error');
+    };
+
+    const task3 = async () => 'task3';
+
+    const result1 = queue.add(task1);
+    const result2 = queue.add(task2);
+    const result3 = queue.add(task3);
+
+    vi.runAllTimers();
+
+    expect(result1).resolves.toBe('task1');
+    expect(result2).rejects.toThrow('task2 error');
+    expect(result3).resolves.toBe('task3');
+  });
+});

--- a/src/common/async-queue/async-queue.ts
+++ b/src/common/async-queue/async-queue.ts
@@ -1,0 +1,39 @@
+import { Subject, concatMap } from 'rxjs';
+
+interface Job<T> {
+  task: (...args: any[]) => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: any) => void;
+}
+
+/**
+ * A queue that runs tasks asynchronously in the order they are added.
+ * Note: This is an extremely naive implementation and should not be used beyond very basic use cases.
+ * It has no additional features such as concurrency limits, error handling, or task cancellation, overflow tracking, etc.
+ */
+class AsyncQueue {
+  private readonly queue$ = new Subject<Job<unknown>>();
+
+  constructor() {
+    this.queue$
+      .pipe(
+        concatMap(async ({ task, resolve, reject }) => {
+          try {
+            const result = await task();
+            resolve(result);
+          } catch (error) {
+            reject(error);
+          }
+        }),
+      )
+      .subscribe();
+  }
+
+  public add<T>(task: (...args: any[]) => Promise<T>) {
+    return new Promise((resolve, reject) => {
+      this.queue$.next({ task, resolve, reject });
+    });
+  }
+}
+
+export { AsyncQueue };

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -1,0 +1,3 @@
+import * as matchers from 'jest-extended';
+import { expect } from 'vitest';
+expect.extend(matchers);

--- a/types/jest-extended.d.ts
+++ b/types/jest-extended.d.ts
@@ -1,0 +1,8 @@
+import type CustomMatchers from 'jest-extended';
+import 'vitest';
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining<T = any> extends CustomMatchers<T> {}
+  interface ExpectStatic extends CustomMatchers<T> {}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    setupFiles: ['./test/test-setup.ts'],
     globals: true,
     coverage: {
       include: ['src/**/*.ts'],


### PR DESCRIPTION
Google Sheets API calls can be subject to race conditions since we are not performing this atomically. We read/fetch data from the sheet to determine what cells to we want to populate on the prog sheet, but multiple concurrent requests could determine the same set there and overwrite one another