### PR TITLE
refactor(signups): add additional information for name changes

### DIFF
--- a/src/slash-commands/signup/commands/handlers/signup.command-handler.ts
+++ b/src/slash-commands/signup/commands/handlers/signup.command-handler.ts
@@ -7,6 +7,7 @@ import {
   ChatInputCommandInteraction,
   Colors,
   ComponentType,
+  channelLink,
   DiscordjsErrorCodes,
   EmbedBuilder,
   MessageFlags,
@@ -240,7 +241,7 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
       // display a warning that their name does not match. it could be a spelling mistake
       embed.addFields({
         name: '⚠️ Name Mismatch Warning',
-        value: `Your Discord display name \`${displayName}\` doesn't match your submitted character name \`${titleCase(character)}\`. Please be sure this is correct before confirming.`,
+        value: `Your Discord display name \`${displayName}\` doesn't match your submitted character name \`${titleCase(character)}\`. Please be sure this is correct before confirming.\n\nNames can be updated by visting the ${channelLink('1264643007848906884')} channel. Please refer to the pinned FAQ for more information.`,
         inline: false,
       });
     }


### PR DESCRIPTION
## Summary

This PR updates the name mismatch warning message to include a link to the channel where users can update their name and a reference to the FAQ for more information. This should help guide users to the correct place to resolve the warning.

## Changes

- Modified `signup.command-handler.ts` to add more information to the name mismatch warning embed.

## How to Test

1. Trigger the signup command.
2. Provide a character name that does not match your Discord display name.
3. Observe the warning message and verify the new text and channel link are present.
