### PR TITLE
fix(signup): resolve race condition in role assignment

### DIFF
--- a/src/slash-commands/signup/handlers/assign-roles.event-handler.ts
+++ b/src/slash-commands/signup/handlers/assign-roles.event-handler.ts
@@ -31,22 +31,20 @@ class AssignRolesEventHandler implements IEventHandler<SignupApprovedEvent> {
 
     try {
       await match(partyStatus)
-        .with(PartyStatus.ClearParty, () =>
-          Promise.all([
-            this.updateRole({
-              discordId,
-              guildId,
-              action: 'remove',
-              role: progRole,
-            }),
-            this.updateRole({
-              discordId,
-              guildId,
-              role: clearRole,
-              action: 'add',
-            }),
-          ]),
-        )
+        .with(PartyStatus.ClearParty, async () => {
+          await this.updateRole({
+            discordId,
+            guildId,
+            action: 'remove',
+            role: progRole,
+          });
+          await this.updateRole({
+            discordId,
+            guildId,
+            role: clearRole,
+            action: 'add',
+          });
+        })
         .with(PartyStatus.ProgParty, PartyStatus.EarlyProgParty, () =>
           this.updateRole({
             discordId,


### PR DESCRIPTION
## Summary
• Fixed race condition in Discord role assignment during signup approval
• Converted concurrent Promise.all to sequential await calls to prevent conflicts

## Test plan
- [ ] Verify role assignment works correctly for clear party signups
- [ ] Test that prog roles are properly removed before clear roles are added
- [ ] Confirm no Discord API errors occur during role updates

🤖 Generated with [Claude Code](https://claude.ai/code)