### PR TITLE
perf: adjust internal discord cache parameters

### DIFF
--- a/src/discord/discord.consts.ts
+++ b/src/discord/discord.consts.ts
@@ -6,10 +6,11 @@ import {
 } from 'discord.js';
 
 export const INTENTS = [
-  GatewayIntentBits.DirectMessages,
-  GatewayIntentBits.GuildMembers,
-  GatewayIntentBits.GuildMessages,
-  GatewayIntentBits.GuildPresences,
+  // GatewayIntentBits.DirectMessages,
+  // GatewayIntentBits.GuildMembers,
+  // GatewayIntentBits.GuildMessages,
+  // GatewayIntentBits.GuildPresences,
+  // GatewayIntentBits.MessageContent,
   /**
    * The Guilds intent populates and maintains the guilds, channels and guild.roles caches, plus thread-related events.
    * If this intent is not enabled, data for interactions and messages
@@ -17,7 +18,6 @@ export const INTENTS = [
    */
   GatewayIntentBits.Guilds,
   GatewayIntentBits.GuildMessageReactions,
-  GatewayIntentBits.MessageContent,
 ];
 
 export const PARTIALS = [Partials.Message, Partials.Channel, Partials.Reaction];
@@ -34,3 +34,13 @@ export function getMessageLink({
 }: Message | PartialMessage) {
   return `https://discord.com/channels/${guildId}/${channelId}/${id}`;
 }
+
+/**
+ * the amount of seconds in each unit of time
+ */
+export const CACHE_TIME_VALUES = {
+  SECOND: 1,
+  MINUTE: 60,
+  HOUR: 3600,
+  DAY: 86400,
+};

--- a/src/discord/discord.helpers.spec.ts
+++ b/src/discord/discord.helpers.spec.ts
@@ -1,6 +1,6 @@
 import { PartialMessageReaction, PartialUser } from 'discord.js';
 import { createMock } from '../../test/create-mock.js';
-import { hydrateReaction, hydrateUser } from './discord.helpers.js';
+import { CacheTime, hydrateReaction, hydrateUser } from './discord.helpers.js';
 
 describe('Discord Helper Methods', () => {
   it('hydrates a partial reaction', async () => {
@@ -45,5 +45,13 @@ describe('Discord Helper Methods', () => {
     });
 
     expect(hydrateUser(user)).resolves.toBe(user);
+  });
+
+  it('returns the right value in seconds for a requested cache time unit', () => {
+    expect(CacheTime(1, 'seconds')).toBe(1);
+    expect(CacheTime(1, 'minutes')).toBe(60);
+    expect(CacheTime(1, 'hours')).toBe(3600);
+    expect(CacheTime(1, 'days')).toBe(86400);
+    expect(CacheTime(2, 'minutes')).toBe(120);
   });
 });

--- a/src/discord/discord.helpers.ts
+++ b/src/discord/discord.helpers.ts
@@ -4,6 +4,8 @@ import {
   PartialUser,
   User,
 } from 'discord.js';
+import { match } from 'ts-pattern';
+import { CACHE_TIME_VALUES } from './discord.consts.js';
 
 export function hydrateReaction(
   reaction: MessageReaction | PartialMessageReaction,
@@ -13,4 +15,21 @@ export function hydrateReaction(
 
 export function hydrateUser(user: User | PartialUser): Promise<User> {
   return user.partial ? user.fetch() : Promise.resolve(user);
+}
+
+type CACHE_TIME_UNIT = 'days' | 'hours' | 'minutes' | 'seconds';
+
+/**
+ *  converts a value to seconds based on the given unit
+ * @param value
+ * @param unit
+ * @returns
+ */
+export function CacheTime(value: number, unit: CACHE_TIME_UNIT) {
+  return match(unit)
+    .with('seconds', () => value * CACHE_TIME_VALUES.SECOND)
+    .with('minutes', () => value * CACHE_TIME_VALUES.MINUTE)
+    .with('hours', () => value * CACHE_TIME_VALUES.HOUR)
+    .with('days', () => value * CACHE_TIME_VALUES.DAY)
+    .exhaustive();
 }


### PR DESCRIPTION
By default it looks like Discord.JS only sweeps the threads cache. This can potentially create an issue when the bot is long-running in production and build up memory overtime eventually going OOM. This limits some obvious caches and applies the sweeper to other caches we expect to see usage. 

Additionally this removes some Intents that look like they are unnecessary. 