### PR TITLE
feat(signups): now removes prior message  when a new one is submitted

### DIFF
--- a/src/commands/signup/signup-interaction.dto.ts
+++ b/src/commands/signup/signup-interaction.dto.ts
@@ -41,13 +41,13 @@ class SignupInteractionDto
   @ValidateIf(
     ({ screenshot, proofOfProgLink }) => proofOfProgLink || !screenshot,
   )
-  proofOfProgLink?: string | null;
+  proofOfProgLink: string | null = null;
 
   @IsString({
     message: 'A screenshot must be attached if no link is provided',
   })
   @ValidateIf(({ proofOfProgLink }) => !proofOfProgLink)
-  screenshot?: string | null;
+  screenshot: string | null = null;
 
   @IsString()
   @ToLowercase()

--- a/src/commands/signup/signup.consts.ts
+++ b/src/commands/signup/signup.consts.ts
@@ -1,4 +1,4 @@
-import { SignupStatus } from '../../firebase/models/signup.model.js';
+import { SignupStatusValues } from '../../firebase/models/signup.model.js';
 
 export const SIGNUP_MESSAGES = {
   CONFIRMATION_TIMEOUT:
@@ -29,13 +29,15 @@ You can reach out to a coordinator to discuss any issues.
     'An error occurred while processing your response. The signup may not have been added to the Google Sheet, please verify it or add it manually',
 };
 
-export const SIGNUP_REVIEW_REACTIONS: Record<
-  keyof typeof SignupStatus,
-  string
-> = {
+export const SIGNUP_REVIEW_REACTIONS: Record<SignupStatusValues, string> = {
+  // biome-ignore lint/style/useNamingConvention: using literal enum values as keys
   APPROVED: '✅',
+  // biome-ignore lint/style/useNamingConvention: using literal enum values as keys
   DECLINED: '❌',
+  // biome-ignore lint/style/useNamingConvention: using literal enum values as keys
   PENDING: ':question:',
+  // biome-ignore lint/style/useNamingConvention: using literal enum values as keys
+  UPDATE_PENDING: ':question:',
 };
 
 // string validation via IsUrl does not work the same as regex. It does like

--- a/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
+++ b/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
@@ -113,7 +113,9 @@ describe('Remove Signup Command Handler', () => {
     });
 
     discordService.userHasRole.mockResolvedValue(false);
-    signupsRepository.findOne.mockResolvedValue({ discordId: '1' } as any);
+    signupsRepository.findOneOrFail.mockResolvedValue({
+      discordId: '1',
+    } as any);
 
     await handler.execute({ interaction });
     expect(signupsRepository.removeSignup).toHaveBeenCalled();

--- a/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.ts
+++ b/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.ts
@@ -86,8 +86,7 @@ class RemoveSignupCommandHandler
       return true;
     }
 
-    const signup = await this.signupsRepository.findOne(options);
-
+    const signup = await this.signupsRepository.findOneOrFail(options);
     return signup.discordId === user.id;
   }
 }

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -59,6 +59,16 @@ class DiscordService {
     const hasEmoji = this.client.emojis.cache.has(emojiId);
     return hasEmoji ? `<:_:${emojiId}>` : '';
   }
+
+  public async deleteMessage(
+    guildId: string,
+    channelId: string,
+    messageId: string,
+  ) {
+    const channel = await this.getTextChannel({ guildId, channelId });
+    const message = await channel?.messages.fetch(messageId);
+    return message?.delete();
+  }
 }
 
 export { DiscordService };

--- a/src/firebase/firebase.exceptions.ts
+++ b/src/firebase/firebase.exceptions.ts
@@ -1,1 +1,5 @@
-export class DocumentNotFoundException extends Error {}
+export class DocumentNotFoundException extends Error {
+  constructor(public readonly data?: Record<string, any>) {
+    super('Document not found');
+  }
+}

--- a/src/firebase/models/signup.model.ts
+++ b/src/firebase/models/signup.model.ts
@@ -5,7 +5,10 @@ export enum SignupStatus {
   PENDING = 'PENDING',
   APPROVED = 'APPROVED',
   DECLINED = 'DECLINED',
+  UPDATE_PENDING = 'UPDATE_PENDING',
 }
+
+export type SignupStatusValues = keyof { [K in SignupStatus]: any };
 
 export enum PartyType {
   EARLY_PROG_PARTY = 'Early Prog Party',


### PR DESCRIPTION
- Adds a new signup state `UPDATE_PENDING` which differentiates from `PENDING` meaning that you may have already had a prior signup that was approved and now your new update is pending. Also means prior `PENDING` states get updated to `UPDATE_PENDING`. 
- Checks if a `reviewMessageId` exists on a prior signup when confirming a signup, to delete the message that had been posted
- Unsets screenshot/link if its not provided in a subsequent signup. A signup update is assumed to be the new prog proof not cumulative to the prior prog proof. 