### PR TITLE
feat(signup): add medal.tv support for ff-xiv-online prog proof

### DIFF
--- a/src/slash-commands/signup/signup.consts.ts
+++ b/src/slash-commands/signup/signup.consts.ts
@@ -53,6 +53,7 @@ export const PROG_PROOF_HOSTS_WHITELIST = [
   /streamable.com/,
   /twitch.tv/,
   /youtube.com/,
+  /medal\.tv\/games\/ff-xiv-online/,
 ];
 
 // which makes us need to do this mapping for presentation


### PR DESCRIPTION
## Summary
• Added `https://medal.tv/games/ff-xiv-online` to the allowed signup URLs for prog proof
• Users can now submit Medal.tv clips from FF XIV Online as valid prog proof links

## Test plan
- [ ] Verify Medal.tv FF XIV clips are accepted in signup forms
- [ ] Confirm other Medal.tv game URLs are still rejected
- [ ] Test existing allowed domains still work (fflogs, streamable, twitch, youtube)

🤖 Generated with [Claude Code](https://claude.ai/code)