### PR TITLE
refactor: remove deprecated partyType field from SignupDocument

### DIFF
--- a/src/fflogs/fflogs.service.ts
+++ b/src/fflogs/fflogs.service.ts
@@ -11,12 +11,12 @@ import {
 } from 'rxjs';
 import { getErrorMessage } from '../common/error-guards.js';
 import type { Encounter } from '../encounters/encounters.consts.js';
-import { isEncounterRankings } from './types.js';
 import { FFLOGS_REPORT_MAX_AGE_DAYS } from '../slash-commands/signup/signup.consts.js';
 import { EncounterIds, expiredReportError } from './fflogs.consts.js';
 import { InjectFFLogsSDKClient } from './fflogs.decorators.js';
 import type { FFLogsSDKClient } from './fflogs.interfaces.js';
 import type { EncounterRankingsQueryVariables } from './graphql/sdk.js';
+import { isEncounterRankings } from './types.js';
 
 @Injectable()
 class FFLogsService {

--- a/src/firebase/models/signup.model.ts
+++ b/src/firebase/models/signup.model.ts
@@ -35,8 +35,6 @@ export interface SignupDocument {
   progPointRequested: string;
   // the party type we determined they should be
   partyStatus?: PartyStatus;
-  /** @deprecated */
-  partyType?: PartyStatus;
   // discordId of the user that reviewed this signup
   reviewedBy?: string | null;
   // the message id of the review message posted to discord

--- a/src/slash-commands/signup/events/handlers/send-approved-message.event-handler.ts
+++ b/src/slash-commands/signup/events/handlers/send-approved-message.event-handler.ts
@@ -60,9 +60,7 @@ class SendApprovedMessageEventHandler
       return;
     }
 
-    const hasCleared =
-      signup.partyStatus === PartyStatus.Cleared ||
-      signup.partyType === PartyStatus.Cleared;
+    const hasCleared = signup.partyStatus === PartyStatus.Cleared;
 
     const content = this.getMessageContent(hasCleared, signup.encounter);
 

--- a/src/slash-commands/signup/signup.service.ts
+++ b/src/slash-commands/signup/signup.service.ts
@@ -9,7 +9,6 @@ import * as Sentry from '@sentry/nestjs';
 import { SentryTraced } from '@sentry/nestjs';
 import {
   ActionRowBuilder,
-  ButtonBuilder,
   DiscordjsErrorCodes,
   Embed,
   EmbedBuilder,
@@ -19,8 +18,8 @@ import {
   MessageReaction,
   type PartialMessage,
   type PartialMessageReaction,
-  StringSelectMenuBuilder,
   type PartialUser,
+  StringSelectMenuBuilder,
   User,
 } from 'discord.js';
 import {

--- a/src/slash-commands/signup/signup.utils.spec.ts
+++ b/src/slash-commands/signup/signup.utils.spec.ts
@@ -61,16 +61,11 @@ describe('shouldDeleteReviewMessageForSignup', () => {
 
 describe('hasClearedStatus', () => {
   test.each([
-    [true, 'partyType is Cleared', PartyStatus.Cleared, PartyStatus.ProgParty],
-    [
-      true,
-      'partyStatus is Cleared',
-      PartyStatus.ProgParty,
-      PartyStatus.Cleared,
-    ],
-    [false, 'neither is Cleared', PartyStatus.ProgParty, PartyStatus.ProgParty],
-  ])('should return %s when %s', (expected, _, partyType, partyStatus) => {
-    const signup = { partyType, partyStatus };
+    [true, 'partyStatus is Cleared', PartyStatus.Cleared],
+    [false, 'partyStatus is not Cleared', PartyStatus.ProgParty],
+    [false, 'partyStatus is undefined', undefined],
+  ])('should return %s when %s', (expected, _, partyStatus) => {
+    const signup = { partyStatus };
     expect(hasClearedStatus(signup)).toBe(expected);
   });
 });

--- a/src/slash-commands/signup/signup.utils.ts
+++ b/src/slash-commands/signup/signup.utils.ts
@@ -14,12 +14,9 @@ export function shouldDeleteReviewMessageForSignup({ status }: SignupDocument) {
 }
 
 export function hasClearedStatus({
-  partyType,
   partyStatus,
-}: Pick<SignupDocument, 'partyStatus' | 'partyType'>) {
-  return (
-    partyType === PartyStatus.Cleared || partyStatus === PartyStatus.Cleared
-  );
+}: Pick<SignupDocument, 'partyStatus'>) {
+  return partyStatus === PartyStatus.Cleared;
 }
 
 /**

--- a/src/slash-commands/turboprog/commands/handlers/turbo-prog.command-handler.spec.ts
+++ b/src/slash-commands/turboprog/commands/handlers/turbo-prog.command-handler.spec.ts
@@ -1,7 +1,6 @@
 import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
 import { Encounter } from '../../../../encounters/encounters.consts.js';
-import { SignupCollection } from '../../../../firebase/collections/signup.collection.js';
 import {
   PartyStatus,
   type SignupDocument,
@@ -50,7 +49,6 @@ const searchableCases: Pick<SignupDocument, 'status' | 'partyStatus'>[] = [
 
 describe('TurboProgCommandHandler', () => {
   let handler: TurboProgCommandHandler;
-  let _collection: DeepMocked<SignupCollection>;
   let sheetsService: DeepMocked<SheetsService>;
 
   beforeEach(async () => {
@@ -61,7 +59,6 @@ describe('TurboProgCommandHandler', () => {
       .compile();
 
     handler = fixture.get(TurboProgCommandHandler);
-    _collection = fixture.get(SignupCollection);
     sheetsService = fixture.get(SheetsService);
   });
 
@@ -75,7 +72,6 @@ describe('TurboProgCommandHandler', () => {
       // Include role in the mock to ensure it's used properly in mapSignupToRowData
       const mockSignup = createMock<SignupDocument>({
         ...signup,
-        partyType: undefined,
         role: 'TestRole',
         progPoint: 'TestProgPoint',
         character: 'TestCharacter',
@@ -111,7 +107,6 @@ describe('TurboProgCommandHandler', () => {
     async (signup) => {
       const mockSignup = createMock<SignupDocument>({
         ...signup,
-        partyType: undefined,
         encounter: Encounter.DSR,
         discordId: 'testDiscordId',
       });
@@ -140,7 +135,6 @@ describe('TurboProgCommandHandler', () => {
     async (signup) => {
       const mockSignup = createMock<SignupDocument>({
         ...signup,
-        partyType: undefined,
         encounter: Encounter.DSR,
         discordId: 'testDiscordId',
         character: 'TestCharacter',


### PR DESCRIPTION
## Summary

Removes the deprecated `partyType` field from the `SignupDocument` interface and updates all related code to use only `partyStatus`. The `partyType` field is no longer present in the database and was causing technical debt.

## Changes

- Remove `partyType` field from `SignupDocument` interface
- Update `hasClearedStatus()` function to only check `partyStatus`
- Remove `partyType` fallback check from send-approved-message event handler
- Update all test files to remove `partyType` references
- Fix TypeScript compilation issues

## Benefits

- Eliminates deprecated field usage
- Simplifies signup status checking logic  
- Reduces technical debt
- Improves code clarity by removing unnecessary fallback logic

## Test Plan

- [x] All 262 tests pass
- [x] TypeScript compilation successful
- [x] No regressions in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)