### PR TITLE
feat(signups): add prog point to embed

### DIFF
--- a/src/commands/signup/subcommands/send-signup-review/send-signup-review-command.handler.spec.ts
+++ b/src/commands/signup/subcommands/send-signup-review/send-signup-review-command.handler.spec.ts
@@ -27,6 +27,7 @@ describe('Send Signup Review Command Handler', () => {
     screenshot: 'http://somelinksurely',
     status: SignupStatus.PENDING,
     world: 'bar',
+    progPointRequested: 'baz',
   });
 
   beforeEach(async () => {

--- a/src/commands/signup/subcommands/send-signup-review/send-signup-review-command.handler.ts
+++ b/src/commands/signup/subcommands/send-signup-review/send-signup-review-command.handler.ts
@@ -77,6 +77,7 @@ class SendSignupReviewCommandHandler
     screenshot,
     world,
     role,
+    progPointRequested,
   }: SignupDocument) {
     let embed = new EmbedBuilder()
       .setDescription(
@@ -98,11 +99,16 @@ class SendSignupReviewCommandHandler
         { name: 'Home World', value: capitalCase(world), inline: true },
         { name: 'Availability', value: availability, inline: true },
         { name: 'Job', value: role, inline: true },
+        { name: 'Prog Point', value: progPointRequested, inline: true },
       ]);
 
     if (proofOfProgLink) {
       embed = embed.addFields([
-        { name: 'Prog Proof Link', value: `[View](${proofOfProgLink})` },
+        {
+          name: 'Prog Proof Link',
+          value: `[View](${proofOfProgLink})`,
+          inline: true,
+        },
       ]);
     }
 


### PR DESCRIPTION
Adds the user provided prog point to the embed so coordinators can see it more easily