### PR TITLE
chore(tooling): replace husky with lefthook for git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-pnpm commitlint ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm typecheck && pnpm test --run

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL fly_launch_runtime="NestJS"
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN wget -qO- https://get.pnpm.io/install.sh | PNPM_VERSION=10.30.1 ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+RUN wget -qO- https://get.pnpm.io/install.sh | PNPM_VERSION=10.30.3 ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 
 # Print the pnpm version
 RUN pnpm --version

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  commands:
+    typecheck:
+      run: pnpm typecheck
+    test:
+      run: pnpm test --run
+
+commit-msg:
+  commands:
+    commitlint:
+      run: pnpm commitlint --edit {1}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "graphql:codegen": "graphql-codegen --config codegen.ts",
     "lint": "biome lint --diagnostic-level=error src",
     "lint:ci": "biome ci --diagnostic-level=error src",
-    "prepare": "node scripts/prepare.js",
+    "prepare": "node scripts/install-hooks.js",
     "start:sentry": "NODE_OPTIONS=\"--import=./instrumentation.mjs\" pnpm start",
     "start": "dotenvx run -f .env -f .env.development -- node dist/main",
     "test": "vitest",
@@ -74,8 +74,8 @@
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
     "commitizen": "^4.3.1",
-    "husky": "^9.1.7",
     "hygen": "^6.2.11",
+    "lefthook": "^2.1.2",
     "rimraf": "^6.1.3",
     "source-map-support": "^0.5.21",
     "unplugin-swc": "^1.5.9",
@@ -89,6 +89,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@biomejs/biome",
+      "lefthook",
       "@firebase/util",
       "@nestjs/core",
       "@sentry-internal/node-cpu-profiler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,12 +129,12 @@ importers:
       commitizen:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@25.3.3)(typescript@5.9.3)
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       hygen:
         specifier: ^6.2.11
         version: 6.2.11
+      lefthook:
+        specifier: ^2.1.2
+        version: 2.1.2
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -3371,11 +3371,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   hygen@6.2.11:
     resolution: {integrity: sha512-t6/zLI2XozP5gvV74nnl8LZSbwpVNFUkUs/O9DwuOdiiBbws5k4AQNVwKZ9FGzcKjdJ5EBBYkVzlcUHkLyY0FQ==}
     hasBin: true
@@ -3637,6 +3632,60 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lefthook-darwin-arm64@2.1.2:
+    resolution: {integrity: sha512-AgHu93YuJtj1l9bcKlCbo4Tg8N8xFl9iD6BjXCGaGMu46LSjFiXbJFlkUdpgrL8fIbwoCjJi5FNp3POpqs4Wdw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.2:
+    resolution: {integrity: sha512-exooc9Ectz13OLJJOXM9AzaFQbqzf9QCF8JuVvGfbr4RYABYK+BwwtydjlPQrA76/n/h4tsS11MH5bBULnLkYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.2:
+    resolution: {integrity: sha512-E1QMlJPEU21n9eewv6ePfh+JmoTSg5R1jaYcKCky10kfbMdohNucI3xV91F2LcerE+p3UejKDqr/1wWO2RMGeQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.2:
+    resolution: {integrity: sha512-/5zp+x8055Thj46x9S7hgnneZxvWhHQvPWkkgISCab1Lh6eLrbxvhE1qTb1lU3DqTnNmH9NeXdq1xPHc9uGluA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.2:
+    resolution: {integrity: sha512-UK5FvDTkwKO7tOznY8iEZzuTsM1jXMZAG5BMRs7olN1k1K6m2unR6oKABP0hCd0wDErK6DZKDJDJfB564Rzqtw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.2:
+    resolution: {integrity: sha512-4eOtz4PNh8GbJ+nA8YVDfW/eMirQWdZqMP/V/MVtoVBGobf6oXvvuDOySvAPOgNYEFN0Boegytmuji/851Vstg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.2:
+    resolution: {integrity: sha512-lJXRJ6iJIBKwomuNBA3CUNSclj2/rKuxGAQoUra214B92VB6jL9zaY5YEs6h/ie9jQrzSnllEeg7xyDIsuVCrQ==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.2:
+    resolution: {integrity: sha512-GyOje4W0DIqkmR7/Of5D+mZ0vWqMvtGAVedtJR6d1239xNeMzCS8Q+/a3O1xigceZa5xhlqq0BWlssB/QYPQnA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.2:
+    resolution: {integrity: sha512-MZKMqTULEpX/8N3fKXAR0A9RjsGKkEEY0japLqrHOIpxsJXry1DRz0FvQo2kkY4WW3rtFegV9m6eesOymuDrUg==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.2:
+    resolution: {integrity: sha512-NZUgObuaSxc0EXAwC/CzkMf7TuQc++GGIk6TLPdaUpoSsNSJSZEwBVz5DtFB1cG+eMkfO/wOKplls+yjimTTtQ==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.2:
+    resolution: {integrity: sha512-HdAMl4g47kbWSkrUkCx3Kucq54omFS6piMJtXwXNtmCAfB40UaybTJuYtFW4hNzZ5SvaEimtxTp7P/MNIkEfsA==}
+    hasBin: true
 
   libphonenumber-js@1.12.38:
     resolution: {integrity: sha512-vwzxmasAy9hZigxtqTbFEwp8ZdZ975TiqVDwj5bKx5sR+zi5ucUQy9mbVTkKM9GzqdLdxux/hTw2nmN5J7POMA==}
@@ -8792,8 +8841,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  husky@9.1.7: {}
-
   hygen@6.2.11:
     dependencies:
       '@types/node': 17.0.45
@@ -9087,6 +9134,49 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  lefthook-darwin-arm64@2.1.2:
+    optional: true
+
+  lefthook-darwin-x64@2.1.2:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.2:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.2:
+    optional: true
+
+  lefthook-linux-arm64@2.1.2:
+    optional: true
+
+  lefthook-linux-x64@2.1.2:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.2:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.2:
+    optional: true
+
+  lefthook-windows-arm64@2.1.2:
+    optional: true
+
+  lefthook-windows-x64@2.1.2:
+    optional: true
+
+  lefthook@2.1.2:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.2
+      lefthook-darwin-x64: 2.1.2
+      lefthook-freebsd-arm64: 2.1.2
+      lefthook-freebsd-x64: 2.1.2
+      lefthook-linux-arm64: 2.1.2
+      lefthook-linux-x64: 2.1.2
+      lefthook-openbsd-arm64: 2.1.2
+      lefthook-openbsd-x64: 2.1.2
+      lefthook-windows-arm64: 2.1.2
+      lefthook-windows-x64: 2.1.2
 
   libphonenumber-js@1.12.38:
     optional: true

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+// Only install git hooks if we're in a git repository
+// This prevents hook installation in Docker containers and CI environments
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const isGitRepo = existsSync('.git');
+
+if (isGitRepo) {
+  try {
+    execSync('pnpm dlx lefthook install', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to install lefthook hooks:', error);
+    process.exit(1);
+  }
+} else {
+  console.log('Skipping lefthook install (not in a git repository)');
+}

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,5 +1,0 @@
-const { NODE_ENV } = process.env;
-
-if (NODE_ENV !== 'production') {
-  await import('husky').then((dep) => dep.default());
-}


### PR DESCRIPTION
## Summary

- Replaces `husky` with `lefthook` for managing git hooks
- Adds `lefthook.yml` with `pre-commit` (typecheck + test) and `commit-msg` (commitlint) hooks
- Replaces `scripts/prepare.js` with `scripts/install-hooks.js` that skips hook installation outside a git repo (e.g. Docker)
- Adds `lefthook` to `pnpm.onlyBuiltDependencies` to allow its postinstall script

## Test plan

- [ ] `pnpm install` runs `lefthook install` and registers hooks in `.git/hooks`
- [ ] Committing runs typecheck, tests, and commitlint via lefthook