### PR TITLE
fix: make casing consistent

### DIFF
--- a/src/commands/lookup/lookup.dto.ts
+++ b/src/commands/lookup/lookup.dto.ts
@@ -1,16 +1,17 @@
+import { capitalCase } from 'change-case';
 import { IsOptional, IsString } from 'class-validator';
-import { ToLowercase } from '../../common/decorators/to-lowercase.js';
+import { ToCasing } from '../../common/decorators/to-casing.js';
 import { SignupDocument } from '../../firebase/models/signup.model.js';
 
 export class LookupInteractionDto
   implements Pick<SignupDocument, 'character' | 'world'>
 {
   @IsString()
-  @ToLowercase()
+  @ToCasing(capitalCase)
   character: string;
 
   @IsString()
   @IsOptional()
-  @ToLowercase()
+  @ToCasing(capitalCase)
   world: string;
 }

--- a/src/commands/signup/signup-interaction.dto.ts
+++ b/src/commands/signup/signup-interaction.dto.ts
@@ -50,7 +50,7 @@ class SignupInteractionDto
   username: string;
 
   @IsString()
-  @ToLowercase()
+  @ToCasing(capitalCase)
   world: string;
 }
 

--- a/src/common/decorators/to-casing.ts
+++ b/src/common/decorators/to-casing.ts
@@ -9,4 +9,4 @@ type CaseTransformer = (value: string) => string;
  * @returns
  */
 export const ToCasing = (fn: CaseTransformer) =>
-  Transform(({ value }) => fn(value));
+  Transform(({ value }) => value && fn(value));


### PR DESCRIPTION
special formatting for display purposes should be left to the google sheet ops not any other place. Every other place such as 
- firestore
- command queries
should be consistently lowercase. 

#179 introduced a regression since lookup commands were trying to match on lowercase but data was being stored as capital case 