### PR TITLE
docs(architecture): add architecture documentation under docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Architecture Documentation
+
+This directory contains architecture documentation for the **ulti-project** — a Discord bot that manages FFXIV (Final Fantasy XIV) raid group signups, role assignment, and progression tracking.
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [Architecture Overview](./architecture-overview.md) | Big-picture system design: NestJS application context, module graph, CQRS, error handling, and core technology choices |
+| [Slash Commands](./slash-commands.md) | How Discord slash commands are structured, routed, and processed using the CQRS pattern |
+| [Data Layer](./data-layer.md) | Firebase/Firestore collections, document models, caching strategy, and data lifecycle |
+| [Integrations](./integrations.md) | External service integrations: Discord.js client, Google Sheets, and FF Logs GraphQL API |
+| [Scheduled Jobs](./scheduled-jobs.md) | Background cron jobs: clear checking, sheet maintenance, and invite cleanup |
+| [Configuration](./configuration.md) | Environment variables, Zod validation, APPLICATION_MODE, and deployment |
+
+## Quick Start for Developers
+
+See [`CLAUDE.md`](../CLAUDE.md) at the project root for development commands (build, test, lint, etc.).
+
+**Key commands:**
+
+```sh
+pnpm start:dev        # Start bot with hot reload
+pnpm test             # Run tests
+pnpm lint             # Lint with Biome
+pnpm typecheck        # TypeScript type checking
+```
+
+## What the Bot Does
+
+The bot provides Discord-based tooling for organizing FFXIV raid progression groups:
+
+- **Signups** — Players submit signup requests with proof of progression (FF Logs link or screenshot)
+- **Review workflow** — Coordinators review signups via emoji reactions in a dedicated channel; the bot assigns appropriate Discord roles on approval
+- **Sheets sync** — Approved signups are mirrored to Google Sheets for public roster visibility
+- **Clear checking** — A daily job queries FF Logs to automatically remove signups from players who have cleared the encounter
+- **Moderation** — Blacklist management, role cleanup utilities, and audit logging to a mod channel

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,144 @@
+# Architecture Overview
+
+## What the Bot Does
+
+The ulti-project is a Discord bot for managing FFXIV (Final Fantasy XIV) raid group formation. It handles:
+
+1. **Signup intake** — Players submit signup requests via `/signup` with a character, world, job, progression point, and proof link
+2. **Coordinator review** — Coordinators approve or decline signups via emoji reactions on a review embed; the bot assigns Discord roles on approval
+3. **Sheets sync** — Approved signups are mirrored to Google Sheets for public roster visibility
+4. **Automated maintenance** — Daily jobs remove cleared players, clean expired sheet rows, and prune old Discord invites
+
+The bot supports three content modes (`savage`, `ultimate`, `legacy`) which can be run independently or combined. The mode controls which encounter choices and signup options are presented to users.
+
+---
+
+## Why NestJS Application Context (Not HTTP)
+
+The bot is bootstrapped with `NestFactory.createApplicationContext()` rather than the typical `NestFactory.create()` that starts an HTTP server:
+
+```ts
+// src/main.ts
+const app = await NestFactory.createApplicationContext(AppModule, {
+  bufferLogs: true,
+});
+```
+
+**Reasoning:** This application has no REST endpoints — its entire surface area is Discord interactions and scheduled jobs. Using `createApplicationContext` gives us the full NestJS dependency injection container (modules, providers, lifecycle hooks) without spinning up a network listener. It's the right tool for a pure event-driven application that never needs to handle HTTP requests.
+
+---
+
+## Module Graph
+
+The root `AppModule` composes all feature modules:
+
+```mermaid
+graph TD
+    AppModule --> CqrsModule
+    AppModule --> DiscordModule
+    AppModule --> ErrorModule
+    AppModule --> FirebaseModule
+    AppModule --> SheetsModule
+    AppModule --> SlashCommandsModule
+    AppModule --> JobsModule
+    AppModule --> LoggerModule
+
+    SlashCommandsModule --> FirebaseModule
+    SlashCommandsModule --> SheetsModule
+    SlashCommandsModule --> DiscordModule
+    SlashCommandsModule --> FFLogsModule
+
+    JobsModule --> FirebaseModule
+    JobsModule --> SheetsModule
+    JobsModule --> FFLogsModule
+    JobsModule --> DiscordModule
+```
+
+Each module is self-contained with its own providers and exports. `FirebaseModule`, `SheetsModule`, and `DiscordModule` are shared infrastructure modules consumed by both the slash-command handlers and the background jobs.
+
+---
+
+## CQRS Pattern
+
+The bot uses NestJS's built-in CQRS module (`@nestjs/cqrs`) throughout. The key motivations:
+
+- **Separation of intent from side effects** — A command (e.g., `SignupCommand`) represents the user's intent. The handler executes that intent and publishes domain events. Side effects (send review message, assign roles, update sheet) are handled by separate event handlers and sagas — not inline in the command handler.
+- **Testability** — Command handlers and event handlers are plain classes injected with services. Each can be unit tested in isolation by mocking its dependencies.
+- **Async orchestration** — Sagas consume an Observable event stream, making it easy to react to one event by dispatching multiple follow-up commands without coupling the original handler to those concerns.
+
+### Command → Event → Saga Flow
+
+```mermaid
+sequenceDiagram
+    participant Discord
+    participant SlashCommandsService
+    participant CommandBus
+    participant Handler
+    participant EventBus
+    participant Saga
+    participant FollowUpHandler
+
+    Discord->>SlashCommandsService: interactionCreate
+    SlashCommandsService->>CommandBus: execute(command)
+    CommandBus->>Handler: execute()
+    Handler->>EventBus: publish(event)
+    EventBus->>Saga: Observable<IEvent>
+    Saga->>CommandBus: dispatch follow-up commands
+    CommandBus->>FollowUpHandler: execute()
+```
+
+### App-Level Sagas
+
+Cross-cutting workflows are defined in `src/app.sagas.ts`. The four sagas:
+
+| Saga | Trigger | Dispatches |
+|------|---------|------------|
+| `handleSignupCreated` | `SignupCreatedEvent` | `SendSignupReviewCommand` |
+| `handleClearedSignup` | `SignupApprovedEvent` (cleared status) | `RemoveRolesCommand` + `TurboProgRemoveSignupCommand` |
+| `handleSignupRemoved` | `RemoveSignupEvent` | `RemoveRolesCommand` + `TurboProgRemoveSignupCommand` |
+| `handleSignupApprovalSend` | `SignupApprovalSentEvent` | `BlacklistSearchCommand` |
+
+> **Note:** These sagas live at the `AppModule` level because they orchestrate across module boundaries (signup → roles → sheets). The code includes a TODO acknowledging they could eventually move into a more purpose-built saga module.
+
+---
+
+## Technology Stack
+
+| Concern | Technology | Why |
+|---------|-----------|-----|
+| Framework | NestJS 11 | DI container, module system, CQRS, lifecycle hooks |
+| Discord | Discord.js 14 | De-facto standard Node.js Discord library |
+| Database | Firebase Admin / Firestore | Serverless document store; fits guild-scoped config and per-character documents without schema migrations |
+| Sheets sync | Google Sheets API v4 | Coordinators want a public-facing spreadsheet roster independent of Discord |
+| Clear validation | FF Logs GraphQL API | Authoritative source for FFXIV raid clear data |
+| Validation | Zod | Type-safe schema validation at both compile time and runtime for env config and user input |
+| Logging | Pino via `nestjs-pino` | Structured JSON logging in production; pretty-printed in development |
+| Error monitoring | Sentry (`@sentry/nestjs`) | Captures exceptions with full context (command name, guild, user) and performance traces |
+| Linting/Formatting | Biome | Replaces ESLint + Prettier with a single fast tool |
+| Testing | Vitest | Fast, ESM-native test runner compatible with the project's `nodenext` module resolution |
+| Pattern matching | `ts-pattern` | Exhaustive, type-safe match expressions for command routing |
+
+---
+
+## Error Handling Strategy
+
+Errors are handled at three levels:
+
+1. **Per-command** — Each command handler wraps its logic in try/catch. On failure, `ErrorService.handleCommandError()` sends a user-friendly Discord embed to the interaction and logs/captures to Sentry.
+
+2. **Unhandled exceptions** — `AppService` subscribes to the CQRS `UnhandledExceptionBus`. Any exception that escapes a handler is caught here and forwarded to `ErrorService.captureError()` (which logs and sends to Sentry without a Discord reply, since there may be no active interaction).
+
+3. **Discord client errors** — The `DiscordModule` hooks into `client.once('error', ...)` to capture low-level Discord.js errors via Sentry.
+
+All Sentry captures include structured context: command name, guild ID, user ID, and the relevant entity (e.g., the signup document). The `@SentryTraced()` decorator is applied to service methods to create performance spans automatically.
+
+---
+
+## Logging
+
+Structured logging uses Pino:
+- **Development:** `pino-pretty` with `singleLine: true` for readable terminal output
+- **Production:** Raw JSON (no transport), consumed by log aggregation infrastructure
+- **Level:** Controlled by the `LOG_LEVEL` environment variable (default: `info`)
+
+The logger is bootstrapped with `bufferLogs: true` so early startup messages are not lost before the logger is fully initialized.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,121 @@
+# Configuration
+
+## Why Zod for Environment Validation
+
+All configuration is loaded from environment variables and validated at startup using Zod schemas (`src/config/app.ts`, `src/config/firebase.ts`).
+
+**The benefit:** If a required variable is missing or malformed, the process exits immediately with a clear, human-readable error message — before establishing any connections. Without this, the bot might start, connect to Discord, and then crash mid-command when trying to access an undefined config value. Fail-fast at startup is far easier to diagnose than a runtime crash.
+
+Zod also narrows types: after parsing, `appConfig.APPLICATION_MODE` is typed as `('savage' | 'ultimate' | 'legacy')[]` rather than `string`, and `appConfig.DISCORD_REFRESH_COMMANDS` is a `boolean` rather than a string.
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `DISCORD_TOKEN` | string | Discord bot token |
+| `CLIENT_ID` | string | Discord application (bot) client ID |
+| `GCP_ACCOUNT_EMAIL` | string | GCP service account email (used for Firestore + Sheets) |
+| `GCP_PRIVATE_KEY` | string | GCP service account private key |
+| `GCP_PROJECT_ID` | string | GCP project ID |
+
+### Optional
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `APPLICATION_MODE` | `savage\|ultimate\|legacy` (plus-separated) | `ultimate` | Controls which encounters and command options are active. See below. |
+| `DISCORD_REFRESH_COMMANDS` | boolean | `false` | If `true`, re-registers all slash commands with Discord on startup. See below. |
+| `FFLOGS_API_ACCESS_TOKEN` | string | — | Bearer token for FF Logs GraphQL API. If absent, FF Logs integration is disabled. |
+| `FIRESTORE_DATABASE_ID` | string | — | Named Firestore database (defaults to the project's default database). |
+| `LOG_LEVEL` | `debug\|info\|warn\|error\|silent\|fatal` | `info` | Pino log level. |
+| `NODE_ENV` | `development\|production\|test` | `development` | Affects log formatting (pretty-print vs JSON) and may affect other environment-specific behavior. |
+
+---
+
+## APPLICATION_MODE
+
+This variable controls which raid content the bot is configured for:
+
+```
+APPLICATION_MODE=ultimate            # Single mode
+APPLICATION_MODE=savage+ultimate     # Multiple modes combined
+APPLICATION_MODE=savage+ultimate+legacy
+```
+
+**What it affects:**
+- Which encounter choices appear in `/signup` and other commands
+- Which encounter-specific command options are registered with Discord
+
+**Why a runtime flag rather than separate bots?** Some communities run multiple content types (e.g., both Savage and Ultimate progression groups) in the same Discord server. A single bot instance can serve all of them. Separate deployments can be used for servers that only need one mode.
+
+The `+` separator was chosen over commas because some deployment environments (particularly Docker/Fly.io) have issues passing comma-containing values through environment variable expansion.
+
+**Default:** `ultimate` — the original use case this bot was built for.
+
+---
+
+## DISCORD_REFRESH_COMMANDS
+
+When `true`, the bot registers (or re-registers) all slash commands with Discord's API on startup via a bulk HTTP request. Discord caches slash command definitions; this flag forces a refresh.
+
+**When to use `true`:**
+- After adding, removing, or changing any slash command definitions or options
+- When setting up a new bot instance
+
+**Why default `false`:**
+- Discord rate-limits command registration. Refreshing on every startup would hit this limit in normal production operation.
+- Discord propagates command updates globally within minutes — there's no need to refresh unless the definitions actually changed.
+
+---
+
+## Deployment
+
+### Docker
+
+A `Dockerfile` is included at the project root. The typical build and run:
+
+```sh
+docker build -t ulti-project .
+docker run --env-file .env ulti-project
+```
+
+### Fly.io
+
+A `fly.toml` is included for deployment to [Fly.io](https://fly.io). The bot runs as a persistent VM (not a serverless function) — necessary because it maintains a persistent WebSocket connection to Discord.
+
+Key considerations for Fly.io deployment:
+- Set all environment variables as Fly secrets (`fly secrets set KEY=value`)
+- The bot has no HTTP port to expose; configure Fly to run it as a background worker
+
+### Local Development
+
+```sh
+cp .env.example .env   # fill in required variables
+pnpm start:dev         # hot reload via ts-node-dev
+```
+
+For local development with Sentry instrumentation:
+```sh
+pnpm start:dev:sentry
+```
+
+---
+
+## Config Module Structure
+
+```
+src/config/
+├── app.ts       # Main app config (Discord, GCP, FF Logs, mode, logging)
+└── firebase.ts  # Firebase-specific config (FIRESTORE_DATABASE_ID)
+```
+
+Both files export a typed config object parsed at module load time:
+
+```ts
+export const appConfig = appSchema.parse(process.env);
+```
+
+This means config is a plain object — no `ConfigService` injection needed. Any module can import `appConfig` directly. This is intentional: it avoids the extra indirection of NestJS's `ConfigModule` for a use case where the config is fully known at startup and doesn't need to vary per-request.

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -1,0 +1,174 @@
+# Data Layer
+
+## Why Firestore
+
+The application uses Firebase Admin SDK / Firestore as its primary data store. Key reasons for this choice:
+
+- **Serverless, no infrastructure to manage** — No database server to provision, patch, or scale. Firestore scales automatically and fits a Discord bot's bursty, low-volume access pattern.
+- **Document model fits the domain** — Each Discord guild is isolated; settings and signups are naturally scoped per-guild. The document model avoids the relational join complexity that would arise from a SQL schema.
+- **Per-character signups** — Each signup is one document; there's no need for complex relational queries. Firestore's `where()` chaining is sufficient.
+- **Firebase Admin + GCP** — The bot already uses GCP service accounts for Google Sheets, so sharing GCP credentials with Firestore avoids introducing a second auth provider.
+
+---
+
+## Collections
+
+The `FirebaseModule` (`src/firebase/firebase.module.ts`) initializes Firestore and exports five collection services:
+
+| Collection | Service Class | Purpose |
+|------------|--------------|---------|
+| `signups` | `SignupCollection` | One document per player per encounter |
+| `settings` | `SettingsCollection` | Guild-level bot configuration |
+| `blacklist` | `BlacklistCollection` | Players blocked from signing up |
+| `jobs` | `JobCollection` | Per-guild cron job enable/disable flags |
+| `encounters` | `EncountersCollection` | Encounter definitions with prog points and party thresholds |
+
+---
+
+## SignupDocument
+
+**Path:** `src/firebase/models/signup.model.ts`
+
+```ts
+interface SignupDocument {
+  character: string;
+  discordId: string;
+  encounter: Encounter;
+  username: string;
+  world: string;
+  role: string;               // freeform job/class field
+  progPointRequested: string; // submitted by the player
+  progPoint?: string;         // assigned by the coordinator on review
+  partyStatus?: PartyStatus;  // EarlyProgParty | ProgParty | ClearParty | Cleared
+  status: SignupStatus;
+  reviewedBy?: string | null; // discordId of coordinator
+  reviewMessageId?: string;   // Discord message ID of the review embed
+  proofOfProgLink?: string | null;
+  screenshot?: string | null; // Discord CDN URL (expires after ~2 weeks)
+  notes?: string | null;
+  declineReason?: string;
+  expiresAt: Timestamp;       // 28 days from last upsert
+}
+```
+
+### Status State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : upsert (new)
+    PENDING --> PENDING : re-upsert while PENDING
+    PENDING --> APPROVED : coordinator approves
+    PENDING --> DECLINED : coordinator declines
+    APPROVED --> UPDATE_PENDING : player re-submits
+    DECLINED --> UPDATE_PENDING : player re-submits
+    UPDATE_PENDING --> APPROVED : coordinator re-approves
+    UPDATE_PENDING --> DECLINED : coordinator re-declines
+```
+
+**Why `UPDATE_PENDING`?** When a player re-submits a signup that was previously reviewed, simply reverting to `PENDING` would mix re-submissions with fresh signups in a coordinator's queue and lose the context that this is a revision. `UPDATE_PENDING` signals coordinators that this needs fresh attention.
+
+### Composite Key Design
+
+**Path:** `src/firebase/collections/signup.collection.ts`
+
+```ts
+static getKeyForSignup({ discordId, encounter }: SignupCompositeKey) {
+  return `${discordId.toLowerCase()}-${encounter}`;
+}
+```
+
+The document ID is `{discordId}-{encounter}` (e.g., `123456789-TOP`). This enforces **one signup per player per encounter** at the database level — upserts always hit the same document, making idempotency free. It also makes direct document lookups O(1) without needing a query.
+
+`discordId` is lowercased to guard against any case inconsistency at the call sites.
+
+### TTL (Expiry)
+
+Each signup has an `expiresAt` Timestamp set to 28 days from the last upsert. Firestore's TTL feature can be configured to automatically delete expired documents. This prevents stale signups from accumulating indefinitely without requiring explicit cleanup logic in the application.
+
+---
+
+## SettingsDocument
+
+**Path:** `src/firebase/models/settings.model.ts`
+
+Stores all guild-level bot configuration in a single document (document ID = guild ID):
+
+- **Channel IDs** — `reviewChannel`, `signupChannel`, `autoModChannelId`
+- **Role IDs** — `reviewerRole` (gate for who can approve signups)
+- **Per-encounter role maps** — `progRoles: Record<Encounter, string>`, `clearRoles: Record<Encounter, string>` — Discord role IDs to assign upon approval
+- **Spreadsheet IDs** — `spreadsheetId` (signup roster), `turboProgSpreadsheetId`
+
+### In-Memory Cache
+
+`SettingsCollection` maintains a `Map<string, SettingsDocument>` cache keyed by `settings:{guildId}`:
+
+```ts
+private readonly cache = new Map<string, unknown>();
+private cacheKey = (guildId: string) => `settings:${guildId}`;
+```
+
+**Why cache?** Settings are read on virtually every command execution (to find the review channel, check reviewer role, get spreadsheet ID). Without caching, each interaction would incur a Firestore read. Settings rarely change — coordinators update them infrequently — so a write-through cache (invalidated on `upsert()`) is a good trade-off.
+
+**Cache invalidation:** After any `upsert()`, the cache is synchronously refreshed from Firestore. On a cache-update failure, the key is deleted (forcing the next read to hit Firestore) rather than serving stale data.
+
+---
+
+## BlacklistDocument
+
+**Path:** `src/firebase/models/blacklist.model.ts`
+
+Simple document per blacklisted player:
+
+```ts
+interface BlacklistDocument {
+  characterName: string;
+  discordId: string;
+  reason?: string;
+  lodestoneId?: string;
+}
+```
+
+Used to surface blacklist status in `/lookup` and to run a background check after every signup approval (`BlacklistSearchCommand` dispatched by `handleSignupApprovalSend` saga).
+
+---
+
+## EncountersCollection
+
+Stores encounter definitions dynamically in Firestore rather than hardcoding them. Each document represents one encounter (e.g., TOP, DSR) with:
+
+- `name`, `description`, `active`
+- `progPartyThreshold`, `clearPartyThreshold` — min signups to form a prog vs. clear party
+- `ProgPointDocuments` — the list of valid prog points for that encounter
+
+This allows coordinators to manage encounters and their prog points via the `/encounters` slash command without requiring a code deployment.
+
+---
+
+## JobCollection
+
+Stores per-guild feature flags for background jobs. Each job (clear-checker, sheet-cleaner, invite-cleaner) reads this collection at runtime to determine whether it is enabled for a given guild. This lets operators enable/disable maintenance jobs per server without configuration redeployment.
+
+---
+
+## Firestore Initialization
+
+```ts
+// src/firebase/firebase.module.ts
+initializeApp({
+  credential: cert({
+    clientEmail: appConfig.GCP_ACCOUNT_EMAIL,
+    privateKey: appConfig.GCP_PRIVATE_KEY,
+    projectId: appConfig.GCP_PROJECT_ID,
+  }),
+});
+
+const firestore = firebaseConfig.FIRESTORE_DATABASE_ID
+  ? getFirestore(app, firebaseConfig.FIRESTORE_DATABASE_ID)
+  : getFirestore(app);
+
+firestore.settings({ ignoreUndefinedProperties: true });
+```
+
+`ignoreUndefinedProperties: true` prevents Firestore from throwing when a document field is `undefined` (TypeScript optional fields). Without this, every optional field would need explicit `null` coercion before writing.
+
+The optional `FIRESTORE_DATABASE_ID` supports running multiple named Firestore databases in the same GCP project (e.g., a staging database separate from production).

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,186 @@
+# Integrations
+
+## Discord.js
+
+**Module:** `src/discord/discord.module.ts`
+**Service:** `src/discord/discord.service.ts`
+
+### Client Setup
+
+The Discord.js `Client` is created in `DiscordModule` with carefully chosen intents and partials. Only the intents the bot actually needs are enabled — Discord.js will throw if you request data from an intent not declared at connection time, and unnecessary intents increase the event volume the process receives.
+
+### Memory Management
+
+Discord.js caches guild data in-process by default. For a bot that may be in many guilds, uncontrolled caching can become a memory problem. The module disables or limits several caches:
+
+```ts
+// Caches entirely disabled (bot doesn't use these)
+makeCache: Options.cacheWithLimits({
+  PresenceManager: 0,          // Presence updates not used
+  DMMessageManager: 0,         // DMs not used
+  GuildTextThreadManager: 0,   // Threads not used
+})
+```
+
+**Sweepers** run on intervals to evict stale entries from caches that are kept:
+
+| Cache | Interval | Condition |
+|-------|----------|-----------|
+| Guild members | 2 hours | Not bot itself |
+| Messages | 12-hour lifetime | All messages |
+| Reactions | 2 hours | All reactions |
+| Users | 2 hours | Not bot itself |
+
+**Why sweepers?** Discord.js's default behavior retains every member/message seen for the lifetime of the process. For a long-running bot, this is an unbounded memory leak. Sweeping periodically bounds the memory footprint.
+
+### Graceful Shutdown
+
+On `onApplicationShutdown`, the module calls `client.removeAllListeners()`. This ensures event listeners don't fire against a destroyed client during NestJS's shutdown sequence, avoiding unhandled-rejection noise in logs.
+
+### DiscordService Utilities
+
+`DiscordService` provides commonly needed Discord operations used across multiple command handlers:
+
+| Method | Purpose |
+|--------|---------|
+| `getGuildMember()` | Fetch a guild member with error handling |
+| `sendDirectMessage()` | DM a user |
+| `getTextChannel()` | Fetch a text-based channel |
+| `getDisplayName()` | Get member's display name |
+| `userHasRole()` | Check if a member has a role |
+| `removeRole()` | Bulk-remove a role from members (50 concurrent) |
+| `retireRole()` | Swap one role for another across members (5 concurrent) |
+| `getGuildInvites()` | Fetch all guild invites |
+
+Concurrency limits on bulk operations (`p-limit` / `mergeMap` with max concurrent) prevent hitting Discord's rate limits when operating on large guilds.
+
+---
+
+## Google Sheets
+
+**Module:** `src/sheets/sheets.module.ts`
+**Service:** `src/sheets/sheets.service.ts`
+
+### Purpose
+
+Google Sheets serves as a **public-facing view** of signup rosters. Firestore is the authoritative source of truth; Sheets is a presentation layer that coordinators and players can view without Discord access. Coordinators also use the sheets to manage party composition visually.
+
+### Why Sheets in Addition to Firestore?
+
+The signup workflow predates this bot — coordinators were already using Sheets to manage raids. The bot integrates with that existing workflow rather than replacing it. Sheets also provides a familiar tabular interface for managing large numbers of signups across multiple encounters.
+
+### Authentication
+
+The Sheets client authenticates using a GCP service account (same credentials as Firestore):
+
+```ts
+const auth = new google.auth.GoogleAuth({
+  credentials: {
+    client_email: appConfig.GCP_ACCOUNT_EMAIL,
+    private_key: appConfig.GCP_PRIVATE_KEY,
+  },
+  scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+});
+```
+
+### Party Type Routing
+
+Signups are written to different sheet tabs based on their `partyStatus`:
+
+| `PartyStatus` | Sheet Tab |
+|--------------|-----------|
+| `EarlyProgParty` | Early Prog Party |
+| `ProgParty` | Prog Party |
+| `ClearParty` | Clear Party |
+| `Cleared` | Removed from sheets |
+
+When a signup transitions to `Cleared`, the character is deleted from whatever sheet they were on.
+
+### AsyncQueue for Serialized Writes
+
+`SheetsService` uses a custom `AsyncQueue` (`src/common/async-queue/async-queue.ts`) backed by RxJS `concatMap` to serialize writes to each party-type sheet:
+
+```ts
+private readonly partyQueues = new Map<PartyStatus, AsyncQueue>();
+```
+
+**Why serialize?** Google Sheets API does not support concurrent writes to the same spreadsheet safely. If two signups arrive simultaneously and both try to append a row, the second write can corrupt the sheet state (overwrite the first row, produce gaps, or fail entirely). The queue ensures writes are processed one at a time per party type, with a separate queue for TurboProg sheets.
+
+---
+
+## FF Logs GraphQL API
+
+**Module:** `src/fflogs/fflogs.module.ts`
+**Service:** `src/fflogs/fflogs.service.ts`
+
+### Purpose
+
+FF Logs is the authoritative FFXIV raid logging platform. The integration serves two functions:
+
+1. **Proof validation on signup** — When a player submits an FF Logs report URL as their prog proof, the bot verifies the report is recent (not older than the configured max age). This prevents players from submitting stale or irrelevant logs.
+2. **Clear checking** — A nightly job queries FF Logs to detect whether signed-up players have cleared the encounter since their signup, automatically removing them from the queue.
+
+### Authentication
+
+FF Logs uses a client credentials OAuth2 flow. The bot authenticates with a Bearer token (`FFLOGS_API_ACCESS_TOKEN` env var). If this token is not configured, FF Logs features degrade gracefully (validation is skipped, clear checking is not run).
+
+### GraphQL SDK
+
+The GraphQL client is generated from the FF Logs schema (`schema.graphql`) via `pnpm graphql:codegen`. This produces a typed SDK, so all queries and their responses are fully type-safe. The underlying HTTP transport is `graphql-request`.
+
+### Encounter ID Mapping
+
+FF Logs identifies fights by numeric encounter IDs, and FFXIV patches sometimes change these IDs as content is updated. The `FFLOGS_ENCOUNTER_IDS` map (`src/fflogs/fflogs.consts.ts`) maps each encounter name to an array of known IDs:
+
+```ts
+// Example: TOP has two known encounter IDs (different patch versions)
+TOP: [1068, 1077]
+```
+
+When checking for a clear, the service queries all known IDs for the encounter concurrently (up to 5 at a time via `mergeMap`) and returns `true` on the first successful result.
+
+### Observable-Based Clear Check
+
+```mermaid
+flowchart LR
+    A[encounterIds array] -->|mergeMap, 5 concurrent| B[FFLogs API query per ID]
+    B --> C{totalKills > 0?}
+    C -->|Yes| D[emit true, cancel remaining]
+    C -->|No| E[continue]
+    E --> F{all done?}
+    F -->|yes, all false| G[emit false]
+```
+
+**Why RxJS Observables?** The concurrent query pattern (fan-out, take-first-truthy) maps naturally to `mergeMap` + `first()`. With Promises this would require `Promise.any()` with manual cancellation; RxJS handles both automatically via `takeWhile` or `first` operators.
+
+### Report Age Validation
+
+`validateReportAge()` queries the FF Logs API for a report's `endTime` (the timestamp of the last recorded pull, not the first) and compares it against the configured `FFLOGS_REPORT_MAX_AGE_DAYS`:
+
+```ts
+// endTime is used, not startTime
+// A report from 3 months ago that was recently re-parsed still fails validation
+```
+
+Using `endTime` means a report is considered current based on when the actual play session ended, not when the log was created.
+
+The method returns a structured result:
+
+```ts
+{ isValid: boolean; errorMessage?: string; reportDate?: Date }
+```
+
+If the FF Logs API is unreachable, the handler catches the error, logs it, and allows the signup to proceed (fail open). This is a deliberate trade-off: a transient API outage should not block legitimate signups.
+
+---
+
+## Authentication Summary
+
+| Service | Auth Method | Credentials |
+|---------|------------|-------------|
+| Discord | Bot token | `DISCORD_TOKEN` env var |
+| Firestore | GCP service account | `GCP_ACCOUNT_EMAIL` + `GCP_PRIVATE_KEY` + `GCP_PROJECT_ID` |
+| Google Sheets | GCP service account (same) | Same GCP credentials |
+| FF Logs | Bearer token | `FFLOGS_API_ACCESS_TOKEN` env var |
+
+All credentials are loaded at startup via Zod-validated environment variables. If required credentials are missing, the process fails fast with a descriptive error before connecting to Discord.

--- a/docs/scheduled-jobs.md
+++ b/docs/scheduled-jobs.md
@@ -1,0 +1,144 @@
+# Scheduled Jobs
+
+## Overview
+
+The `JobsModule` (`src/jobs/jobs.module.ts`) hosts three background cron jobs that run daily to maintain the integrity of the signup system. Each job:
+
+- Implements `OnApplicationBootstrap` and `OnApplicationShutdown` for clean lifecycle management
+- Reads per-guild enable/disable flags from `JobCollection` in Firestore — so each guild can opt in/out without affecting others
+- Uses RxJS streams internally for concurrent processing
+- Posts a summary embed to each guild's `autoModChannelId` after running
+
+```mermaid
+gantt
+    title Daily Job Schedule (approximate)
+    dateFormat HH:mm
+    section Jobs
+    Clear Checker   :03:00, 1h
+    Sheet Cleaner   :04:00, 1h
+    Invite Cleaner  :05:00, 30m
+```
+
+---
+
+## CronTime DSL
+
+Jobs use a fluent DSL (`src/common/cron.ts`) rather than raw cron strings:
+
+```ts
+CronTime.everyDay().at(3)        // '0 0 3 * * *'
+CronTime.everyDay().at(4, 30)    // '0 30 4 * * *'
+CronTime.everyHour().at(30)      // '0 30 * * * *'
+CronTime.everyWeek().on(0).at(12) // '0 0 12 * * 0'
+```
+
+**Why a DSL?** Raw cron expressions are error-prone to read and write (the difference between `0 3 * * *` and `0 0 3 * * *` is significant and hard to spot). The DSL is self-documenting and prevents common field-ordering mistakes.
+
+---
+
+## Clear Checker Job
+
+**Path:** `src/jobs/clear-checker/clear-checker.job.ts`
+**Schedule:** Daily at 3 AM
+
+### Purpose
+
+Automatically removes signups from players who have cleared the encounter since they signed up, freeing their slot for other players without requiring manual coordinator action.
+
+### Flow
+
+```mermaid
+flowchart TD
+    A[Job triggers] --> B[Get guilds with clear-checker enabled]
+    B --> C[For each guild: get signups + active encounters]
+    C --> D[For each signup: query FF Logs]
+    D -->|cleared| E[Delete from Firestore]
+    E --> F[Delete from Google Sheets]
+    F --> G[Emit RemoveSignupEvent]
+    G --> H[Saga: RemoveRolesCommand + TurboProgRemoveSignupCommand]
+    D -->|not cleared| I[Skip]
+    C --> J[Post summary embed to mod channel]
+```
+
+FF Logs queries run with up to 5 concurrent requests per guild (via `mergeMap` concurrency control) to respect API rate limits while still processing quickly.
+
+The `RemoveSignupEvent` is published through the CQRS event bus, which triggers the saga to dispatch role removal and TurboProg sheet cleanup. This reuses the exact same side-effect logic as the `/remove-signup` command — no duplication.
+
+### Graceful Degradation
+
+If the FF Logs API is unavailable, the job logs the error and skips clear-checking for that run. Signups are not removed if their clear status cannot be confirmed.
+
+---
+
+## Sheet Cleaner Job
+
+**Path:** `src/jobs/sheet-cleaner/sheet-cleaner.job.ts`
+**Schedule:** Daily at 4 AM
+
+### Purpose
+
+Removes rows from Google Sheets for signups that no longer exist in Firestore (e.g., expired via TTL, manually removed, or cleaned up by the clear checker). Prevents the sheets from accumulating orphaned rows.
+
+### Flow
+
+```mermaid
+flowchart TD
+    A[Job triggers] --> B[Get guilds with sheet-cleaner enabled]
+    B --> C[Get active encounters from Firestore]
+    C --> D[For each encounter: SheetsService.cleanSheet]
+    D --> E[Compare sheet rows vs active Firestore signups]
+    E --> F[Delete orphaned rows]
+    B --> G[Post summary to mod channel]
+```
+
+**Sequential processing with `concatMap`:** Each encounter's sheet is cleaned one at a time (sequentially) rather than in parallel. This prevents concurrent writes from corrupting the spreadsheet — the same reason `SheetsService` uses an `AsyncQueue` for normal signup writes.
+
+### Dynamic Encounters
+
+The job fetches the list of active encounters from `EncountersCollection` at runtime rather than using a hardcoded list. As coordinators add or retire encounters via `/encounters`, the sheet cleaner automatically adapts.
+
+---
+
+## Invite Cleaner Job
+
+**Path:** `src/jobs/invite-cleaner/invite-cleaner.job.ts`
+**Schedule:** Daily at 5 AM
+
+### Purpose
+
+Deletes Discord guild invites older than 14 days. Prevents invite link accumulation when coordinators create temporary invites to onboard new members.
+
+### Flow
+
+```mermaid
+flowchart TD
+    A[Job triggers] --> B[Get guilds with invite-cleaner enabled]
+    B --> C[Fetch all guild invites]
+    C --> D[Filter: createdTimestamp older than 14 days]
+    D --> E[Delete invites, configurable concurrency]
+    E --> F[Collect stats: cleaned / failed / total]
+    F --> G[Post summary to mod channel]
+```
+
+Invite deletion runs with configurable concurrency (`INVITE_CLEANER_CONCURRENCY` env var) to avoid Discord rate limits.
+
+---
+
+## Per-Guild Enable/Disable
+
+Each job checks `JobCollection` in Firestore before doing any work for a guild. A missing or `false` flag means the job is skipped for that guild. This allows:
+
+- **Phased rollout** — Enable jobs for specific guilds before a full rollout
+- **Opt-out** — Guilds that manage their own cleanup can disable individual jobs
+- **Emergency stop** — A job behaving unexpectedly can be disabled without a deployment
+
+---
+
+## Summary Embeds
+
+After each job run, a summary embed is posted to the guild's `autoModChannelId`. The embed includes:
+- Total entities processed
+- Count of successful operations
+- Count of failures (with reasons where available)
+
+This provides an audit trail of automated actions without requiring coordinators to inspect logs directly.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,164 @@
+# Slash Commands
+
+## Overview
+
+All Discord slash commands live under `src/slash-commands/`. Each command is a self-contained NestJS module following a consistent file convention. The `SlashCommandsModule` imports all individual command modules and registers one interaction listener that dispatches incoming Discord interactions to the appropriate CQRS command handler.
+
+---
+
+## File Conventions
+
+Every command feature follows this three-file pattern:
+
+| File | Role |
+|------|------|
+| `<name>.slash-command.ts` | Discord.js `SlashCommandBuilder` definition — the shape of the command Discord presents to users (name, description, options, permissions) |
+| `commands/<name>.command.ts` | CQRS command class — a plain data-transfer object carrying the `ChatInputCommandInteraction` and any pre-extracted context |
+| `handlers/<name>.command-handler.ts` | CQRS command handler — the business logic (`@CommandHandler(...)` + `execute()`) |
+
+**Why this split?** The slash-command definition file is deliberately kept free of logic — it's a pure Discord API contract. The command class is a lightweight DTO. All meaningful work happens in the handler, which can be unit tested without any Discord or NestJS setup overhead.
+
+Additional files per feature as needed:
+- `<name>.schema.ts` — Zod schema for validating user-supplied input
+- `<name>.module.ts` — NestJS module wiring the handler and any local services
+- `events/<name>.events.ts` — CQRS event class definitions
+- `handlers/<name>.event-handler.ts` — CQRS event handler for side effects
+
+---
+
+## Command List
+
+| Command | Admin Only | Description |
+|---------|-----------|-------------|
+| `/signup` | No | Submit a raid signup with character, world, job, prog point, and proof |
+| `/remove-signup` | No | Remove an existing signup for an encounter |
+| `/status` | No | View your own signup statuses across all encounters |
+| `/help` | No | Display all available commands |
+| `/search` | Yes | Search signups by encounter and prog point (interactive menus) |
+| `/lookup` | Yes | Look up all signups for a player by character name + world, including blacklist status |
+| `/blacklist add/remove/display` | Yes | Manage the list of players blocked from signing up |
+| `/encounters` | Yes | Configure encounter prog points and party size thresholds |
+| `/settings channels/reviewer/encounter-roles/spreadsheet/turbo-prog/view` | Yes (Manage Guild) | Configure bot channels, roles, reviewer gate, and spreadsheet IDs |
+| `/turbo-prog` | No | Submit a lightweight signup for a turbo-prog or final-push event |
+| `/final-push` | No | Alias for `/turbo-prog` — same handler, different command name |
+| `/clean-roles` | Yes | Remove prog/clear roles from members without active signups (supports dry-run) |
+| `/remove-role` | Yes | Bulk remove a specific role from all guild members |
+| `/retire` | Yes | Move members from one role to another (for retiring a raid tier) |
+
+---
+
+## Command Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Discord
+    participant SlashCommandsService
+    participant getCommandForInteraction
+    participant CommandBus
+    participant Handler
+    participant EventBus
+    participant Saga
+
+    User->>Discord: Uses slash command
+    Discord->>SlashCommandsService: interactionCreate (ChatInputCommandInteraction)
+    SlashCommandsService->>getCommandForInteraction: interaction
+    getCommandForInteraction-->>SlashCommandsService: CQRS Command instance
+    SlashCommandsService->>CommandBus: execute(command)
+    CommandBus->>Handler: execute(command)
+    Handler-->>Discord: Reply / deferred reply
+    Handler->>EventBus: publish(DomainEvent)
+    EventBus->>Saga: Observable stream
+    Saga->>CommandBus: follow-up commands
+```
+
+---
+
+## Command Routing
+
+`src/slash-commands/slash-commands.utils.ts` contains `getCommandForInteraction()`, which maps a Discord interaction's `commandName` (and optionally `subcommand`) to a CQRS command instance using the `ts-pattern` `match()` function:
+
+```ts
+return match(interaction.commandName)
+  .with(BlacklistSlashCommand.name, () => {
+    const subcommand = interaction.options.getSubcommand();
+    return match(subcommand)
+      .with('add', () => new BlacklistAddCommand(interaction))
+      .with('remove', () => new BlacklistRemoveCommand(interaction))
+      .with('display', () => new BlacklistDisplayCommand(interaction))
+      .run();
+  })
+  .with(SIGNUP_SLASH_COMMAND_NAME, () => new SignupCommand(interaction))
+  // ...
+  .otherwise(() => undefined);
+```
+
+**Why `ts-pattern`?** It provides exhaustive, type-safe pattern matching. An unrecognized command returns `undefined` rather than throwing — the service gracefully ignores unknown interactions (e.g., stale commands from a previous version).
+
+**Subcommand dispatch:** For commands with subcommands (`/blacklist`, `/settings`, `/encounters`), the top-level `commandName` match resolves to a nested `match` on the subcommand string. Each subcommand gets its own CQRS command class and dedicated handler — avoiding large branching in a single handler.
+
+---
+
+## CQRS Rationale
+
+Using NestJS CQRS (commands + events + sagas) rather than direct service-to-service calls provides:
+
+- **Decoupling** — The signup handler doesn't know about the review channel, Sheets service, or role management. It publishes a `SignupCreatedEvent` and those concerns react independently.
+- **Side-effect isolation** — Side effects (DM to user, sheet update, role assignment) live in event handlers. If one fails, the others are not blocked.
+- **Testability** — Each handler is a class with explicit dependencies. Unit tests can stub the event bus entirely and test handler logic in isolation.
+- **Async orchestration via sagas** — Sagas convert event streams into command streams using RxJS operators. A cleared-signup approval can fan out to both a role-removal command and a TurboProg sheet cleanup command without those concerns touching each other.
+
+---
+
+## Signup Flow (Deep Dive)
+
+The `/signup` command is the most complex in the system. Its handler (`src/slash-commands/signup/handlers/signup.command-handler.ts`) orchestrates:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Handler
+    participant FFLogs
+    participant Discord
+    participant Firestore
+    participant EventBus
+
+    User->>Handler: /signup (character, world, job, prog-point, proof-link)
+    Handler->>Handler: Validate input with Zod schema
+    Handler->>FFLogs: validateReportAge(proofLink) [if FFLogs URL]
+    FFLogs-->>Handler: valid / error message
+    Handler->>Discord: deferReply()
+    Handler->>Discord: Send confirmation embed with Accept/Cancel buttons
+    User->>Discord: Click Accept or Cancel (60s timeout)
+    Discord->>Handler: ButtonInteraction
+    alt User cancels or timeout
+        Handler->>Discord: Edit reply with cancelled message
+    else User confirms
+        Handler->>Firestore: signupCollection.upsert(signup)
+        Handler->>Discord: Edit reply with confirmed embed
+        Handler->>EventBus: publish(SignupCreatedEvent)
+        EventBus->>Saga: SignupCreatedEvent
+        Saga->>CommandBus: SendSignupReviewCommand
+        CommandBus->>ReviewHandler: Post review embed to review channel
+        ReviewHandler->>Firestore: setReviewMessageId()
+        ReviewHandler->>EventBus: publish(SignupApprovalSentEvent)
+        EventBus->>Saga: SignupApprovalSentEvent
+        Saga->>CommandBus: BlacklistSearchCommand
+    end
+```
+
+**FF Logs validation** is performed before confirmation. If the supplied link is an FF Logs report URL, the handler queries the FF Logs API to verify the report is not older than the configured maximum age. If validation fails, the user is told why and the signup is rejected early. If the FF Logs API is unavailable, validation is skipped gracefully (the feature degrades, not fails).
+
+**Proof link URL validation** also enforces an allowlist of accepted domains (fflogs.com, streamable, twitch, youtube, medal.tv) to prevent spoofing via lookalike URLs.
+
+**Upsert behavior** — If the player already has a signup for that encounter:
+- If still `PENDING`: fields are updated in place, status stays `PENDING`
+- If previously reviewed (`APPROVED`/`DECLINED`): status transitions to `UPDATE_PENDING`, signalling coordinators need to re-review
+
+---
+
+## Subcommand Pattern
+
+Commands with multiple related subcommands (e.g., `/settings`, `/encounters`, `/blacklist`) use a single top-level slash command definition with `addSubcommand()` entries, and a single parent CQRS command class that wraps the interaction. The parent handler's `execute()` reads `interaction.options.getSubcommand()` and dispatches to a child command via `this.commandBus.execute(childCommand)`.
+
+This keeps the Discord command tree tidy while letting each subcommand have its own focused handler class.


### PR DESCRIPTION
Adds seven focused Markdown documents covering the bot's architecture, design decisions, and key patterns for both new contributors and the existing team.

https://claude.ai/code/session_017D4JTUtgaGWyN9EkhKb9L1