### PR TITLE
refactor(settings): rename modChannelId to autoModChannelId

### DIFF
--- a/src/firebase/models/settings.model.ts
+++ b/src/firebase/models/settings.model.ts
@@ -4,7 +4,7 @@ import { Encounter } from '../../encounters/encounters.consts.js';
 export interface SettingsDocument extends DocumentData {
   reviewChannel?: string;
   reviewerRole?: string;
-  modChannelId?: string;
+  autoModChannelId?: string;
   signupChannel?: string;
   spreadsheetId?: string;
   turboProgActive?: boolean;

--- a/src/jobs/clear-checker/clear-checker.job.ts
+++ b/src/jobs/clear-checker/clear-checker.job.ts
@@ -238,7 +238,7 @@ class ClearCheckerJob implements OnApplicationBootstrap, OnApplicationShutdown {
 
     const settings = await this.settingsCollection.getSettings(guildId);
 
-    if (!settings?.modChannelId) {
+    if (!settings?.autoModChannelId) {
       return;
     }
 
@@ -249,7 +249,7 @@ class ClearCheckerJob implements OnApplicationBootstrap, OnApplicationShutdown {
 
     const channel = await this.discordService.getTextChannel({
       guildId,
-      channelId: settings.modChannelId,
+      channelId: settings.autoModChannelId,
     });
 
     return await channel?.send({ embeds: [embed] });

--- a/src/jobs/invite-cleaner/invite-cleaner.job.spec.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.job.spec.ts
@@ -60,7 +60,7 @@ describe('InviteCleanerJob', () => {
       vi.spyOn(discordService, 'getGuilds').mockReturnValue([mockGuildId]);
       vi.spyOn(jobCollection, 'getJob').mockResolvedValue({ enabled: true });
       vi.spyOn(settingsCollection, 'getSettings').mockResolvedValue({
-        modChannelId: 'mod-channel',
+        autoModChannelId: 'mod-channel',
       });
       vi.spyOn(discordService, 'getTextChannel').mockResolvedValue({
         send: vi.fn().mockResolvedValue(undefined),

--- a/src/jobs/invite-cleaner/invite-cleaner.job.ts
+++ b/src/jobs/invite-cleaner/invite-cleaner.job.ts
@@ -143,7 +143,7 @@ class InviteCleanerJob
     if (stats.cleanedInvites === 0 && stats.failedCleanups === 0) return;
 
     const settings = await this.settingsCollection.getSettings(guildId);
-    if (!settings?.modChannelId) return;
+    if (!settings?.autoModChannelId) return;
 
     const embed = new EmbedBuilder()
       .setTitle(':broom: Invite Cleanup :broom:')
@@ -162,7 +162,7 @@ class InviteCleanerJob
 
     const channel = await this.discordService.getTextChannel({
       guildId,
-      channelId: settings.modChannelId,
+      channelId: settings.autoModChannelId,
     });
 
     return await channel?.send({ embeds: [embed] });

--- a/src/slash-commands/blacklist/commands/handlers/blacklist-search.command-handler.ts
+++ b/src/slash-commands/blacklist/commands/handlers/blacklist-search.command-handler.ts
@@ -23,12 +23,12 @@ class BlacklistSearchCommandHandler
 
   async execute({ signup, guildId }: BlacklistSearchCommand) {
     const settings = await this.settingsCollection.getSettings(guildId);
-    if (!settings?.modChannelId) {
-      this.logger.warn(`No mod channel set for guild ${guildId}`);
+    if (!settings?.autoModChannelId) {
+      this.logger.warn(`No auto-mod channel set for guild ${guildId}`);
       return;
     }
 
-    const { modChannelId, reviewChannel } = settings;
+    const { autoModChannelId, reviewChannel } = settings;
 
     // search to see if the signup is in the blacklist
     const match = await this.blacklistCollection.search({
@@ -41,7 +41,7 @@ class BlacklistSearchCommandHandler
 
     const channel = await this.discordService.getTextChannel({
       guildId,
-      channelId: modChannelId,
+      channelId: autoModChannelId,
     });
 
     const embed = await this.createBlacklistEmbed(match, signup, {

--- a/src/slash-commands/blacklist/events/handlers/blacklist-updated.event-handler.ts
+++ b/src/slash-commands/blacklist/events/handlers/blacklist-updated.event-handler.ts
@@ -20,11 +20,11 @@ class BlacklistUpdatedEventHandler
   }: BlacklistUpdatedEvent) {
     const settings = await this.settingsCollection.getSettings(guildId);
 
-    if (!settings?.modChannelId) {
+    if (!settings?.autoModChannelId) {
       return;
     }
 
-    const { modChannelId } = settings;
+    const { autoModChannelId } = settings;
 
     const toFrom = type === 'added' ? 'to' : 'from';
     const displayName = await getDisplayName(this.discordService, {
@@ -66,7 +66,7 @@ class BlacklistUpdatedEventHandler
       .addFields(fields);
 
     const channel = await this.discordService.getTextChannel({
-      channelId: modChannelId,
+      channelId: autoModChannelId,
       guildId,
     });
 

--- a/src/slash-commands/settings/settings.slash-command.ts
+++ b/src/slash-commands/settings/settings.slash-command.ts
@@ -28,7 +28,7 @@ export const EditChannelsSubcommand = new SlashCommandSubcommandBuilder()
   .addChannelOption((option) =>
     option
       .setName('moderation-channel')
-      .setDescription('The channel to send moderation messages to')
+      .setDescription('The channel to send automatic moderation messages to')
       .addChannelTypes(ChannelType.GuildText)
       .setRequired(false),
   );

--- a/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.spec.ts
@@ -27,12 +27,12 @@ describe('Edit Channels Command Handler', () => {
     const guildId = '12345';
     const reviewChannelId = '67890';
     const signupChannelId = '09876';
-    const modChannelId = '54321';
+    const autoModChannelId = '54321';
 
     const existingSettings = {
       reviewChannel: 'old-review',
       signupChannel: 'old-signup',
-      modChannelId: 'old-mod',
+      autoModChannelId: 'old-mod',
     };
 
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
@@ -48,7 +48,7 @@ describe('Edit Channels Command Handler', () => {
               case 'signup-public-channel':
                 return createMock({ id: signupChannelId });
               case 'moderation-channel':
-                return createMock({ id: modChannelId });
+                return createMock({ id: autoModChannelId });
               default:
                 return null;
             }
@@ -63,7 +63,7 @@ describe('Edit Channels Command Handler', () => {
       expect.objectContaining({
         reviewChannel: reviewChannelId,
         signupChannel: signupChannelId,
-        modChannelId: modChannelId,
+        autoModChannelId: autoModChannelId,
       }),
     );
   });

--- a/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.ts
@@ -25,7 +25,8 @@ export class EditChannelsCommandHandler
       const signupChannel = interaction.options.getChannel(
         'signup-public-channel',
       );
-      const modChannelId = interaction.options.getChannel('moderation-channel');
+      const autoModChannelId =
+        interaction.options.getChannel('moderation-channel');
 
       const settings = await this.settingsCollection.getSettings(
         interaction.guildId,
@@ -35,7 +36,7 @@ export class EditChannelsCommandHandler
         ...settings,
         reviewChannel: reviewChannel?.id,
         signupChannel: signupChannel?.id,
-        modChannelId: modChannelId?.id,
+        autoModChannelId: autoModChannelId?.id,
       });
 
       await interaction.editReply('Channel settings updated!');

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
@@ -55,7 +55,7 @@ class ViewSettingsCommandHandler
     }
 
     const {
-      modChannelId,
+      autoModChannelId,
       progRoles,
       clearRoles,
       reviewChannel,
@@ -71,8 +71,8 @@ class ViewSettingsCommandHandler
 
     const fields = [
       {
-        name: 'Moderation Channel',
-        value: formatChannel(modChannelId),
+        name: 'Auto-Moderation Channel',
+        value: formatChannel(autoModChannelId),
         inline: true,
       },
       {


### PR DESCRIPTION
## Summary
• Renamed `modChannelId` to `autoModChannelId` throughout the codebase for better clarity
• Updated slash command descriptions to specify "automatic moderation messages"
• Changed settings display from "Moderation Channel" to "Auto-Moderation Channel"
• Updated log messages and documentation to reflect the new naming

## Test plan
- [x] All TypeScript type checks pass
- [x] All 185 tests pass
- [x] Linting and formatting checks pass
- [x] No remaining instances of old `modChannelId` references

🤖 Generated with [Claude Code](https://claude.ai/code)