### PR TITLE
fix(sheets): fix handling of deleted spreadsheets when requesting metadata

### DIFF
--- a/src/sheets/sheets.service.spec.ts
+++ b/src/sheets/sheets.service.spec.ts
@@ -1,22 +1,44 @@
+import { sheets_v4 } from '@googleapis/sheets';
 import { Test } from '@nestjs/testing';
-
-import { createMock } from '@golevelup/ts-vitest';
+import { SHEETS_CLIENT } from './sheets.consts.js';
 import { SheetsService } from './sheets.service.js';
+
+vi.mock('@googleapis/sheets', () => ({
+  sheets_v4: {},
+  sheets: {
+    spreadsheets: {
+      get: vi.fn(),
+    },
+  },
+}));
 
 describe('Sheets Service', () => {
   let service: SheetsService;
+  let client: sheets_v4.Sheets;
 
   beforeEach(async () => {
+    const { sheets } = await import('@googleapis/sheets');
     const fixture = await Test.createTestingModule({
-      providers: [SheetsService],
-    })
-      .useMocker(() => createMock())
-      .compile();
+      providers: [SheetsService, { provide: SHEETS_CLIENT, useValue: sheets }],
+    }).compile();
 
     service = fixture.get(SheetsService);
+    client = fixture.get(SHEETS_CLIENT);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('#getSheetMetadata', () => {
+    it('returns deleted sheet if the request returns 404', () => {
+      const spy = vi.spyOn(client.spreadsheets, 'get');
+
+      spy.mockRejectedValueOnce({ code: 404 });
+
+      expect(service.getSheetMetadata('rando banana')).resolves.toMatchObject({
+        title: 'Deleted Spreadsheet',
+      });
+    });
   });
 });


### PR DESCRIPTION
# Description

When a google sheet has been deleted the request for metadata will throw a 404.
This will break commands and cause the application to not reply. 

It should instead return some information that this has happened.

It will now provide a description that its been deleted along with a link to the deleted sheet
