### PR TITLE
feat(turbo-prog): add turbo prog command

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { SettingsModule } from './commands/settings/settings.module.js';
 import { SignupModule } from './commands/signup/signup.module.js';
 import { SlashCommandsModule } from './commands/slash-commands.module.js';
 import { StatusModule } from './commands/status/status.module.js';
+import { TurboProgModule } from './commands/turboprog/turbo-prog.module.js';
 import { DiscordModule } from './discord/discord.module.js';
 import { FirebaseModule } from './firebase/firebase.module.js';
 import { SentryModule } from './sentry/sentry.module.js';
@@ -26,6 +27,7 @@ import { SheetsModule } from './sheets/sheets.module.js';
     SignupModule,
     SlashCommandsModule,
     StatusModule,
+    TurboProgModule,
     ConfigModule.forRoot({
       cache: true,
       envFilePath: ['.env', '.env.development'],

--- a/src/commands/settings/settings-slash-command.ts
+++ b/src/commands/settings/settings-slash-command.ts
@@ -39,6 +39,18 @@ const EditSettingsSubcommand = new SlashCommandSubcommandBuilder()
       .setDescription(
         'The id of the spreadsheet to use for persistence modifications',
       ),
+  )
+  .addBooleanOption((option) =>
+    option
+      .setName('turbo-prog-active')
+      .setDescription('Whether or not turbo prog is currently active')
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName('turbo-prog-spreadsheet-id')
+      .setDescription('The id of the spreadsheet to use for turbo prog')
+      .setRequired(false),
   );
 
 // add all encounters to have a role option

--- a/src/commands/settings/subcommands/edit-settings-command.handler.spec.ts
+++ b/src/commands/settings/subcommands/edit-settings-command.handler.spec.ts
@@ -52,6 +52,7 @@ describe('Edit Settings Command Handler', () => {
                 return null;
             }
           },
+          getBoolean: () => true,
           getChannel: () => createMock({ id: reviewChannel }),
           getString: () => 'spreadsheetId',
         },
@@ -59,18 +60,21 @@ describe('Edit Settings Command Handler', () => {
       }),
     });
 
-    expect(settingsCollection.upsertSettings).toHaveBeenCalledWith(guildId, {
-      reviewerRole,
-      reviewChannel,
-      spreadsheetId,
-      signupChannel: reviewChannel,
-      progRoles: {
-        [Encounter.DSR]: 'dsr-prog-role',
-        [Encounter.UCOB]: 'ucob-prog-role',
-        [Encounter.TEA]: 'tea-prog-role',
-        [Encounter.TOP]: 'top-prog-role',
-        [Encounter.UWU]: 'uwu-prog-role',
-      },
-    });
+    expect(settingsCollection.upsertSettings).toHaveBeenCalledWith(
+      guildId,
+      expect.objectContaining({
+        reviewerRole,
+        reviewChannel,
+        spreadsheetId,
+        signupChannel: reviewChannel,
+        progRoles: {
+          [Encounter.DSR]: 'dsr-prog-role',
+          [Encounter.UCOB]: 'ucob-prog-role',
+          [Encounter.TEA]: 'tea-prog-role',
+          [Encounter.TOP]: 'top-prog-role',
+          [Encounter.UWU]: 'uwu-prog-role',
+        },
+      }),
+    );
   });
 });

--- a/src/commands/settings/subcommands/edit-settings-command.handler.ts
+++ b/src/commands/settings/subcommands/edit-settings-command.handler.ts
@@ -55,6 +55,10 @@ class EditSettingsCommandHandler
     const reviewChannel = options.getChannel('signup-review-channel');
     const signupChannel = options.getChannel('signup-public-channel');
     const spreadsheetId = options.getString('spreadsheet-id') ?? undefined;
+    const turboProgActive =
+      options.getBoolean('turbo-prog-active') ?? undefined;
+    const turboProgSpreadsheetId =
+      options.getString('turbo-prog-spreadsheet-id') ?? undefined;
 
     const progRoles: Record<string, string | undefined> = {};
 
@@ -71,6 +75,8 @@ class EditSettingsCommandHandler
       signupChannel,
       spreadsheetId,
       progRoles,
+      turboProgActive,
+      turboProgSpreadsheetId,
     };
   }
 }

--- a/src/commands/settings/subcommands/view-settings-command.handler.ts
+++ b/src/commands/settings/subcommands/view-settings-command.handler.ts
@@ -30,6 +30,8 @@ class ViewSettingsCommandHandler
       spreadsheetId,
       signupChannel,
       progRoles,
+      turboProgActive,
+      turboProgSpreadsheetId,
     } = settings;
     const role = reviewerRole ? `<@&${reviewerRole}>` : 'No Role Set';
     const publicSignupChannel = signupChannel
@@ -50,8 +52,16 @@ class ViewSettingsCommandHandler
       `**Review Channel:** <#${reviewChannel}>`,
       `**Reviewer Role:** ${role}`,
       `**Signup Channel:** ${publicSignupChannel}`,
-      ...progRoleSettings,
+      `**Turbo Prog Active:** ${turboProgActive ? 'Yes' : 'No'}`,
     ];
+
+    if (turboProgSpreadsheetId) {
+      const { title, url } = await this.sheetsService.getSheetMetadata(
+        turboProgSpreadsheetId,
+      );
+
+      messages.push(`**Turbo Prog Spreadsheet:** [${title}](${url})`);
+    }
 
     if (spreadsheetId) {
       const { title, url } =
@@ -59,6 +69,8 @@ class ViewSettingsCommandHandler
 
       messages.push(`**Managed Spreadsheet:** [${title}](${url})`);
     }
+
+    messages.push(...progRoleSettings);
 
     await interaction.editReply(messages.join('\n'));
   }

--- a/src/commands/slash-commands.interfaces.ts
+++ b/src/commands/slash-commands.interfaces.ts
@@ -1,5 +1,6 @@
 import { ChatInputCommandInteraction } from 'discord.js';
 
+// TODO: make base class for all commands
 export interface DiscordCommand {
   interaction: ChatInputCommandInteraction;
 }

--- a/src/commands/slash-commands.service.ts
+++ b/src/commands/slash-commands.service.ts
@@ -26,6 +26,8 @@ import { RemoveSignupCommand } from './signup/subcommands/remove-signup/remove-s
 import { SLASH_COMMANDS } from './slash-commands.js';
 import { StatusSlashCommand } from './status/status-slash-command.js';
 import { StatusCommand } from './status/status.command.js';
+import { TurboProgCommand } from './turboprog/turbo-prog.command.js';
+import { TurboProgSlashCommand } from './turboprog/turbo-prog.slash-command.js';
 
 @Injectable()
 class SlashCommandsService {
@@ -44,6 +46,7 @@ class SlashCommandsService {
           return;
         }
 
+        // TODO: move user name to setUser, not extras
         scope.setUser({ userId: interaction.user.id });
         scope.setExtras({
           username: interaction.user.username,
@@ -65,6 +68,10 @@ class SlashCommandsService {
           .with(
             RemoveSignupSlashCommand.name,
             () => new RemoveSignupCommand(interaction),
+          )
+          .with(
+            TurboProgSlashCommand.name,
+            () => new TurboProgCommand(interaction),
           )
           .otherwise(() => undefined);
 

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -3,6 +3,7 @@ import { SettingsSlashCommand } from './settings/settings-slash-command.js';
 import { SignupSlashCommand } from './signup/signup-slash-command.js';
 import { RemoveSignupSlashCommand } from './signup/subcommands/remove-signup/remove-signup-slash-command.js';
 import { StatusSlashCommand } from './status/status-slash-command.js';
+import { TurboProgSlashCommand } from './turboprog/turbo-prog.slash-command.js';
 
 export const SLASH_COMMANDS = [
   LookupSlashCommand,
@@ -10,4 +11,5 @@ export const SLASH_COMMANDS = [
   SettingsSlashCommand,
   SignupSlashCommand,
   StatusSlashCommand,
+  TurboProgSlashCommand,
 ];

--- a/src/commands/turboprog/turbo-prog-signup-interaction.dto.ts
+++ b/src/commands/turboprog/turbo-prog-signup-interaction.dto.ts
@@ -1,0 +1,27 @@
+import { IsEnum, IsString } from 'class-validator';
+import { ToLowercase } from '../../common/decorators/to-lowercase.js';
+import { Encounter } from '../../encounters/encounters.consts.js';
+import { SignupDocument } from '../../firebase/models/signup.model.js';
+
+class TurboProgSignupInteractionDto
+  implements
+    Pick<SignupDocument, 'character' | 'encounter' | 'role' | 'availability'>
+{
+  @IsString()
+  availability: string;
+
+  @IsString()
+  @ToLowercase()
+  character: string;
+
+  @IsEnum(Encounter)
+  encounter: Encounter;
+
+  @IsString()
+  role: string;
+
+  @IsString()
+  world: string;
+}
+
+export { TurboProgSignupInteractionDto };

--- a/src/commands/turboprog/turbo-prog.command-handler.ts
+++ b/src/commands/turboprog/turbo-prog.command-handler.ts
@@ -1,0 +1,188 @@
+import { CommandHandler } from '@nestjs/cqrs';
+import * as Sentry from '@sentry/node';
+import { plainToClass } from 'class-transformer';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { match } from 'ts-pattern';
+import { SettingsCollection } from '../../firebase/collections/settings-collection.js';
+import { SignupCollection } from '../../firebase/collections/signup.collection.js';
+import {
+  PartyStatus,
+  SignupDocument,
+  SignupStatus,
+} from '../../firebase/models/signup.model.js';
+import { SheetsService } from '../../sheets/sheets.service.js';
+import { TurboProgSheetsService } from '../../sheets/turbo-prog-sheets/turbo-prog-sheets.service.js';
+import { TurboProgSignupInteractionDto } from './turbo-prog-signup-interaction.dto.js';
+import { TurboProgCommand } from './turbo-prog.command.js';
+import { TurboProgEntry } from './turbo-prog.interfaces.js';
+import {
+  TURBO_PROG_INACTIVE,
+  TURBO_PROG_MISSING_SIGNUPS_SHEETS,
+  TURBO_PROG_NO_SIGNUP_FOUND,
+  TURBO_PROG_SIGNUP_INVALID,
+  TURBO_PROG_SUBMISSION_APPROVED,
+} from './turboprog.consts.js';
+
+@CommandHandler(TurboProgCommand)
+class TurboProgCommandHandler {
+  constructor(
+    private readonly settingsCollection: SettingsCollection,
+    private readonly signupCollection: SignupCollection,
+    private readonly sheetsService: SheetsService,
+    private readonly turboSheetService: TurboProgSheetsService,
+  ) {}
+
+  async execute({ interaction }: TurboProgCommand) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const settings = await this.settingsCollection.getSettings(
+      interaction.guildId,
+    );
+
+    if (!settings?.turboProgActive) {
+      return await interaction.editReply(TURBO_PROG_INACTIVE);
+    }
+
+    const options = this.getOptions(interaction);
+    const scope = Sentry.getCurrentScope();
+    scope.setExtra('input', options);
+
+    if (settings.spreadsheetId && settings.turboProgSpreadsheetId) {
+      const validation = await this.isProggerAllowed(
+        options,
+        settings.spreadsheetId,
+      );
+
+      if (validation.allowed) {
+        await this.turboSheetService.upsert(
+          validation.data,
+          settings.turboProgSpreadsheetId,
+        );
+
+        return await interaction.editReply(TURBO_PROG_SUBMISSION_APPROVED);
+      }
+
+      if (validation.error) {
+        return await interaction.editReply(validation.error);
+      }
+
+      scope.setExtra('validation', validation);
+      throw new Error('Unexpected turbo prog validation error');
+    }
+
+    scope.setExtra('settings', settings);
+    scope.captureMessage(
+      'one or more spreadsheet IDs are missing for turbo prog',
+    );
+    return await interaction.editReply(TURBO_PROG_MISSING_SIGNUPS_SHEETS);
+  }
+
+  private async isProggerAllowed(
+    options: TurboProgSignupInteractionDto,
+    spreadsheetId: string,
+  ): Promise<
+    | {
+        error: string;
+        allowed: undefined;
+      }
+    | {
+        allowed: true;
+        data: TurboProgEntry;
+      }
+  > {
+    const signup = await this.signupCollection.findOne({
+      character: options.character,
+      world: options.world,
+      encounter: options.encounter,
+    });
+
+    // if the progger has an entry already in the database we can check its status
+    if (signup) {
+      return match(signup)
+        .with(
+          {
+            status: SignupStatus.APPROVED,
+          },
+          ({ partyStatus }) =>
+            partyStatus === PartyStatus.ClearParty ||
+            partyStatus === PartyStatus.ProgParty,
+          () => ({
+            allowed: true as true, // TODO: dafuq typescript
+            data: this.mapSignupToRowData(signup, options),
+          }),
+        )
+        .otherwise(() => ({
+          allowed: undefined,
+          error: TURBO_PROG_SIGNUP_INVALID,
+        }));
+    }
+
+    // if they're not in the database as approved we need to check the google sheet
+    const rowData = await this.sheetsService.findCharacterRowValues(
+      options,
+      spreadsheetId,
+    );
+
+    if (rowData) {
+      return {
+        allowed: true,
+        data: this.mapSheetData(rowData, options),
+      };
+    }
+
+    return {
+      allowed: undefined,
+      error: TURBO_PROG_NO_SIGNUP_FOUND,
+    };
+  }
+
+  private getOptions({
+    options,
+  }: ChatInputCommandInteraction<'cached' | 'raw'>) {
+    return plainToClass(TurboProgSignupInteractionDto, {
+      availability: options.getString('availability', true),
+      character: options.getString('character', true),
+      encounter: options.getString('encounter', true),
+      role: options.getString('job', true),
+    });
+  }
+
+  private mapSignupToRowData(
+    { progPointRequested, progPoint }: SignupDocument,
+    { character, role, availability, encounter }: TurboProgSignupInteractionDto,
+  ) {
+    return {
+      character,
+      job: role,
+      availability,
+      encounter,
+      progPoint: progPoint || progPointRequested,
+    };
+  }
+
+  /**
+   * maps the sheet data from the standard google sheet to the turbo prog format
+   * @param
+   */
+  private mapSheetData(
+    values: string[],
+    { availability, encounter }: TurboProgSignupInteractionDto,
+  ) {
+    if (values.length !== 4 || values.some((value, i) => i > 1 && !value)) {
+      throw new Error(
+        'Data found on Google Sheet is not in the correct format. Please check out that the regular signup sheet has your character entered correctly or reach out to a coordinator for assistance',
+      );
+    }
+
+    // TODO: dear lord forgive us for our sins
+    return {
+      character: values[0],
+      job: values[2],
+      progPoint: values[3],
+      availability,
+      encounter,
+    };
+  }
+}
+
+export { TurboProgCommandHandler };

--- a/src/commands/turboprog/turbo-prog.command.ts
+++ b/src/commands/turboprog/turbo-prog.command.ts
@@ -1,0 +1,8 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import { DiscordCommand } from '../slash-commands.interfaces.js';
+
+export class TurboProgCommand implements DiscordCommand {
+  constructor(
+    public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
+  ) {}
+}

--- a/src/commands/turboprog/turbo-prog.interfaces.ts
+++ b/src/commands/turboprog/turbo-prog.interfaces.ts
@@ -1,0 +1,7 @@
+import { SignupDocument } from '../../firebase/models/signup.model.js';
+
+export interface TurboProgEntry
+  extends Pick<SignupDocument, 'character' | 'availability' | 'encounter'> {
+  job: string;
+  progPoint: string;
+}

--- a/src/commands/turboprog/turbo-prog.module.ts
+++ b/src/commands/turboprog/turbo-prog.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { FirebaseModule } from '../../firebase/firebase.module.js';
+import { SheetsModule } from '../../sheets/sheets.module.js';
+import { SettingsModule } from '../settings/settings.module.js';
+import { TurboProgCommandHandler } from './turbo-prog.command-handler.js';
+
+@Module({
+  imports: [SettingsModule, SheetsModule, FirebaseModule],
+  providers: [TurboProgCommandHandler],
+})
+export class TurboProgModule {}

--- a/src/commands/turboprog/turbo-prog.slash-command.ts
+++ b/src/commands/turboprog/turbo-prog.slash-command.ts
@@ -1,0 +1,34 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { ENCOUNTER_CHOICES } from '../slash-commands.consts.js';
+
+// TODO: abstract common options between this and /signup
+export const TurboProgSlashCommand = new SlashCommandBuilder()
+  .setName('turbo-signup')
+  .setDescription('signup for the current turbo prog session!')
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('Select an encounter')
+      .setName('encounter')
+      .addChoices(...ENCOUNTER_CHOICES),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('Character Name')
+      .setName('character'),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('Availability. Ex: M-F 8pm-12am EST')
+      .setName('availability'),
+  )
+  .addStringOption((option) =>
+    option
+      .setRequired(true)
+      .setDescription('Job/Role. Ex. SGE/WHM, Healer/Tank, etc')
+      // we want the display label to be job, but its actually broader than a specific job so we'll refer to it as
+      // role still internally, even though that's not broad enough either since people can multi-role
+      .setName('job'),
+  );

--- a/src/commands/turboprog/turboprog.consts.ts
+++ b/src/commands/turboprog/turboprog.consts.ts
@@ -1,0 +1,13 @@
+export const TURBO_PROG_SUBMISSION_APPROVED = 'Turbo Prog submission approved!';
+
+export const TURBO_PROG_INACTIVE =
+  'Turbo Prog is not currently active. Please keep an eye out for any announcements.';
+
+export const TURBO_PROG_SIGNUP_INVALID =
+  'Only currently approved signups that are Clear Ready/Late Prog are eligible for Turbo Prog';
+
+export const TURBO_PROG_NO_SIGNUP_FOUND =
+  'No signup was found for this character. Only currently approved signups are eligible for Turbo Prog. Please use the **/signup** command to signup and then once approved you will be eligible for turbo prog.';
+
+export const TURBO_PROG_MISSING_SIGNUPS_SHEETS =
+  'The bot is missing a required configuration option for tubro prog to function. This issue has been reported and staff has been notified. Please try again later';

--- a/src/firebase/models/settings.model.ts
+++ b/src/firebase/models/settings.model.ts
@@ -6,7 +6,11 @@ export interface SettingsDocument extends DocumentData {
   reviewerRole?: string;
   signupChannel?: string;
   spreadsheetId?: string;
+  turboProgActive?: boolean;
+  turboProgSpreadsheetId?: string;
+
   progRoles?: {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     [key in keyof typeof Encounter]?: string;
   };
 }

--- a/src/sheets/sheets.config.ts
+++ b/src/sheets/sheets.config.ts
@@ -6,6 +6,7 @@ export interface SheetsConfig {
   GOOGLE_UNIVERSE_DOMAIN: string;
   SHEET_EARLY_PROG_NAME: string;
   SHEET_PROG_NAME: string;
+  TURBO_PROG_SHEET_NAME: string;
 }
 
 const schema = Joi.object({
@@ -16,6 +17,7 @@ const schema = Joi.object({
   GOOGLE_UNIVERSE_DOMAIN: Joi.string().default('googleapis.com'),
   SHEET_EARLY_PROG_NAME: Joi.string().default('EARLY PROG (Season 4)'),
   SHEET_PROG_NAME: Joi.string().default('MID/LATE PROG (Season 4)'),
+  TURBO_PROG_SHEET_NAME: Joi.string().default('Bot'),
 });
 
 export const sheetsConfig = registerAs<SheetsConfig>('sheets', () => {

--- a/src/sheets/sheets.module.ts
+++ b/src/sheets/sheets.module.ts
@@ -6,6 +6,7 @@ import { AppConfig } from '../app.config.js';
 import { SheetsConfig, sheetsConfig } from './sheets.config.js';
 import { SHEETS_CLIENT } from './sheets.consts.js';
 import { SheetsService } from './sheets.service.js';
+import { TurboProgSheetsService } from './turbo-prog-sheets/turbo-prog-sheets.service.js';
 
 const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
 
@@ -13,6 +14,7 @@ const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
   imports: [ConfigModule.forFeature(sheetsConfig)],
   providers: [
     SheetsService,
+    TurboProgSheetsService,
     {
       provide: SHEETS_CLIENT,
       inject: [ConfigService],
@@ -44,6 +46,6 @@ const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
       },
     },
   ],
-  exports: [SheetsService],
+  exports: [SheetsService, TurboProgSheetsService],
 })
 export class SheetsModule {}

--- a/src/sheets/sheets.utils.ts
+++ b/src/sheets/sheets.utils.ts
@@ -1,0 +1,75 @@
+import { sheets_v4 } from '@googleapis/sheets';
+
+type GetSheetValuesProps = {
+  spreadsheetId: string;
+  range: string;
+};
+
+export async function getSheetValues(
+  client: sheets_v4.Sheets,
+  { range, spreadsheetId }: GetSheetValuesProps,
+) {
+  const response = await client.spreadsheets.values.get({
+    spreadsheetId,
+    range,
+  });
+
+  return response.data.values;
+}
+
+type UpdateSheetProps = {
+  values: string[];
+  type: 'update' | 'append';
+} & GetSheetValuesProps;
+
+export function updateSheet(
+  client: sheets_v4.Sheets,
+  { spreadsheetId, type, values, range }: UpdateSheetProps,
+) {
+  const payload = {
+    spreadsheetId,
+    range,
+    valueInputOption: 'USER_ENTERED',
+    requestBody: {
+      values: [values],
+    },
+  };
+
+  return type === 'update'
+    ? client.spreadsheets.values.update(payload)
+    : client.spreadsheets.values.append(payload);
+}
+
+export function batchUpdate(
+  client: sheets_v4.Sheets,
+  spreadsheetId: string,
+  requests: any[],
+) {
+  return client.spreadsheets.batchUpdate({
+    spreadsheetId,
+    requestBody: {
+      requests,
+    },
+  });
+}
+
+type FindCharacterRowProps = GetSheetValuesProps & {
+  predicate: (values: Set<any>) => boolean;
+};
+
+export async function findCharacterRowIndex(
+  client: sheets_v4.Sheets,
+  { range, spreadsheetId, predicate }: FindCharacterRowProps,
+) {
+  const sheetValues = await getSheetValues(client, { range, spreadsheetId });
+  if (!sheetValues) {
+    return { rowIndex: -1, sheetValues };
+  }
+
+  const rowIndex = sheetValues.findIndex((row: string[]) => {
+    const set = new Set(row.map((values) => values.toLowerCase()));
+    return predicate(set);
+  });
+
+  return { rowIndex, sheetValues };
+}

--- a/src/sheets/turbo-prog-sheets/turbo-prog-sheets.consts.ts
+++ b/src/sheets/turbo-prog-sheets/turbo-prog-sheets.consts.ts
@@ -1,0 +1,26 @@
+import { Encounter } from '../../encounters/encounters.consts.js';
+
+export const TURBP_PROG_SHEET_STARTING_ROW = 4;
+
+export const TurboProgSheetRanges = {
+  [Encounter.DSR]: {
+    start: 'Q',
+    end: 'T',
+  },
+  [Encounter.TEA]: {
+    start: 'L',
+    end: 'O',
+  },
+  [Encounter.TOP]: {
+    start: 'V',
+    end: 'Y',
+  },
+  [Encounter.UCOB]: {
+    start: 'B',
+    end: 'E',
+  },
+  [Encounter.UWU]: {
+    start: 'G',
+    end: 'J',
+  },
+};

--- a/src/sheets/turbo-prog-sheets/turbo-prog-sheets.service.ts
+++ b/src/sheets/turbo-prog-sheets/turbo-prog-sheets.service.ts
@@ -1,0 +1,66 @@
+import { sheets_v4 } from '@googleapis/sheets';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { titleCase } from 'title-case';
+import { TurboProgEntry } from '../../commands/turboprog/turbo-prog.interfaces.js';
+import { AsyncQueue } from '../../common/async-queue/async-queue.js';
+import { Encounter } from '../../encounters/encounters.consts.js';
+import { sheetsConfig } from '../sheets.config.js';
+import { InjectSheetsClient } from '../sheets.decorators.js';
+import { findCharacterRowIndex, updateSheet } from '../sheets.utils.js';
+import {
+  TURBP_PROG_SHEET_STARTING_ROW,
+  TurboProgSheetRanges,
+} from './turbo-prog-sheets.consts.js';
+
+@Injectable()
+class TurboProgSheetsService {
+  private readonly queue = new AsyncQueue();
+
+  constructor(
+    @InjectSheetsClient() private readonly client: sheets_v4.Sheets,
+    @Inject(sheetsConfig.KEY)
+    private readonly config: ConfigType<typeof sheetsConfig>,
+  ) {}
+
+  public upsert(entry: TurboProgEntry, spreadsheetId: string) {
+    return this.queue.add(() => this.upsertEntry(entry, spreadsheetId));
+  }
+
+  private async upsertEntry(
+    { encounter, character, job, progPoint, availability }: TurboProgEntry,
+    spreadsheetId: string,
+  ) {
+    // TODO: Figure out what to do about world
+    const sheetName = this.config.TURBO_PROG_SHEET_NAME;
+    const range = TurboProgSheetRanges[encounter as Encounter];
+
+    const { rowIndex, sheetValues } = await findCharacterRowIndex(this.client, {
+      spreadsheetId,
+      range: `${sheetName}!${range.start}:${range.end}`,
+      predicate: (values) => values.has(character.toLowerCase()),
+    });
+
+    const rowOffset = sheetValues
+      ? sheetValues.length + 1
+      : TURBP_PROG_SHEET_STARTING_ROW;
+
+    const values = [titleCase(character), job, progPoint, availability];
+
+    const updateRange =
+      rowIndex === -1
+        ? `${sheetName}!${range.start}${rowOffset}:${range.end}`
+        : `${sheetName}!${range.start}${rowIndex + 1}:${range.end}${
+            rowIndex + 1
+          }`;
+
+    await updateSheet(this.client, {
+      spreadsheetId,
+      range: updateRange,
+      values,
+      type: 'update',
+    });
+  }
+}
+
+export { TurboProgSheetsService };


### PR DESCRIPTION
# Feature

Adds a new command `/turbo-signup` for signing up for the Turbo Prog events. 

This command will check if a user has a currently active approved signup. If they do they'll be sent to a turbo prog google sheet for scheduling. 

_Implemented quick and dirty for upcoming turbo prog session will refactor in the future_


