### PR TITLE
feat: add helper retirement command

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { SheetsModule } from './sheets/sheets.module.js';
 import { BlacklistModule } from './slash-commands/blacklist/blacklist.module.js';
 import { LookupModule } from './slash-commands/lookup/lookup.module.js';
 import { RemoveRoleModule } from './slash-commands/remove-role/remove-role.module.js';
+import { RetireModule } from './slash-commands/retire/retire.module.js';
 import { SettingsModule } from './slash-commands/settings/settings.module.js';
 import { SignupModule } from './slash-commands/signup/signup.module.js';
 import { SlashCommandsModule } from './slash-commands/slash-commands.module.js';
@@ -28,6 +29,7 @@ import { TurboProgModule } from './slash-commands/turboprog/turbo-prog.module.js
     DiscordModule,
     FirebaseModule,
     LookupModule,
+    RetireModule,
     SettingsModule,
     SheetsModule,
     SignupModule,

--- a/src/slash-commands/retire/retire.command-handler.spec.ts
+++ b/src/slash-commands/retire/retire.command-handler.spec.ts
@@ -1,0 +1,223 @@
+import { createMock } from '@golevelup/ts-vitest';
+import { Test } from '@nestjs/testing';
+import { ChatInputCommandInteraction, Colors } from 'discord.js';
+import { DiscordService } from '../../discord/discord.service.js';
+import { RetireCommandHandler } from './retire.command-handler.js';
+import { RetireCommand } from './retire.command.js';
+
+describe('RetireCommandHandler', () => {
+  let handler: RetireCommandHandler;
+  let discordService: DiscordService;
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [RetireCommandHandler],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    handler = fixture.get(RetireCommandHandler);
+    discordService = fixture.get(DiscordService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  describe('execute', () => {
+    // Helper function to create interaction mock
+    const createInteractionMock = (
+      options: {
+        inGuild?: boolean;
+        guildId?: string;
+        currentRoleId?: string;
+        currentRoleName?: string;
+        retiredRoleId?: string;
+        retiredRoleName?: string;
+      } = {},
+    ) => {
+      const {
+        inGuild = true,
+        guildId = 'guild-123',
+        currentRoleId = '111111',
+        currentRoleName = 'CurrentHelperRole',
+        retiredRoleId = '222222',
+        retiredRoleName = 'RetiredHelperRole',
+      } = options;
+
+      const deferReply = vi.fn().mockResolvedValue(undefined);
+      const editReply = vi.fn().mockResolvedValue(undefined);
+
+      return {
+        mock: createMock<ChatInputCommandInteraction<'cached'>>({
+          deferReply,
+          editReply,
+          guildId,
+          inGuild: () => inGuild,
+          options: {
+            getRole: (name: string) => {
+              if (name === 'current-helper-role') {
+                return {
+                  id: currentRoleId,
+                  name: currentRoleName,
+                };
+              }
+              return {
+                id: retiredRoleId,
+                name: retiredRoleName,
+              };
+            },
+          },
+          valueOf: () => '',
+        }),
+        deferReply,
+        editReply,
+      };
+    };
+
+    // Test cases
+    it('should do nothing if not in a guild', async () => {
+      const { mock, deferReply } = createInteractionMock({ inGuild: false });
+      await handler.execute(new RetireCommand(mock));
+      expect(deferReply).not.toHaveBeenCalled();
+    });
+
+    it('should reject if source and destination roles are the same', async () => {
+      const { mock, editReply } = createInteractionMock({
+        currentRoleId: 'same-id',
+        retiredRoleId: 'same-id',
+      });
+
+      await handler.execute(new RetireCommand(mock));
+
+      expect(editReply).toHaveBeenCalledWith({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Role Retirement',
+              description:
+                'The current and retired helper roles cannot be the same.',
+              color: Colors.Red,
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('should indicate when no members have the role', async () => {
+      const { mock, editReply } = createInteractionMock();
+
+      discordService.retireRole = vi.fn().mockResolvedValue({
+        totalMembers: 0,
+        successCount: 0,
+        failCount: 0,
+      });
+
+      await handler.execute(new RetireCommand(mock));
+
+      expect(discordService.retireRole).toHaveBeenCalledWith(
+        'guild-123',
+        '111111',
+        '222222',
+      );
+
+      expect(editReply).toHaveBeenCalledWith({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Role Retirement Complete',
+              color: Colors.Green,
+              fields: expect.arrayContaining([
+                { name: 'Total members processed', value: '0', inline: true },
+              ]),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('should update roles for all members with the source role', async () => {
+      const { mock, editReply } = createInteractionMock();
+
+      discordService.retireRole = vi.fn().mockResolvedValue({
+        totalMembers: 2,
+        successCount: 2,
+        failCount: 0,
+      });
+
+      await handler.execute(new RetireCommand(mock));
+
+      expect(discordService.retireRole).toHaveBeenCalledWith(
+        'guild-123',
+        '111111',
+        '222222',
+      );
+
+      expect(editReply).toHaveBeenCalledWith({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Role Retirement Complete',
+              description: 'Replaced CurrentHelperRole with RetiredHelperRole',
+              fields: [
+                { name: 'Total members processed', value: '2', inline: true },
+                { name: 'Successful updates', value: '2', inline: true },
+                { name: 'Failed updates', value: '0', inline: true },
+              ],
+              color: Colors.Green,
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('should handle errors during role updates', async () => {
+      const { mock, editReply } = createInteractionMock();
+
+      discordService.retireRole = vi.fn().mockResolvedValue({
+        totalMembers: 2,
+        successCount: 1,
+        failCount: 1,
+      });
+
+      await handler.execute(new RetireCommand(mock));
+
+      expect(editReply).toHaveBeenCalledWith({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Role Retirement Complete',
+              color: Colors.Yellow, // Yellow because there was a failure
+              fields: expect.arrayContaining([
+                { name: 'Failed updates', value: '1', inline: true },
+              ]),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('should handle unexpected errors gracefully', async () => {
+      const { mock, editReply } = createInteractionMock();
+
+      discordService.retireRole = vi
+        .fn()
+        .mockRejectedValue(new Error('Something went wrong'));
+
+      await handler.execute(new RetireCommand(mock));
+
+      expect(editReply).toHaveBeenCalledWith({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Role Retirement Failed',
+              description:
+                'An error occurred while processing role retirement.',
+              color: Colors.Red,
+            }),
+          }),
+        ],
+      });
+    });
+  });
+});

--- a/src/slash-commands/retire/retire.command-handler.ts
+++ b/src/slash-commands/retire/retire.command-handler.ts
@@ -1,0 +1,101 @@
+import { Logger } from '@nestjs/common';
+import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { Colors, EmbedBuilder, MessageFlags } from 'discord.js';
+import { DiscordService } from '../../discord/discord.service.js';
+import { SentryTraced } from '../../sentry/sentry-traced.decorator.js';
+import { RetireCommand } from './retire.command.js';
+
+@CommandHandler(RetireCommand)
+class RetireCommandHandler implements ICommandHandler<RetireCommand> {
+  private readonly logger = new Logger(RetireCommandHandler.name);
+
+  constructor(private readonly discordService: DiscordService) {}
+
+  @SentryTraced()
+  async execute({ interaction }: RetireCommand): Promise<void> {
+    // This command can only be used in a guild
+    if (!interaction.inGuild()) {
+      this.logger.error('Retire command used outside of a guild');
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    const currentHelperRole = interaction.options.getRole(
+      'current-helper-role',
+      true,
+    );
+    const retiredHelperRole = interaction.options.getRole(
+      'retired-helper-role',
+      true,
+    );
+
+    if (currentHelperRole.id === retiredHelperRole.id) {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Role Retirement')
+            .setDescription(
+              'The current and retired helper roles cannot be the same.',
+            )
+            .setColor(Colors.Red),
+        ],
+      });
+      return;
+    }
+
+    try {
+      // Use the new retireRole method to handle the role retirement
+      const result = await this.discordService.retireRole(
+        interaction.guildId,
+        currentHelperRole.id,
+        retiredHelperRole.id,
+      );
+
+      // Send completion message
+      const resultEmbed = new EmbedBuilder()
+        .setTitle('Role Retirement Complete')
+        .setDescription(
+          `Replaced ${currentHelperRole.name} with ${retiredHelperRole.name}`,
+        )
+        .addFields([
+          {
+            name: 'Total members processed',
+            value: result.totalMembers.toString(),
+            inline: true,
+          },
+          {
+            name: 'Successful updates',
+            value: result.successCount.toString(),
+            inline: true,
+          },
+          {
+            name: 'Failed updates',
+            value: result.failCount.toString(),
+            inline: true,
+          },
+        ])
+        .setColor(result.failCount > 0 ? Colors.Yellow : Colors.Green)
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [resultEmbed] });
+      this.logger.log(
+        `Role retirement complete: ${result.successCount} successful, ${result.failCount} failed`,
+      );
+    } catch (error) {
+      this.logger.error('Error during role retirement', error);
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Role Retirement Failed')
+            .setDescription(
+              'An error occurred while processing role retirement.',
+            )
+            .setColor(Colors.Red),
+        ],
+      });
+    }
+  }
+}
+
+export { RetireCommandHandler };

--- a/src/slash-commands/retire/retire.command.ts
+++ b/src/slash-commands/retire/retire.command.ts
@@ -1,0 +1,8 @@
+import { ChatInputCommandInteraction } from 'discord.js';
+import type { DiscordCommand } from '../slash-commands.interfaces.js';
+
+export class RetireCommand implements DiscordCommand {
+  constructor(
+    public readonly interaction: ChatInputCommandInteraction<'cached' | 'raw'>,
+  ) {}
+}

--- a/src/slash-commands/retire/retire.module.ts
+++ b/src/slash-commands/retire/retire.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { DiscordModule } from '../../discord/discord.module.js';
+import { RetireCommandHandler } from './retire.command-handler.js';
+
+@Module({
+  imports: [CqrsModule, DiscordModule],
+  providers: [RetireCommandHandler],
+})
+export class RetireModule {}

--- a/src/slash-commands/retire/retire.slash-command.ts
+++ b/src/slash-commands/retire/retire.slash-command.ts
@@ -1,0 +1,18 @@
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+
+export const RetireSlashCommand = new SlashCommandBuilder()
+  .setName('retire')
+  .setDescription('Retire all members of the current helper role')
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+  .addRoleOption((option) =>
+    option
+      .setName('current-helper-role')
+      .setDescription('The role to be replaced')
+      .setRequired(true),
+  )
+  .addRoleOption((option) =>
+    option
+      .setName('retired-helper-role')
+      .setDescription('The role to replace with')
+      .setRequired(true),
+  );

--- a/src/slash-commands/slash-commands.service.ts
+++ b/src/slash-commands/slash-commands.service.ts
@@ -25,6 +25,7 @@ import { sentryReport } from '../sentry/sentry.consts.js';
 import { BlacklistSlashCommand } from './blacklist/blacklist.slash-command.js';
 import { LookupSlashCommand } from './lookup/lookup.slash-command.js';
 import { RemoveRoleSlashCommand } from './remove-role/remove-role.slash-command.js';
+import { RetireSlashCommand } from './retire/retire.slash-command.js';
 import { SettingsSlashCommand } from './settings/settings.slash-command.js';
 import { createSignupSlashCommand } from './signup/signup.slash-command.js';
 import { createRemoveSignupSlashCommand } from './signup/subcommands/remove-signup/remove-signup.slash-command.js';
@@ -117,6 +118,7 @@ class SlashCommandsService {
       createTurboProgSlashCommand(applicationModeConfig),
       LookupSlashCommand,
       RemoveRoleSlashCommand,
+      RetireSlashCommand,
       SettingsSlashCommand,
       StatusSlashCommand,
     ];

--- a/src/slash-commands/slash-commands.utils.ts
+++ b/src/slash-commands/slash-commands.utils.ts
@@ -10,6 +10,8 @@ import { LookupCommand } from './lookup/lookup.command.js';
 import { LookupSlashCommand } from './lookup/lookup.slash-command.js';
 import { RemoveRoleCommand } from './remove-role/remove-role.command.js';
 import { RemoveRoleSlashCommand } from './remove-role/remove-role.slash-command.js';
+import { RetireCommand } from './retire/retire.command.js';
+import { RetireSlashCommand } from './retire/retire.slash-command.js';
 import { SettingsSlashCommand } from './settings/settings.slash-command.js';
 import { EditSettingsCommand } from './settings/subcommands/edit/edit-settings.command.js';
 import { ViewSettingsCommand } from './settings/subcommands/view/view-settings.command.js';
@@ -44,6 +46,7 @@ export function getCommandForInteraction(
     .with(LookupSlashCommand.name, () => new LookupCommand(interaction))
     .with(SIGNUP_SLASH_COMMAND_NAME, () => new SignupCommand(interaction))
     .with(StatusSlashCommand.name, () => new StatusCommand(interaction))
+    .with(RetireSlashCommand.name, () => new RetireCommand(interaction))
     .with(SettingsSlashCommand.name, () => {
       const subcommand = interaction.options.getSubcommand();
       return match(subcommand)


### PR DESCRIPTION
# Role Retirement Feature

## New Changes
- Added a new `retireRole` method to DiscordService that handles:
  - Retrieving members with a specific role
  - Removing the original role from members
  - Adding the new role to members
  - Handling errors during the process
  - Reporting success and failure counts
- Updated RetireCommandHandler to use the new service method
- Improved test suite with better mocking and helper functions

## Notes
This PR was created with assistance from GitHub Copilot Agent powered by Claude 3 Opus.
