### PR TITLE
feat(jobs): add server invite cleaner job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ NOTES.md
 # Sentry Config File
 .sentryclirc
 .private
+pr-description.md

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -208,6 +208,11 @@ class DiscordService {
       failCount,
     };
   }
+
+  public async getGuildInvites(guildId: string) {
+    const guild = await this.client.guilds.fetch(guildId);
+    return guild.invites.fetch();
+  }
 }
 
 export { DiscordService };

--- a/src/jobs/invite-cleaner/invite-cleaner.config.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.config.ts
@@ -1,0 +1,13 @@
+import { registerAs } from '@nestjs/config';
+import { z } from 'zod';
+
+const schema = z.object({
+  INVITE_CLEANER_CONCURRENCY: z.number().default(5),
+});
+
+export type InviteCleanerConfig = z.infer<typeof schema>;
+
+export const inviteCleanerConfig = registerAs<InviteCleanerConfig>(
+  'invite-cleaner',
+  () => schema.parse(process.env),
+);

--- a/src/jobs/invite-cleaner/invite-cleaner.job.spec.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.job.spec.ts
@@ -1,0 +1,136 @@
+import { Test } from '@nestjs/testing';
+import { Collection, Invite } from 'discord.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiscordService } from '../../discord/discord.service.js';
+import { JobCollection } from '../../firebase/collections/job/job.collection.js';
+import { SettingsCollection } from '../../firebase/collections/settings-collection.js';
+import { inviteCleanerConfig } from './invite-cleaner.config.js';
+import { InviteCleanerJob } from './invite-cleaner.job.js';
+
+describe('InviteCleanerJob', () => {
+  let job: InviteCleanerJob;
+  let discordService: DiscordService;
+  let jobCollection: JobCollection;
+  let settingsCollection: SettingsCollection;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        InviteCleanerJob,
+        {
+          provide: DiscordService,
+          useValue: {
+            getGuilds: vi.fn(),
+            getGuildInvites: vi.fn(),
+            getTextChannel: vi.fn(),
+          },
+        },
+        {
+          provide: JobCollection,
+          useValue: {
+            getJob: vi.fn(),
+          },
+        },
+        {
+          provide: SettingsCollection,
+          useValue: {
+            getSettings: vi.fn(),
+          },
+        },
+        {
+          provide: inviteCleanerConfig.KEY,
+          useValue: {
+            INVITE_CLEANER_CONCURRENCY: 5,
+          },
+        },
+      ],
+    }).compile();
+
+    job = module.get(InviteCleanerJob);
+    discordService = module.get(DiscordService);
+    jobCollection = module.get(JobCollection);
+    settingsCollection = module.get(SettingsCollection);
+  });
+
+  describe('cleanInvites', () => {
+    const mockGuildId = '123';
+    const twoWeeksAgo = Date.now() - 14 * 24 * 60 * 60 * 1000;
+
+    beforeEach(() => {
+      vi.spyOn(discordService, 'getGuilds').mockReturnValue([mockGuildId]);
+      vi.spyOn(jobCollection, 'getJob').mockResolvedValue({ enabled: true });
+      vi.spyOn(settingsCollection, 'getSettings').mockResolvedValue({
+        modChannelId: 'mod-channel',
+      });
+      vi.spyOn(discordService, 'getTextChannel').mockResolvedValue({
+        send: vi.fn().mockResolvedValue(undefined),
+      } as any);
+    });
+
+    it('should delete invites older than 2 weeks', async () => {
+      // Create mock invites
+      const oldInvite = {
+        createdTimestamp: twoWeeksAgo - 1000, // Older than 2 weeks
+        code: 'old-invite',
+        delete: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Invite;
+
+      const newInvite = {
+        createdTimestamp: Date.now(), // Fresh invite
+        code: 'new-invite',
+        delete: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Invite;
+
+      // Create mock collection
+      const invites = new Collection<string, Invite>();
+      invites.set(oldInvite.code, oldInvite);
+      invites.set(newInvite.code, newInvite);
+
+      vi.spyOn(discordService, 'getGuildInvites').mockResolvedValue(invites);
+
+      // Run the job
+      await job['cleanInvites']();
+
+      // Verify old invite was deleted and new invite was kept
+      expect(oldInvite.delete).toHaveBeenCalled();
+      expect(newInvite.delete).not.toHaveBeenCalled();
+    });
+
+    it('should handle failed deletions gracefully', async () => {
+      // Create mock invite that will fail to delete
+      const oldInvite = {
+        createdTimestamp: twoWeeksAgo - 1000,
+        code: 'old-invite',
+        delete: vi.fn().mockRejectedValue(new Error('Delete failed')),
+      } as unknown as Invite;
+
+      // Create mock collection
+      const invites = new Collection<string, Invite>();
+      invites.set(oldInvite.code, oldInvite);
+
+      vi.spyOn(discordService, 'getGuildInvites').mockResolvedValue(invites);
+
+      // Run the job - should not throw
+      await expect(job['cleanInvites']()).resolves.not.toThrow();
+    });
+
+    it('should skip guilds where job is disabled', async () => {
+      vi.spyOn(jobCollection, 'getJob').mockResolvedValue({ enabled: false });
+
+      // Run the job
+      await job['cleanInvites']();
+
+      // Verify guild invites were not fetched
+      expect(discordService.getGuildInvites).not.toHaveBeenCalled();
+    });
+
+    it('should handle guilds with no invites', async () => {
+      // Create empty collection
+      const invites = new Collection<string, Invite>();
+      vi.spyOn(discordService, 'getGuildInvites').mockResolvedValue(invites);
+
+      // Run the job - should not throw
+      await expect(job['cleanInvites']()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/jobs/invite-cleaner/invite-cleaner.job.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.job.ts
@@ -1,0 +1,176 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  type OnApplicationBootstrap,
+  type OnApplicationShutdown,
+} from '@nestjs/common';
+import type { ConfigType } from '@nestjs/config';
+import { CronJob } from 'cron';
+import { EmbedBuilder, Invite } from 'discord.js';
+import { filter, from, lastValueFrom, mergeMap, reduce } from 'rxjs';
+import { CronTime } from '../../common/cron.js';
+import { DiscordService } from '../../discord/discord.service.js';
+import { JobCollection } from '../../firebase/collections/job/job.collection.js';
+import { SettingsCollection } from '../../firebase/collections/settings-collection.js';
+import { createJob, jobDateFormatter } from '../jobs.consts.js';
+import { inviteCleanerConfig } from './invite-cleaner.config.js';
+
+const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
+
+interface CleanupStats {
+  totalInvites: number;
+  cleanedInvites: number;
+  failedCleanups: number;
+}
+
+interface DeleteResult {
+  success: boolean;
+}
+
+@Injectable()
+class InviteCleanerJob
+  implements OnApplicationBootstrap, OnApplicationShutdown
+{
+  protected job: CronJob<null, null>;
+  private readonly logger = new Logger(InviteCleanerJob.name);
+
+  constructor(
+    private readonly discordService: DiscordService,
+    private readonly jobsCollection: JobCollection,
+    private readonly settingsCollection: SettingsCollection,
+    @Inject(inviteCleanerConfig.KEY)
+    private readonly config: ConfigType<typeof inviteCleanerConfig>,
+  ) {
+    this.job = createJob('invite-cleaner', {
+      cronTime: CronTime.everyDay().at(5), // Run at 5 AM Pacific
+      onTick: () => {
+        this.cleanInvites();
+      },
+    });
+  }
+
+  onApplicationBootstrap() {
+    this.job.start();
+    this.logger.log(
+      `daily run scheduled for: ${jobDateFormatter.format(this.job.nextDate().toJSDate())}`,
+    );
+  }
+
+  onApplicationShutdown() {
+    this.job.stop();
+  }
+
+  private async cleanInvites() {
+    this.logger.log('starting invite cleaner job');
+
+    const guilds = this.discordService.getGuilds();
+    const twoWeeksAgo = Date.now() - TWO_WEEKS_MS;
+
+    const task$ = from(guilds).pipe(
+      mergeMap((guild) =>
+        this.jobsCollection
+          .getJob(guild, 'invite-cleaner')
+          .then((job) => [guild, job] as const),
+      ),
+      filter(([_, job]) => !!job?.enabled),
+      mergeMap(async ([guildId]) => {
+        const invites = await this.discordService.getGuildInvites(guildId);
+
+        // Process deletions with concurrency control and collect stats
+        const stats = await lastValueFrom(
+          from(invites.values()).pipe(
+            filter((invite): invite is Invite => {
+              const timestamp = invite.createdTimestamp;
+              return timestamp != null && timestamp < twoWeeksAgo;
+            }),
+            mergeMap(async (invite) => {
+              this.logger.debug(
+                `deleting old invite ${invite.code} from ${guildId}`,
+              );
+              try {
+                await invite.delete();
+                return { success: true };
+              } catch (error: unknown) {
+                this.logger.error(
+                  `Failed to delete invite ${invite.code}:`,
+                  error,
+                );
+                return { success: false };
+              }
+            }, this.config.INVITE_CLEANER_CONCURRENCY),
+            reduce<{ success: boolean }, CleanupStats>(
+              (stats, result) => {
+                if (result.success) {
+                  stats.cleanedInvites++;
+                } else {
+                  stats.failedCleanups++;
+                }
+                return stats;
+              },
+              {
+                totalInvites: invites.size,
+                cleanedInvites: 0,
+                failedCleanups: 0,
+              },
+            ),
+          ),
+        );
+
+        // Log stats for this guild
+        this.logger.log(
+          `Guild ${guildId} cleanup summary:`,
+          `${stats.cleanedInvites} invites cleaned up,`,
+          `${stats.failedCleanups} failures,`,
+          `out of ${stats.totalInvites} total invites`,
+        );
+
+        try {
+          // Post summary to mod channel if configured
+          await this.publishResults(stats, guildId);
+        } catch (error: unknown) {
+          this.logger.error(
+            `Failed to publish results for guild ${guildId}:`,
+            error,
+          );
+        }
+
+        return stats;
+      }),
+    );
+
+    await lastValueFrom(task$, { defaultValue: undefined });
+    this.logger.log('Invite cleanup job complete');
+  }
+
+  private async publishResults(stats: CleanupStats, guildId: string) {
+    if (stats.cleanedInvites === 0 && stats.failedCleanups === 0) return;
+
+    const settings = await this.settingsCollection.getSettings(guildId);
+    if (!settings?.modChannelId) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(':broom: Invite Cleanup :broom:')
+      .setDescription(
+        [
+          `${stats.cleanedInvites} expired invites have been cleaned up!`,
+          stats.failedCleanups > 0
+            ? `${stats.failedCleanups} invites failed to be deleted.`
+            : null,
+          `Total invites in server: ${stats.totalInvites}`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      )
+      .setTimestamp();
+
+    const channel = await this.discordService.getTextChannel({
+      guildId,
+      channelId: settings.modChannelId,
+    });
+
+    return await channel?.send({ embeds: [embed] });
+  }
+}
+
+export { InviteCleanerJob };

--- a/src/jobs/invite-cleaner/invite-cleaner.module.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DiscordModule } from '../../discord/discord.module.js';
+import { FirebaseModule } from '../../firebase/firebase.module.js';
+import { InviteCleanerJob } from './invite-cleaner.job.js';
+
+@Module({
+  imports: [DiscordModule, FirebaseModule],
+  providers: [InviteCleanerJob],
+})
+export class InviteCleanerModule {}

--- a/src/jobs/jobs.consts.ts
+++ b/src/jobs/jobs.consts.ts
@@ -30,4 +30,4 @@ export const jobDateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZoneName: 'short',
 });
 
-export type JobType = 'clear-checker' | 'sheet-cleaner';
+export type JobType = 'clear-checker' | 'sheet-cleaner' | 'invite-cleaner';

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ClearCheckerModule } from './clear-checker/clear-checker.module.js';
+import { InviteCleanerModule } from './invite-cleaner/invite-cleaner.module.js';
 import { SheetCleanerModule } from './sheet-cleaner/sheet-cleaner.module.js';
 
 @Module({
-  imports: [ClearCheckerModule, SheetCleanerModule],
+  imports: [ClearCheckerModule, SheetCleanerModule, InviteCleanerModule],
 })
 export class JobsModule {}


### PR DESCRIPTION
# feat: Add Discord invite cleaner job

Adds a new cronjob that automatically cleans up old Discord invites to prevent invite clutter and maintain server security.

## Changes

- Added new `InviteCleanerJob` that runs daily at 5 AM Pacific time
- Added `getGuildInvites` method to `DiscordService`
- Added comprehensive unit tests for the invite cleaner job
- Added 'invite-cleaner' to the `JobType` enum
- Added job statistics tracking and logging

## Impact

- Automatically deletes Discord invites that are older than 2 weeks
- Only runs on guilds where the job is explicitly enabled
- Provides detailed logging of cleanup operations
- Handles errors gracefully to ensure job continuity

## Testing

- Unit tests cover all major scenarios:
  - Deleting old invites while keeping new ones
  - Handling failed deletions gracefully
  - Skipping guilds where job is disabled
  - Handling guilds with no invites
- Job can be enabled/disabled per guild through Firebase configuration
- Logs provide visibility into job performance and issues
