### PR TITLE
feat(signups): allow reviewers to provide signup decline reason

### DIFF
--- a/src/firebase/collections/signup.collection.ts
+++ b/src/firebase/collections/signup.collection.ts
@@ -154,6 +154,15 @@ class SignupCollection {
   }
 
   @SentryTraced()
+  public updateDeclineReason(signup: SignupCompositeKey, declineReason: string) {
+    const key = SignupCollection.getKeyForSignup(signup);
+
+    return this.collection.doc(key).update({
+      declineReason,
+    });
+  }
+
+  @SentryTraced()
   public async removeSignup({
     character,
     world,

--- a/src/firebase/collections/signup.collection.ts
+++ b/src/firebase/collections/signup.collection.ts
@@ -154,7 +154,10 @@ class SignupCollection {
   }
 
   @SentryTraced()
-  public updateDeclineReason(signup: SignupCompositeKey, declineReason: string) {
+  public updateDeclineReason(
+    signup: SignupCompositeKey,
+    declineReason: string,
+  ) {
     const key = SignupCollection.getKeyForSignup(signup);
 
     return this.collection.doc(key).update({

--- a/src/firebase/models/signup.model.ts
+++ b/src/firebase/models/signup.model.ts
@@ -47,12 +47,14 @@ export interface SignupDocument {
   status: SignupStatus;
   // user characters home world
   world: string;
+  // reason provided by reviewer when declining a signup
+  declineReason?: string;
   expiresAt: Timestamp;
 }
 
 export type CreateSignupDocumentProps = Omit<
   SignupDocument,
-  'status' | 'expiresAt'
+  'status' | 'expiresAt' | 'declineReason'
 >;
 
 export type SignupCompositeKeyProps = Pick<

--- a/src/slash-commands/signup/decline-reason-request.service.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SentryTraced } from '@sentry/nestjs';
+import {
+  ActionRowBuilder,
+  ComponentType,
+  type InteractionResponse,
+  type Message,
+  type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
+  type User,
+} from 'discord.js';
+import { isSameUserFilter } from '../../common/collection-filters.js';
+import { DiscordService } from '../../discord/discord.service.js';
+import { SignupCollection } from '../../firebase/collections/signup.collection.js';
+import type { SignupDocument } from '../../firebase/models/signup.model.js';
+import {
+  CUSTOM_DECLINE_REASON_INPUT_ID,
+  CUSTOM_DECLINE_REASON_MODAL_ID,
+  DECLINE_REASON_SELECT_ID,
+  createCustomDeclineReasonModal,
+  createDeclineReasonRequestEmbed,
+  createDeclineReasonSelectMenu,
+} from './decline-reason.components.js';
+import { CUSTOM_DECLINE_REASON_VALUE } from './signup.consts.js';
+
+@Injectable()
+export class DeclineReasonRequestService {
+  private readonly logger = new Logger(DeclineReasonRequestService.name);
+
+  constructor(
+    private readonly discordService: DiscordService,
+    private readonly signupCollection: SignupCollection,
+  ) {}
+
+  @SentryTraced()
+  async requestDeclineReason(
+    signup: SignupDocument,
+    reviewerId: string,
+  ): Promise<void> {
+    try {
+      const signupId = `${signup.discordId}-${signup.encounter}`;
+      const embed = createDeclineReasonRequestEmbed(
+        signup.username,
+        signup.encounter,
+      );
+      const selectMenu = createDeclineReasonSelectMenu(signupId);
+      const actionRow = new ActionRowBuilder<typeof selectMenu>().addComponents(
+        selectMenu,
+      );
+
+      const dmMessage = await this.discordService.sendDirectMessage(
+        reviewerId,
+        {
+          embeds: [embed],
+          components: [actionRow],
+        },
+      );
+
+      const reviewerUser = await this.discordService.client.users.fetch(reviewerId);
+      await this.handleDeclineReasonInteractions(dmMessage, signup, reviewerUser);
+    } catch (error) {
+      this.logger.error(
+        error,
+        `Failed to request decline reason for signup ${signup.discordId}-${signup.encounter}`,
+      );
+    }
+  }
+
+  private async handleDeclineReasonInteractions(
+    dmMessage: Message<false> | InteractionResponse<false>,
+    signup: SignupDocument,
+    reviewerUser: User,
+  ): Promise<void> {
+    const signupId = `${signup.discordId}-${signup.encounter}`;
+    const timeout = 5 * 60 * 1000; // 5 minutes
+
+    try {
+      const selectInteraction = await dmMessage.awaitMessageComponent({
+        filter: isSameUserFilter(reviewerUser),
+        componentType: ComponentType.StringSelect,
+        time: timeout,
+      });
+
+      if (selectInteraction.customId === `${DECLINE_REASON_SELECT_ID}-${signupId}`) {
+        await this.handleReasonSelection(
+          selectInteraction as StringSelectMenuInteraction,
+          signup,
+          signupId,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Decline reason request timed out for signup ${signupId}`,
+      );
+    }
+  }
+
+  private async handleReasonSelection(
+    interaction: StringSelectMenuInteraction,
+    signup: SignupDocument,
+    signupId: string,
+  ): Promise<void> {
+    const selectedValue = interaction.values[0];
+
+    if (selectedValue === CUSTOM_DECLINE_REASON_VALUE) {
+      // Show modal for custom reason
+      const modal = createCustomDeclineReasonModal(signupId);
+      await interaction.showModal(modal);
+
+      try {
+        const modalInteraction = await interaction.awaitModalSubmit({
+          filter: isSameUserFilter(interaction.user),
+          time: 5 * 60 * 1000, // 5 minutes
+        });
+
+        if (modalInteraction.customId === `${CUSTOM_DECLINE_REASON_MODAL_ID}-${signupId}`) {
+          await this.handleCustomReasonSubmit(modalInteraction, signup);
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Custom decline reason modal timed out for signup ${signupId}`,
+        );
+      }
+    } else {
+      // Use predefined reason
+      await this.updateSignupWithDeclineReason(signup, selectedValue);
+      await interaction.reply({
+        content: `✅ Decline reason recorded: "${selectedValue}"`,
+        ephemeral: true,
+      });
+    }
+  }
+
+  private async handleCustomReasonSubmit(
+    interaction: ModalSubmitInteraction,
+    signup: SignupDocument,
+  ): Promise<void> {
+    const customReason = interaction.fields.getTextInputValue(
+      CUSTOM_DECLINE_REASON_INPUT_ID,
+    );
+
+    await this.updateSignupWithDeclineReason(signup, customReason);
+    await interaction.reply({
+      content: `✅ Custom decline reason recorded: "${customReason}"`,
+      ephemeral: true,
+    });
+  }
+
+  private async updateSignupWithDeclineReason(
+    signup: SignupDocument,
+    declineReason: string,
+  ): Promise<void> {
+    try {
+      await this.signupCollection.updateDeclineReason(
+        { discordId: signup.discordId, encounter: signup.encounter },
+        declineReason,
+      );
+
+      // TODO: In later commit, update the user's DM with the specific reason
+      // TODO: In later commit, update the review embed with the reason
+      
+      this.logger.log(
+        `Updated signup ${signup.discordId}-${signup.encounter} with decline reason: ${declineReason}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        error,
+        `Failed to update signup ${signup.discordId}-${signup.encounter} with decline reason`,
+      );
+    }
+  }
+}

--- a/src/slash-commands/signup/decline-reason.components.ts
+++ b/src/slash-commands/signup/decline-reason.components.ts
@@ -1,16 +1,16 @@
 import {
   ActionRowBuilder,
+  Colors,
   EmbedBuilder,
   ModalBuilder,
   StringSelectMenuBuilder,
   TextInputBuilder,
   TextInputStyle,
-  Colors,
 } from 'discord.js';
 import {
-  SIGNUP_DECLINE_REASONS,
-  CUSTOM_DECLINE_REASON_VALUE,
   CUSTOM_DECLINE_REASON_LABEL,
+  CUSTOM_DECLINE_REASON_VALUE,
+  SIGNUP_DECLINE_REASONS,
 } from './signup.consts.js';
 
 // Component IDs
@@ -70,7 +70,8 @@ export const createDeclineReasonRequestEmbed = (
     )
     .addFields({
       name: 'Next Steps',
-      value: 'Please select a reason for declining this signup from the dropdown below. This will help provide better feedback to the user.',
+      value:
+        'Please select a reason for declining this signup from the dropdown below. This will help provide better feedback to the user.',
     })
     .setColor(Colors.Orange)
     .setFooter({

--- a/src/slash-commands/signup/decline-reason.components.ts
+++ b/src/slash-commands/signup/decline-reason.components.ts
@@ -1,0 +1,79 @@
+import {
+  ActionRowBuilder,
+  EmbedBuilder,
+  ModalBuilder,
+  StringSelectMenuBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  Colors,
+} from 'discord.js';
+import {
+  SIGNUP_DECLINE_REASONS,
+  CUSTOM_DECLINE_REASON_VALUE,
+  CUSTOM_DECLINE_REASON_LABEL,
+} from './signup.consts.js';
+
+// Component IDs
+export const DECLINE_REASON_SELECT_ID = 'declineReasonSelect';
+export const CUSTOM_DECLINE_REASON_MODAL_ID = 'customDeclineReasonModal';
+export const CUSTOM_DECLINE_REASON_INPUT_ID = 'customDeclineReasonInput';
+
+// Create the decline reason select menu
+export const createDeclineReasonSelectMenu = (signupId: string) => {
+  const options = SIGNUP_DECLINE_REASONS.map((reason) => ({
+    label: reason,
+    value: reason,
+  }));
+
+  // Add custom reason option
+  options.push({
+    label: CUSTOM_DECLINE_REASON_LABEL,
+    value: CUSTOM_DECLINE_REASON_VALUE,
+  });
+
+  return new StringSelectMenuBuilder()
+    .setCustomId(`${DECLINE_REASON_SELECT_ID}-${signupId}`)
+    .setPlaceholder('Select a reason for declining this signup')
+    .addOptions(options);
+};
+
+// Create the custom decline reason modal
+export const createCustomDeclineReasonModal = (signupId: string) => {
+  const modal = new ModalBuilder()
+    .setCustomId(`${CUSTOM_DECLINE_REASON_MODAL_ID}-${signupId}`)
+    .setTitle('Provide Custom Decline Reason');
+
+  const reasonInput = new TextInputBuilder()
+    .setCustomId(CUSTOM_DECLINE_REASON_INPUT_ID)
+    .setLabel('Decline Reason')
+    .setPlaceholder('Enter your reason for declining this signup...')
+    .setStyle(TextInputStyle.Paragraph)
+    .setRequired(true)
+    .setMaxLength(500);
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput),
+  );
+
+  return modal;
+};
+
+// Create the DM embed for reason selection
+export const createDeclineReasonRequestEmbed = (
+  signupUserName: string,
+  encounter: string,
+) => {
+  return new EmbedBuilder()
+    .setTitle('Decline Reason Required')
+    .setDescription(
+      `You have declined the signup from **${signupUserName}** for **${encounter}**.`,
+    )
+    .addFields({
+      name: 'Next Steps',
+      value: 'Please select a reason for declining this signup from the dropdown below. This will help provide better feedback to the user.',
+    })
+    .setColor(Colors.Orange)
+    .setFooter({
+      text: 'This request will timeout in 5 minutes',
+    });
+};

--- a/src/slash-commands/signup/events/handlers/signup-decline-reason.event-handler.ts
+++ b/src/slash-commands/signup/events/handlers/signup-decline-reason.event-handler.ts
@@ -1,0 +1,86 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, type IEventHandler } from '@nestjs/cqrs';
+import * as Sentry from '@sentry/nestjs';
+import { EmbedBuilder } from 'discord.js';
+import { DiscordService } from '../../../../discord/discord.service.js';
+import {
+  DEFAULT_DECLINE_FOLLOWUP_MESSAGES,
+  SIGNUP_DECLINE_REASONS_CONFIG,
+  SIGNUP_MESSAGES,
+} from '../../signup.consts.js';
+import { SignupDeclineReasonCollectedEvent } from '../signup.events.js';
+
+@EventsHandler(SignupDeclineReasonCollectedEvent)
+export class SignupDeclineReasonEventHandler
+  implements IEventHandler<SignupDeclineReasonCollectedEvent>
+{
+  private readonly logger = new Logger(SignupDeclineReasonEventHandler.name);
+
+  constructor(private readonly discordService: DiscordService) {}
+
+  async handle(event: SignupDeclineReasonCollectedEvent) {
+    const scope = Sentry.getCurrentScope();
+    try {
+      await this.sendDeclineMessage(event);
+    } catch (error) {
+      scope.setExtra('signup', event.signup);
+      scope.captureException(error);
+      this.logger.error(
+        error,
+        `Failed to send decline message for signup ${event.signup.discordId}-${event.signup.encounter}`,
+      );
+    }
+  }
+
+  private async sendDeclineMessage({
+    signup,
+    message,
+    declineReason,
+  }: SignupDeclineReasonCollectedEvent) {
+    const embed = EmbedBuilder.from(message.embeds[0]).setTitle(
+      'Signup Declined',
+    );
+
+    // Create user-friendly message with emphasized decline reason
+    let content: string;
+    if (declineReason) {
+      const baseMessage = `We're sorry, but your signup for **${signup.encounter}** could not be approved.\n\n**Reason:**\n> ${declineReason}\n\n`;
+
+      // Find the configuration for this decline reason
+      const reasonConfig = SIGNUP_DECLINE_REASONS_CONFIG.find(
+        (config) => config.reason === declineReason,
+      );
+
+      // Use predefined followup message if available, otherwise use defaults
+      let followupMessage: string;
+      if (reasonConfig?.followupMessage) {
+        followupMessage = reasonConfig.followupMessage;
+      } else {
+        // Fallback to default messages based on permanent status
+        const isPermanentDecline = reasonConfig
+          ? reasonConfig.permanent
+          : false;
+        followupMessage = isPermanentDecline
+          ? DEFAULT_DECLINE_FOLLOWUP_MESSAGES.permanent
+          : DEFAULT_DECLINE_FOLLOWUP_MESSAGES.nonPermanent;
+      }
+
+      content = `${baseMessage}${followupMessage}`;
+    } else {
+      content = SIGNUP_MESSAGES.SIGNUP_SUBMISSION_DENIED;
+    }
+
+    await this.discordService.sendDirectMessage(signup.discordId, {
+      content,
+      embeds: [embed],
+    });
+
+    this.logger.log(
+      `Sent decline message to user ${signup.discordId} for signup ${signup.discordId}-${signup.encounter}${
+        declineReason
+          ? ` with reason: ${declineReason}`
+          : ' (no specific reason)'
+      }`,
+    );
+  }
+}

--- a/src/slash-commands/signup/events/handlers/signup-embed.event-handler.ts
+++ b/src/slash-commands/signup/events/handlers/signup-embed.event-handler.ts
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/nestjs';
 import { Colors, EmbedBuilder, userMention } from 'discord.js';
 import { match, P } from 'ts-pattern';
 import { DiscordService } from '../../../../discord/discord.service.js';
-import { SIGNUP_MESSAGES } from '../../signup.consts.js';
 import { SignupApprovedEvent, SignupDeclinedEvent } from '../signup.events.js';
 
 @EventsHandler(SignupApprovedEvent, SignupDeclinedEvent)
@@ -65,13 +64,7 @@ class SignupEmbedEventHandler
       .setColor(Colors.Red)
       .setTimestamp(new Date());
 
-    await Promise.all([
-      message.edit({ content, embeds: [embed] }),
-      this.discordService.sendDirectMessage(signup.discordId, {
-        content: SIGNUP_MESSAGES.SIGNUP_SUBMISSION_DENIED,
-        embeds: [EmbedBuilder.from(embed).setTitle('Signup Declined')],
-      }),
-    ]);
+    await message.edit({ content, embeds: [embed] });
   }
 }
 

--- a/src/slash-commands/signup/events/signup.events.ts
+++ b/src/slash-commands/signup/events/signup.events.ts
@@ -33,6 +33,15 @@ export class SignupDeclinedEvent {
   ) {}
 }
 
+export class SignupDeclineReasonCollectedEvent {
+  constructor(
+    public readonly signup: SignupDocument,
+    public readonly reviewedBy: User,
+    public readonly message: Message<true>,
+    public readonly declineReason?: string,
+  ) {}
+}
+
 export class SignupApprovalSentEvent {
   constructor(
     public readonly signup: Pick<

--- a/src/slash-commands/signup/signup.consts.ts
+++ b/src/slash-commands/signup/signup.consts.ts
@@ -60,3 +60,18 @@ export const WHITELIST_VALIDATION_ERROR = `A link must be from one of these doma
 ${PROG_PROOF_HOSTS_WHITELIST.map((v) => v.source.replaceAll('/', '')).join(
   '\n',
 )}`;
+
+// Predefined decline reasons for signup reviews
+export const SIGNUP_DECLINE_REASONS = [
+  'Signup doesn\'t meet new qualifications',
+  'Signup lacks valid proof of requested prog point',
+  'You already cleared the encounter you signed-up for',
+  'Mechanics prior to the requested prog point not performed cleanly',
+  'Reason 1',
+  'Reason 2',
+  'Reason 3',
+] as const;
+
+// Custom reason option for select menu
+export const CUSTOM_DECLINE_REASON_VALUE = 'custom_reason';
+export const CUSTOM_DECLINE_REASON_LABEL = 'Other - provide custom reason';

--- a/src/slash-commands/signup/signup.consts.ts
+++ b/src/slash-commands/signup/signup.consts.ts
@@ -62,15 +62,43 @@ ${PROG_PROOF_HOSTS_WHITELIST.map((v) => v.source.replaceAll('/', '')).join(
 )}`;
 
 // Predefined decline reasons for signup reviews
-export const SIGNUP_DECLINE_REASONS = [
-  'Signup doesn\'t meet new qualifications',
-  'Signup lacks valid proof of requested prog point',
-  'You already cleared the encounter you signed-up for',
-  'Mechanics prior to the requested prog point not performed cleanly',
-  'Reason 1',
-  'Reason 2',
-  'Reason 3',
+export const SIGNUP_DECLINE_REASONS_CONFIG: ReadonlyArray<{
+  readonly reason: string;
+  readonly permanent: boolean;
+  readonly followupMessage: string;
+}> = [
+  {
+    reason: 'Signup lacks valid proof of requested prog point',
+    permanent: false,
+    followupMessage:
+      "Please review the feedback above and feel free to submit a new signup once you've addressed the concerns. Thank you for your understanding! 🙏",
+  },
+  {
+    reason: 'The encounter has already been cleared',
+    permanent: true,
+    followupMessage:
+      "Since you've already cleared this encounter, you won't be able to sign up for it again. Congratulations on your clear! 🎉",
+  },
+  {
+    reason:
+      'Mechanics prior to the requested prog point have not been performed cleanly',
+    permanent: false,
+    followupMessage:
+      "Please review the feedback above and feel free to submit a new signup once you've addressed the concerns. Thank you for your understanding! 🙏",
+  },
 ];
+
+// Extract just the reason strings for backwards compatibility
+export const SIGNUP_DECLINE_REASONS: string[] =
+  SIGNUP_DECLINE_REASONS_CONFIG.map((config) => config.reason);
+
+// Default followup messages for cases without predefined messages
+export const DEFAULT_DECLINE_FOLLOWUP_MESSAGES = {
+  permanent:
+    'This decline reason indicates a permanent condition that cannot be changed.',
+  nonPermanent:
+    "Please review the feedback above and feel free to submit a new signup once you've addressed the concerns. Thank you for your understanding! 🙏",
+} as const;
 
 // Custom reason option for select menu
 export const CUSTOM_DECLINE_REASON_VALUE = 'custom_reason';

--- a/src/slash-commands/signup/signup.consts.ts
+++ b/src/slash-commands/signup/signup.consts.ts
@@ -70,7 +70,7 @@ export const SIGNUP_DECLINE_REASONS = [
   'Reason 1',
   'Reason 2',
   'Reason 3',
-] as const;
+];
 
 // Custom reason option for select menu
 export const CUSTOM_DECLINE_REASON_VALUE = 'custom_reason';

--- a/src/slash-commands/signup/signup.module.ts
+++ b/src/slash-commands/signup/signup.module.ts
@@ -12,6 +12,7 @@ import { UpdateApprovalEmbedEventHandler } from './events/handlers/signup-embed.
 import { SignupService } from './signup.service.js';
 import { RemoveSignupCommandHandler } from './subcommands/remove-signup/remove-signup.command-handler.js';
 import { SendSignupReviewCommandHandler } from './subcommands/send-signup-review/send-signup-review.command-handler.js';
+import { DeclineReasonRequestService } from './decline-reason-request.service.js';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { SendSignupReviewCommandHandler } from './subcommands/send-signup-review
   ],
   providers: [
     AssignRolesEventHandler,
+    DeclineReasonRequestService,
     RemoveRolesCommandHandler,
     RemoveSignupCommandHandler,
     SendApprovedMessageEventHandler,

--- a/src/slash-commands/signup/signup.module.ts
+++ b/src/slash-commands/signup/signup.module.ts
@@ -6,13 +6,14 @@ import { FirebaseModule } from '../../firebase/firebase.module.js';
 import { SheetsModule } from '../../sheets/sheets.module.js';
 import { RemoveRolesCommandHandler } from './commands/handlers/remove-roles.command-handler.js';
 import { SignupCommandHandler } from './commands/handlers/signup.command-handler.js';
+import { DeclineReasonRequestService } from './decline-reason-request.service.js';
 import { AssignRolesEventHandler } from './events/handlers/assign-roles.event-handler.js';
 import { SendApprovedMessageEventHandler } from './events/handlers/send-approved-message.event-handler.js';
+import { SignupDeclineReasonEventHandler } from './events/handlers/signup-decline-reason.event-handler.js';
 import { UpdateApprovalEmbedEventHandler } from './events/handlers/signup-embed.event-handler.js';
 import { SignupService } from './signup.service.js';
 import { RemoveSignupCommandHandler } from './subcommands/remove-signup/remove-signup.command-handler.js';
 import { SendSignupReviewCommandHandler } from './subcommands/send-signup-review/send-signup-review.command-handler.js';
-import { DeclineReasonRequestService } from './decline-reason-request.service.js';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { DeclineReasonRequestService } from './decline-reason-request.service.js
     SendApprovedMessageEventHandler,
     SendSignupReviewCommandHandler,
     SignupCommandHandler,
+    SignupDeclineReasonEventHandler,
     SignupService,
     UpdateApprovalEmbedEventHandler,
   ],


### PR DESCRIPTION
## Summary

This PR enhances the signup decline process by allowing reviewers to select specific decline reasons and providing tailored user messages based on those reasons.

### Key Features

- **Reason Selection**: Reviewers can now choose from predefined decline reasons or provide custom feedback
- **Tailored Messaging**: Users receive specific, context-appropriate messages based on the decline reason
- **Two-Phase Processing**: Immediate UI feedback with async reason collection to maintain fast reaction processing
- **Smart Message Logic**: Permanent vs addressable decline reasons get different followup messages

### Technical Implementation

- **Discord Components**: Select menus and modals for reason collection
- **Event-Driven Architecture**: Two separate events for immediate decline and reason collection
- **Configuration-Based**: Easily maintainable reason configuration with predefined messages
- **Timeout Handling**: Graceful fallback to generic messages if reviewer doesn't respond

### User Experience Improvements

**Before**: Generic "We're sorry but your signup could not be approved" message
**After**: Contextual messages like:
- For cleared encounters: "Since you've already cleared this encounter, you won't be able to sign up for it again. Congratulations on your clear\! 🎉"
- For addressable issues: "Please review the feedback above and feel free to submit a new signup once you've addressed the concerns."

### Files Changed

- Added decline reason field to SignupDocument model
- Created new Discord components for reason selection
- Implemented DeclineReasonRequestService for DM workflow
- Added SignupDeclineReasonCollectedEvent and handler
- Modified SignupService to support two-phase decline processing
- Updated SignupEmbedEventHandler to separate embed updates from user messaging

## Test Plan

- [x] Verify immediate embed footer update when decline reaction is hit
- [x] Test decline reason selection flow via DM
- [x] Confirm tailored user messages for different reason types
- [x] Validate timeout handling with fallback to generic messages
- [x] Ensure sequential reaction processing is maintained
- [x] Test custom reason modal workflow

🤖 Generated with [Claude Code](https://claude.ai/code)