### PR TITLE
fix: make casing consistent

### DIFF
--- a/src/commands/signup/signup-interaction.dto.ts
+++ b/src/commands/signup/signup-interaction.dto.ts
@@ -1,6 +1,4 @@
-import { capitalCase } from 'change-case';
 import { IsEnum, IsString, IsUrl, ValidateIf } from 'class-validator';
-import { ToCasing } from '../../common/decorators/to-casing.js';
 import { ToLowercase } from '../../common/decorators/to-lowercase.js';
 import { TransformUrl } from '../../common/decorators/transform-url.js';
 import { Encounter } from '../../encounters/encounters.consts.js';
@@ -13,7 +11,7 @@ class SignupInteractionDto
   availability: string;
 
   @IsString()
-  @ToCasing(capitalCase)
+  @ToLowercase()
   character: string;
 
   @IsString()

--- a/src/common/decorators/to-casing.ts
+++ b/src/common/decorators/to-casing.ts
@@ -9,4 +9,4 @@ type CaseTransformer = (value: string) => string;
  * @returns
  */
 export const ToCasing = (fn: CaseTransformer) =>
-  Transform(({ value }) => fn(value));
+  Transform(({ value }) => value && fn(value));


### PR DESCRIPTION
special formatting for display purposes should be left to the google sheet ops not any other place. Every other place such as 
- firestore
- command queries should be consistently lowercase. 

#179 introduced a regression since lookup commands were trying to match on lowercase but data was being stored as capital case 