### PR TITLE
fix(settings): prevent prog roles from being overridden

### DIFF
--- a/src/commands/settings/settings-slash-command.ts
+++ b/src/commands/settings/settings-slash-command.ts
@@ -12,7 +12,6 @@ const EditSettingsSubcommand = new SlashCommandSubcommandBuilder()
   .addChannelOption((option) =>
     option
       .setName('signup-review-channel')
-      .setRequired(true)
       .setDescription(
         'The channel in which reviews will be posted. This must be set to a text channel',
       )

--- a/src/commands/settings/subcommands/edit-settings-command.handler.spec.ts
+++ b/src/commands/settings/subcommands/edit-settings-command.handler.spec.ts
@@ -60,7 +60,7 @@ describe('Edit Settings Command Handler', () => {
       }),
     });
 
-    expect(settingsCollection.upsertSettings).toHaveBeenCalledWith(
+    expect(settingsCollection.upsert).toHaveBeenCalledWith(
       guildId,
       expect.objectContaining({
         reviewerRole,

--- a/src/commands/settings/subcommands/edit-settings-command.handler.ts
+++ b/src/commands/settings/subcommands/edit-settings-command.handler.ts
@@ -26,7 +26,7 @@ class EditSettingsCommandHandler
       const { signupChannel, reviewChannel, reviewerRole, ...rest } =
         this.getInteractionOptions(interaction.options);
 
-      await this.settingsCollection.upsertSettings(guildId, {
+      await this.settingsCollection.upsert(guildId, {
         signupChannel: signupChannel?.id,
         reviewChannel: reviewChannel?.id,
         reviewerRole: reviewerRole?.id,
@@ -64,6 +64,7 @@ class EditSettingsCommandHandler
 
     for (const encounter in Encounter) {
       const role = options.getRole(`${encounter.toLowerCase()}-prog-role`);
+
       if (role) {
         progRoles[encounter] = role.id;
       }

--- a/src/firebase/collections/settings-collection.spec.ts
+++ b/src/firebase/collections/settings-collection.spec.ts
@@ -22,10 +22,10 @@ describe('SettingsCollection', () => {
     firestore = module.get(FIRESTORE);
   });
 
-  it('should call upsertSettings with correct arguments', async () => {
+  it('should call upsert with correct arguments', async () => {
     const settings = { reviewChannel: 'channel', reviewerRole: 'role' };
 
-    await service.upsertSettings(guildId, settings);
+    await service.upsert(guildId, settings);
 
     expect(firestore.collection).toHaveBeenCalledWith('settings');
     expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);

--- a/src/firebase/collections/settings-collection.ts
+++ b/src/firebase/collections/settings-collection.ts
@@ -13,8 +13,18 @@ class SettingsCollection {
     ) as CollectionReference<SettingsDocument>;
   }
 
-  public upsertSettings(guildId: string, settings: Partial<SettingsDocument>) {
-    return this.collection.doc(guildId).set(settings, { merge: true });
+  public async upsert(
+    guildId: string,
+    { progRoles, ...settings }: Partial<SettingsDocument>,
+  ) {
+    // prevent empty object from overriding all existing prog roles
+    // quick n dirty fix for now
+    const progRolesUpdate =
+      progRoles && Object.keys(progRoles).length === 0 ? undefined : progRoles;
+
+    return await this.collection
+      .doc(guildId)
+      .set({ ...settings, progRoles: progRolesUpdate }, { merge: true });
   }
 
   public async getSettings(guildId: string) {

--- a/src/firebase/models/settings.model.ts
+++ b/src/firebase/models/settings.model.ts
@@ -2,7 +2,7 @@ import { DocumentData } from 'firebase-admin/firestore';
 import { Encounter } from '../../encounters/encounters.consts.js';
 
 export interface SettingsDocument extends DocumentData {
-  reviewChannel: string;
+  reviewChannel?: string;
   reviewerRole?: string;
   signupChannel?: string;
   spreadsheetId?: string;


### PR DESCRIPTION
Fixes an issue where when using `merge` with Firestore collections, an empty object would erase the any existing properties on an object in the document. 

This is a quick fix while thinking about how to maybe restructure elements of the collection. This fix will check if the object coming into `upsert` is empty and assign `undefined` instead since undefined fields will be ignored. 