### PR TITLE
feat(signup): add previously approved prog point to reviewer DM

### DIFF
--- a/src/slash-commands/signup/signup.service.ts
+++ b/src/slash-commands/signup/signup.service.ts
@@ -10,6 +10,7 @@ import {
   ActionRowBuilder,
   DiscordjsErrorCodes,
   Embed,
+  EmbedBuilder,
   type Emoji,
   Events,
   Message,
@@ -324,9 +325,19 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
     const menu = EncounterProgMenus[signup.encounter];
     const row = new ActionRowBuilder().addComponents(menu);
 
+    const embed = signup.progPoint
+      ? EmbedBuilder.from(sourceEmbed).addFields([
+          {
+            name: 'Previously Approved Prog Point',
+            value: signup.progPoint,
+            inline: true,
+          },
+        ])
+      : sourceEmbed;
+
     const message = await this.discordService.sendDirectMessage(user.id, {
       content: 'Please confirm the prog point of the following signup',
-      embeds: [sourceEmbed],
+      embeds: [embed],
       components: [row as any],
     });
 

--- a/src/slash-commands/signup/subcommands/send-signup-review/send-signup-review.command-handler.ts
+++ b/src/slash-commands/signup/subcommands/send-signup-review/send-signup-review.command-handler.ts
@@ -120,7 +120,7 @@ class SendSignupReviewCommandHandler
       {
         name: 'Prog Proof Link',
         value: proofOfProgLink,
-        transform: (v) => `[View](${v})`,
+        transform: (v: string) => `[View](${v})`,
         inline: true,
       },
       { name: 'Availability', value: availability, inline: true },


### PR DESCRIPTION
# Add previously approved prog point to reviewer DM

This change adds the previously approved prog point to the embed sent to reviewers when they are DMed to review a signup.

## Changes

- Added the previously approved prog point field to the embed in the signup reviewer DM when it exists

## Impact

This enhancement provides more context to reviewers by showing them the previously approved prog point for a user, helping them make more informed decisions.

## Testing

- Tested with `pnpm test --run` to verify all tests pass
- Verified functionality by checking the embed creation logic

---
_Assisted-by: Claude 3.7 Sonnet_
