### PR TITLE
feat(signups): include member tag when declining signups

### DIFF
--- a/src/settings/subcommands/view/view-settings.command-handler.ts
+++ b/src/settings/subcommands/view/view-settings.command-handler.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { roleMention } from 'discord.js';
 import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
 import { SheetsService } from '../../../sheets/sheets.service.js';
 import { ViewSettingsCommand } from './view-settings.command.js';
@@ -33,7 +34,7 @@ class ViewSettingsCommandHandler
       turboProgActive,
       turboProgSpreadsheetId,
     } = settings;
-    const role = reviewerRole ? `<@&${reviewerRole}>` : 'No Role Set';
+    const role = reviewerRole ? roleMention(reviewerRole) : 'No Role Set';
     const publicSignupChannel = signupChannel
       ? `<#${signupChannel}>`
       : 'No Channel Set';

--- a/src/signup/events/handlers/send-approved-message.event-handler.ts
+++ b/src/signup/events/handlers/send-approved-message.event-handler.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 import * as Sentry from '@sentry/node';
-import { Colors, EmbedBuilder, Message, User } from 'discord.js';
+import { Colors, EmbedBuilder, Message, User, userMention } from 'discord.js';
 import {
   characterField,
   worldField,
@@ -74,7 +74,7 @@ class SendApprovedMessageEventHandler
     );
 
     const message = await channel.send({
-      content: `<@${signup.discordId}> ${content}`,
+      content: `${userMention(signup.discordId)} ${content}`,
       embeds: [embed],
     });
 

--- a/src/signup/events/handlers/signup-embed.event-handler.spec.ts
+++ b/src/signup/events/handlers/signup-embed.event-handler.spec.ts
@@ -2,10 +2,11 @@ import { DeepMocked, createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
 import { Colors, Message, User } from 'discord.js';
 import { DiscordService } from '../../../discord/discord.service.js';
+import { SignupDocument } from '../../../firebase/models/signup.model.js';
 import { SignupApprovedEvent, SignupDeclinedEvent } from '../signup.events.js';
 import { UpdateApprovalEmbedEventHandler } from './signup-embed.event-handler.js';
 
-describe('UpdateApprovalEmbedEventHandler', () => {
+describe('SignupEmbedEventHandler', () => {
   let handler: UpdateApprovalEmbedEventHandler;
 
   const message = createMock<Message<true>>({
@@ -23,7 +24,7 @@ describe('UpdateApprovalEmbedEventHandler', () => {
   const cases = [
     {
       color: Colors.Green,
-      description: 'handles an approval event',
+      case: 'handles an approval event',
       event: new SignupApprovedEvent(
         createMock(),
         createMock(),
@@ -34,9 +35,14 @@ describe('UpdateApprovalEmbedEventHandler', () => {
     },
     {
       color: Colors.Red,
-      description: 'handles a declined event',
-      event: new SignupDeclinedEvent(createMock(), reviewedBy, message),
+      case: 'handles a declined event',
+      event: new SignupDeclinedEvent(
+        createMock<SignupDocument>({ discordId: '12345' }),
+        reviewedBy,
+        message,
+      ),
       footer: 'Declined by Test User',
+      content: 'Declined <@12345>',
     },
   ];
 
@@ -59,10 +65,11 @@ describe('UpdateApprovalEmbedEventHandler', () => {
     expect(handler).toBeDefined();
   });
 
-  it.each(cases)('$description', async ({ event, footer, color }) => {
+  it.each(cases)('$case', async ({ event, footer, color, content }) => {
     await handler.handle(event);
 
     expect(message.edit).toHaveBeenCalledWith({
+      content,
       embeds: [
         expect.objectContaining({
           data: {

--- a/src/signup/events/handlers/signup-embed.event-handler.ts
+++ b/src/signup/events/handlers/signup-embed.event-handler.ts
@@ -1,6 +1,6 @@
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 import * as Sentry from '@sentry/node';
-import { Colors, EmbedBuilder } from 'discord.js';
+import { Colors, EmbedBuilder, userMention } from 'discord.js';
 import { P, match } from 'ts-pattern';
 import { DiscordService } from '../../../discord/discord.service.js';
 import { SIGNUP_MESSAGES } from '../../signup.consts.js';
@@ -55,6 +55,8 @@ class SignupEmbedEventHandler
       userId: reviewedBy.id,
     });
 
+    const content = `Declined ${userMention(signup.discordId)}`;
+
     const embed = EmbedBuilder.from(message.embeds[0])
       .setDescription(null)
       .setFooter({
@@ -66,7 +68,7 @@ class SignupEmbedEventHandler
       .setTimestamp(new Date());
 
     await Promise.all([
-      message.edit({ embeds: [embed] }),
+      message.edit({ content, embeds: [embed] }),
       this.discordService.sendDirectMessage(signup.discordId, {
         content: SIGNUP_MESSAGES.SIGNUP_SUBMISSION_DENIED,
         embeds: [EmbedBuilder.from(embed).setTitle('Signup Declined')],


### PR DESCRIPTION
# Description
Updates the message when declining a signup to include the members tag that was declined. 