### PR TITLE
fix(sheet-cleaner): fixes sheet cleaner job for all encounters

### DIFF
--- a/src/firebase/collections/encounters-collection.ts
+++ b/src/firebase/collections/encounters-collection.ts
@@ -23,6 +23,12 @@ class EncountersCollection {
   }
 
   @SentryTraced()
+  async getActiveEncounters(): Promise<(EncounterDocument & { id: string })[]> {
+    const snapshot = await this.collection.where('active', '==', true).get();
+    return snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
+  }
+
+  @SentryTraced()
   async getEncounter(
     encounterId: string,
   ): Promise<EncounterDocument | undefined> {

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -547,6 +547,8 @@ class SheetsService {
     spreadsheetId: string;
     encounter: Encounter;
   }): Promise<void> {
+    this.logger.log(`Cleaning sheet: ${encounter}`);
+
     const ranges = [
       SheetRanges[PartyStatus.ClearParty],
       SheetRanges[PartyStatus.ProgParty],


### PR DESCRIPTION
feat: Dynamic Sheet Cleaning for Active Encounters

## Description

This pull request updates the sheet cleaner job to dynamically clean sheets for all active encounters, rather than being hardcoded to a single encounter. This improves the scalability and maintainability of the sheet cleaning process.

### Key Changes:

- **`src/firebase/collections/encounters-collection.ts`**: Introduced a new `getActiveEncounters()` method to fetch all encounters marked as active in the Firebase collection.
- **`src/jobs/sheet-cleaner/sheet-cleaner.job.ts`**: The `SheetCleanerJob` has been updated to use the `getActiveEncounters()` method. It now iterates through all active encounters and triggers the cleaning process for each of their respective sheets.
- **`src/sheets/sheets.service.ts`**: Added a logging statement within the `cleanSheet` method to provide better visibility into which sheet is being cleaned.

## How to Test

1.  Run the `SheetCleanerJob`.
2.  Observe the logs to confirm that the job is iterating through all active encounters and attempting to clean their sheets.
3.  Verify that the correct sheets are being cleaned based on the logs.
