### PR TITLE
fix: fixes an issue with remove-signup where multiple rows were modified

### DIFF
--- a/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
+++ b/src/commands/signup/subcommands/remove-signup/remove-signup-command.handler.spec.ts
@@ -4,9 +4,17 @@ import { ChatInputCommandInteraction, User } from 'discord.js';
 import { DiscordService } from '../../../../discord/discord.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
 import { SignupCollection } from '../../../../firebase/collections/signup.collection.js';
+import {
+  SignupDocument,
+  SignupStatus,
+} from '../../../../firebase/models/signup.model.js';
 import { SheetsService } from '../../../../sheets/sheets.service.js';
 import { SIGNUP_MESSAGES } from '../../signup.consts.js';
 import { RemoveSignupCommandHandler } from './remove-signup-command.handler.js';
+import {
+  REMOVAL_MISSING_PERMISSIONS,
+  REMOVAL_SUCCESS,
+} from './remove-signup.consts.js';
 
 describe('Remove Signup Command Handler', () => {
   let discordService: DeepMocked<DiscordService>;
@@ -14,7 +22,7 @@ describe('Remove Signup Command Handler', () => {
   let interaction: DeepMocked<ChatInputCommandInteraction<'cached' | 'raw'>>;
   let settingsCollection: DeepMocked<SettingsCollection>;
   let sheetsService: DeepMocked<SheetsService>;
-  let signupsRepository: DeepMocked<SignupCollection>;
+  let signupsCollection: DeepMocked<SignupCollection>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
@@ -27,7 +35,7 @@ describe('Remove Signup Command Handler', () => {
     handler = fixture.get(RemoveSignupCommandHandler);
     settingsCollection = fixture.get(SettingsCollection);
     sheetsService = fixture.get(SheetsService);
-    signupsRepository = fixture.get(SignupCollection);
+    signupsCollection = fixture.get(SignupCollection);
 
     interaction = createMock<ChatInputCommandInteraction<'cached' | 'raw'>>({
       user: createMock<User>({
@@ -76,19 +84,42 @@ describe('Remove Signup Command Handler', () => {
     });
 
     await handler.execute({ interaction });
-    expect(signupsRepository.removeSignup).toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith('Success!');
+    expect(signupsCollection.removeSignup).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(REMOVAL_SUCCESS);
   });
 
-  it('calls removeSignup from SheetService if spreadsheetId is set', async () => {
+  it('calls removeSignup from SheetService if spreadsheetId is set and signup has been approved', async () => {
     settingsCollection.getSettings.mockResolvedValue({
       spreadsheetId: '1234',
       reviewerRole: 'reviewer',
       reviewChannel: '1234',
     });
 
+    signupsCollection.findOneOrFail.mockResolvedValueOnce(
+      createMock<SignupDocument>({
+        status: SignupStatus.APPROVED,
+      }),
+    );
+
     await handler.execute({ interaction });
     expect(sheetsService.removeSignup).toHaveBeenCalled();
+  });
+
+  it('does not call removeSignup from SheetService if the signup has not been approved', async () => {
+    settingsCollection.getSettings.mockResolvedValue({
+      spreadsheetId: '1234',
+      reviewerRole: 'reviewer',
+      reviewChannel: '1234',
+    });
+
+    signupsCollection.findOneOrFail.mockResolvedValueOnce(
+      createMock<SignupDocument>({
+        status: SignupStatus.PENDING,
+      }),
+    );
+
+    await handler.execute({ interaction });
+    expect(sheetsService.removeSignup).not.toHaveBeenCalled();
   });
 
   it('does not allow removal if the userId does not match the signups discordId', async () => {
@@ -98,11 +129,11 @@ describe('Remove Signup Command Handler', () => {
     });
 
     discordService.userHasRole.mockResolvedValue(false);
-    signupsRepository.findOne.mockResolvedValue({ discordId: '2' } as any);
+    signupsCollection.findOne.mockResolvedValue({ discordId: '2' } as any);
 
     await handler.execute({ interaction });
     expect(interaction.editReply).toHaveBeenCalledWith(
-      'You do not have permission to remove this signup',
+      REMOVAL_MISSING_PERMISSIONS,
     );
   });
 
@@ -113,12 +144,12 @@ describe('Remove Signup Command Handler', () => {
     });
 
     discordService.userHasRole.mockResolvedValue(false);
-    signupsRepository.findOneOrFail.mockResolvedValue({
+    signupsCollection.findOneOrFail.mockResolvedValue({
       discordId: '1',
     } as any);
 
     await handler.execute({ interaction });
-    expect(signupsRepository.removeSignup).toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith('Success!');
+    expect(signupsCollection.removeSignup).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(REMOVAL_SUCCESS);
   });
 });

--- a/src/commands/signup/subcommands/remove-signup/remove-signup.consts.ts
+++ b/src/commands/signup/subcommands/remove-signup/remove-signup.consts.ts
@@ -1,0 +1,21 @@
+import { RemoveSignupDto } from './remove-signup.dto.js';
+
+export const REMOVAL_SUCCESS =
+  'Success! If you signed up prior to the bots release, confirm with a coordinator that you are removed from the Google Sheet!';
+
+export const REMOVAL_MISSING_PERMISSIONS =
+  'You do not have permission to remove this signup';
+
+export const REMOVAL_NO_SHEET_ENTRY = ({
+  character,
+  world,
+  encounter,
+}: RemoveSignupDto) =>
+  `No entry found in the spreadsheet for \`${character}@${world}\` for \`${encounter}\`. If you feel this is an error please reach out to a coordinator.`;
+
+export const REMOVAL_NO_DB_ENTRY = ({
+  character,
+  world,
+  encounter,
+}: RemoveSignupDto) =>
+  `:exclamation: No entry found in database for \`${character}@${world}\` for \`${encounter}\`. Please check for typos. Additionally this command will only work for signups that have gone through the \`/signup\` command. If you have signed up prior to the bots release please reach out to a coordinator to be removed from the sheet.`;

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -204,7 +204,7 @@ class SheetsService {
             range: {
               sheetId,
               startRowIndex: clearRowIndex,
-              endRowIndex: clearRowIndex + 3,
+              endRowIndex: clearRowIndex + 1,
             },
             fields: 'userEnteredValue',
           },


### PR DESCRIPTION
There was a range error on the sheet modification for clear party removals that was overlooked. 
In addition the `/remove-signup` command has been enhanced to do the following 

- Remove a signup that matches no DB entry. - Should return error saying this only works for signups made with the bot, not prior to the bot because we can't verify if they're trying to remove their own or someone elses signup
- Remove signup that matches DB entry but has not yet been approved. - This should remove their entry from the DB but will not check the google sheet since we don't expect to find a row there.
- Remove signup that matches DB entry and has been approved. - This should remove their entry from the DB and check the Google Sheet for a matching row. If a matching row exists, it will remove that row from the Google Sheet. If no matching row exists, it will reply saying it removed the signup from the DB but could not find a matching row in the Google Sheet. If they think this is an error they can reach out to a coordinator.