### PR TITLE
chore: potential fix for code scanning alert no. 5

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,4 +1,6 @@
 name: Fly Deploy and Publish Release To Discord
+permissions:
+  contents: read
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/ssilve1989/ulti-project/security/code-scanning/5](https://github.com/ssilve1989/ulti-project/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves deploying an application and publishing a release to Discord, it does not require write access to the repository contents or other sensitive permissions. We will set `contents: read` at the workflow level to apply minimal permissions to all jobs. If any job requires additional permissions, we will define them specifically within that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
