### PR TITLE
refactor: handle commandBus exceptions

### DIFF
--- a/src/commands/settings/subcommands/view-settings-command.handler.ts
+++ b/src/commands/settings/subcommands/view-settings-command.handler.ts
@@ -12,7 +12,7 @@ class ViewSettingsCommandHandler
     private readonly sheetsService: SheetsService,
   ) {}
 
-  async execute({ interaction }: ViewSettingsCommand) {
+  async execute({ interaction }: ViewSettingsCommand): Promise<void> {
     await interaction.deferReply({ ephemeral: true });
 
     const settings = await this.settingsCollection.getSettings(
@@ -20,7 +20,8 @@ class ViewSettingsCommandHandler
     );
 
     if (!settings) {
-      return interaction.editReply('No settings found!');
+      await interaction.editReply('No settings found!');
+      return;
     }
 
     const {


### PR DESCRIPTION
If a command throws an uncaught exception that'll crash the app, its only the `EventBus` that has the unhandled exception stream. 

Additionally configure the timeout for google sheets calls, they don't seem to document what the default is?