### PR TITLE
feat(signups): remove-signup  now removes unhandled approval messages

### DIFF
--- a/src/commands/signup/signup.utils.ts
+++ b/src/commands/signup/signup.utils.ts
@@ -1,0 +1,12 @@
+import {
+  SignupDocument,
+  SignupStatus,
+} from '../../firebase/models/signup.model.js';
+
+export function shouldDeleteReviewMessageForSignup({ status }: SignupDocument) {
+  // we don't want to remove approvals that were already handled since they
+  // may want to be kept as a reference for why a decision was made earlier
+  return (
+    status === SignupStatus.PENDING || status === SignupStatus.UPDATE_PENDING
+  );
+}

--- a/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
+++ b/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
@@ -77,7 +77,7 @@ describe('Remove Signup Command Handler', () => {
 
     await handler.execute({ interaction });
     expect(signupsRepository.removeSignup).toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith('Signup removed');
+    expect(interaction.editReply).toHaveBeenCalledWith('Success!');
   });
 
   it('calls removeSignup from SheetService if spreadsheetId is set', async () => {
@@ -119,6 +119,6 @@ describe('Remove Signup Command Handler', () => {
 
     await handler.execute({ interaction });
     expect(signupsRepository.removeSignup).toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith('Signup removed');
+    expect(interaction.editReply).toHaveBeenCalledWith('Success!');
   });
 });


### PR DESCRIPTION
`/remove-signup` should check if there's any outstanding approval messages waiting in the review channel and remove them if so. This will prevent document not found errors if a reaction occurs on one of those messages 