### PR TITLE
fix: reaction error handling

### DIFF
--- a/src/commands/signup/signup.consts.ts
+++ b/src/commands/signup/signup.consts.ts
@@ -24,7 +24,7 @@ You can reach out to a coordinator to discuss any issues
   PROG_SELECTION_TIMEOUT:
     'Your response timed out and could not be recorded to set the prog point for this signup. The signup has not been added to the googlesheet since we could not determine what kind party it should be, please add it manually.',
   GENERIC_APPROVAL_ERROR:
-    'An error occurred while processing your response. The signup may not have been added to the googlesheet, please verify it or add it manually',
+    'An error occurred while processing your response. The signup may not have been added to the Google Sheet, please verify it or add it manually',
 };
 
 export const SIGNUP_REVIEW_REACTIONS: Record<

--- a/src/commands/signup/signup.service.ts
+++ b/src/commands/signup/signup.service.ts
@@ -100,7 +100,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
                 );
 
                 return shouldHandle
-                  ? this.handleReaction(reaction, user, settings)
+                  ? await this.handleReaction(reaction, user, settings)
                   : EMPTY;
               } catch (error) {
                 this.handleError(error, event.user, event.reaction.message);

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -283,15 +283,13 @@ class SheetsService {
       }
     }
 
-    const { encounter, character, world, role, progPoint = '' } = signup;
+    const { encounter, character, world } = signup;
     const range = ProgSheetRanges[encounter];
 
     const values = await this.getSheetValues({
       spreadsheetId,
       range: `${sheetName}!${range.start}:${range.end}`,
     });
-
-    this.logger.debug(`updating sheet: ${sheetName} with range ${range}`);
 
     const row = this.findCharacterRow(
       values,


### PR DESCRIPTION
if an error occurs in `handleApprovedReaction` it gets thrown as unhandled, await it so it occurs within the catch block