### PR TITLE
fix(docker): replace corepack with pnpm standalone installer for Node 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ LABEL fly_launch_runtime="NestJS"
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Used to workaround issues where corepack doesn't know about the pnpm
-# version we are using
-ENV COREPACK_INTEGRITY_KEYS=0
-RUN corepack enable
+RUN wget -qO- https://get.pnpm.io/install.sh | PNPM_VERSION=10.30.1 ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 # Print the pnpm version
 RUN pnpm --version


### PR DESCRIPTION
Corepack is no longer bundled with Node.js 25+. Switch to the pnpm
standalone installer script (get.pnpm.io/install.sh) which is pnpm's
official recommended method for Docker/CI environments independent of
corepack or npm. Pins to pnpm@10.30.1 to match the packageManager field
in package.json. Removes the now-unnecessary COREPACK_INTEGRITY_KEYS env var.