### PR TITLE
feat(encounters): enable multi-select when toggling prog points enablement

### DIFF
--- a/src/encounters/encounters.service.ts
+++ b/src/encounters/encounters.service.ts
@@ -5,7 +5,6 @@ import type {
   ProgPointDocument,
 } from '../firebase/models/encounter.model.js';
 import { PartyStatus } from '../firebase/models/signup.model.js';
-
 import type { ProgPointOption } from './encounters.consts.js';
 import { ThresholdError } from './errors/threshold.error.js';
 

--- a/src/encounters/encounters.service.ts
+++ b/src/encounters/encounters.service.ts
@@ -143,8 +143,10 @@ export class EncountersService {
 
     // If we're trying to deactivate an active prog point, check threshold dependencies
     if (progPoint.active && encounter) {
-      let thresholdType: PartyStatus.ProgParty | PartyStatus.ClearParty | null =
-        null;
+      let thresholdType:
+        | PartyStatus.ProgParty
+        | PartyStatus.ClearParty
+        | undefined;
 
       if (encounter.progPartyThreshold === progPointId) {
         thresholdType = PartyStatus.ProgParty;

--- a/src/encounters/errors/threshold.error.ts
+++ b/src/encounters/errors/threshold.error.ts
@@ -1,0 +1,19 @@
+import { PartyStatus } from '../../firebase/models/signup.model.js';
+
+export class ThresholdError extends Error {
+  constructor(
+    public readonly progPointId: string,
+    public readonly progPointLabel: string,
+    public readonly thresholdType:
+      | PartyStatus.ProgParty
+      | PartyStatus.ClearParty,
+    public readonly encounterId: string,
+  ) {
+    const thresholdName =
+      thresholdType === PartyStatus.ProgParty ? 'Prog Party' : 'Clear Party';
+    super(
+      `Cannot deactivate prog point ${progPointId} - used as ${thresholdName} threshold`,
+    );
+    this.name = 'ThresholdError';
+  }
+}

--- a/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.spec.ts
+++ b/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.spec.ts
@@ -253,7 +253,7 @@ describe('ManageProgPointsCommandHandler', () => {
       expect(buttonInteraction.deferUpdate).toHaveBeenCalled();
       expect(interaction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: 'Select a prog point to toggle between active and inactive:',
+          content: 'Select one or more prog points to toggle between active and inactive:',
         }),
       );
     });
@@ -402,7 +402,7 @@ describe('ManageProgPointsCommandHandler', () => {
       await collectHandler?.(selectInteraction);
 
       expect(interaction.editReply).toHaveBeenCalledWith({
-        content: '❌ Prog point not found.',
+        content: '❌ No prog points found.',
         embeds: [],
         components: [],
       });

--- a/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.spec.ts
+++ b/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.spec.ts
@@ -253,7 +253,8 @@ describe('ManageProgPointsCommandHandler', () => {
       expect(buttonInteraction.deferUpdate).toHaveBeenCalled();
       expect(interaction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: 'Select one or more prog points to toggle between active and inactive:',
+          content:
+            'Select one or more prog points to toggle between active and inactive:',
         }),
       );
     });

--- a/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.ts
+++ b/src/slash-commands/encounters/commands/handlers/manage-prog-points.command-handler.ts
@@ -64,7 +64,6 @@ export class ManageProgPointsCommandHandler
 
   // Type-safe pending operation state for multi-step flows
   private pendingAddOperation: PendingAddOperation | null = null;
-  private pendingEditOperation: PendingAddOperation | null = null;
   private pendingPartyStatusOperation: PendingPartyStatusOperation | null =
     null;
   private pendingReorderOperation: PendingReorderOperation | null = null;
@@ -1316,12 +1315,6 @@ export class ManageProgPointsCommandHandler
       const newLongName = modalSubmission.fields.getTextInputValue('long-name');
 
       // Step 2: Show party status select menu with current status selected
-      this.pendingEditOperation = {
-        progPointId: progPoint.id,
-        longName: newLongName,
-        interaction: modalSubmission,
-        action: 'add',
-      };
 
       await this.showPartyStatusSelect(progPoint.id, newLongName, 'edit');
     } catch (_error) {
@@ -1429,7 +1422,6 @@ export class ManageProgPointsCommandHandler
 
       // Clear pending operations
       this.pendingAddOperation = null;
-      this.pendingEditOperation = null;
       this.pendingPartyStatusOperation = null;
     } catch (error) {
       this.logger.error(

--- a/src/slash-commands/encounters/commands/handlers/manage-prog-points.interfaces.ts
+++ b/src/slash-commands/encounters/commands/handlers/manage-prog-points.interfaces.ts
@@ -8,6 +8,7 @@ import type { ProgPointDocument } from '../../../../firebase/models/encounter.mo
 export const ScreenState = {
   MAIN_MENU: 'main_menu',
   TOGGLE_SELECTION: 'toggle_selection',
+  TOGGLE_CONFIRMATION: 'toggle_confirmation',
   EDIT_SELECTION: 'edit_selection',
   DELETE_SELECTION: 'delete_selection',
   REORDER: 'reorder',
@@ -36,6 +37,12 @@ export interface PendingPartyStatusOperation {
 export interface PendingReorderOperation {
   progPointToMove: string;
   sortedProgPoints: ProgPointDocument[];
+}
+
+export interface PendingToggleOperation {
+  selectedProgPointIds: string[];
+  progPointsToActivate: ProgPointDocument[];
+  progPointsToDeactivate: ProgPointDocument[];
 }
 
 // Discord.js collector type - uses the actual type returned by createMessageComponentCollector

--- a/src/slash-commands/encounters/commands/handlers/manage-prog-points.interfaces.ts
+++ b/src/slash-commands/encounters/commands/handlers/manage-prog-points.interfaces.ts
@@ -40,7 +40,7 @@ export interface PendingReorderOperation {
 }
 
 export interface PendingToggleOperation {
-  selectedProgPointIds: string[];
+  selectedProgPointIds: Set<string>;
   progPointsToActivate: ProgPointDocument[];
   progPointsToDeactivate: ProgPointDocument[];
 }


### PR DESCRIPTION
- Add multi-select capability to prog point toggle with confirmation flow
- Create ThresholdError class using PartyStatus enum for structured error handling
- Replace generic error messages with actionable threshold-specific guidance
- Maintain backward compatibility with single-selection toggle
- Update tests to match new multi-select behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
