### PR TITLE
test: replace @golevelup/ts-vitest with native Vitest mocking

### DIFF
--- a/_templates/slash-command/new/command-handler.spec.ejs.t
+++ b/_templates/slash-command/new/command-handler.spec.ejs.t
@@ -2,7 +2,7 @@
 to: src/slash-commands/<%=name%>/<%=name%>.command-handler.spec.ts
 ---
 import { Test } from '@nestjs/testing';
-import { createMock } from '@golevelup/ts-vitest';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { <%= h.changeCase.pascal(name) %>CommandHandler } from './<%=name%>.command-handler.js';
 
 describe('<%=h.changeCase.pascal(name)%>CommandHandler', () => {
@@ -12,7 +12,7 @@ describe('<%=h.changeCase.pascal(name)%>CommandHandler', () => {
     const fixture = await Test.createTestingModule({
       providers: [<%= h.changeCase.pascal(name) %>CommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(<%= h.changeCase.pascal(name) %>CommandHandler);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@commitlint/cz-commitlint": "^20.4.1",
     "@commitlint/prompt-cli": "^20.4.2",
     "@flydotio/dockerfile": "^0.7.10",
-    "@golevelup/ts-vitest": "^0.5.2",
     "@graphql-codegen/cli": "6.1.1",
     "@graphql-codegen/schema-ast": "^5.0.0",
     "@graphql-codegen/typescript": "5.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       '@flydotio/dockerfile':
         specifier: ^0.7.10
         version: 0.7.10(@types/node@25.3.3)
-      '@golevelup/ts-vitest':
-        specifier: ^0.5.2
-        version: 0.5.2
       '@graphql-codegen/cli':
         specifier: 6.1.1
         version: 6.1.1(@types/node@25.3.3)(graphql@16.9.0)(typescript@5.9.3)
@@ -903,9 +900,6 @@ packages:
     resolution: {integrity: sha512-dTXqBjCl7nFmnhlyeDjjPtX+sdfYBWFH9PUKNqAYttvBiczKcYXxr7/0A0wZ+g1FB1tmMzsOzedgr6xap/AB9g==}
     engines: {node: '>=16.0.0'}
     hasBin: true
-
-  '@golevelup/ts-vitest@0.5.2':
-    resolution: {integrity: sha512-kxL12/4lBeYcdpfabvqWGgIagt8ycD6vUNlVyNUjGjxuqo8wPRB1Ohfnn4LNWQG8X8/xf74S2qYnOGqJ7IvWFA==}
 
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
@@ -5869,8 +5863,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@golevelup/ts-vitest@0.5.2': {}
 
   '@google-cloud/firestore@7.11.6':
     dependencies:

--- a/src/discord/discord.helpers.spec.ts
+++ b/src/discord/discord.helpers.spec.ts
@@ -1,4 +1,3 @@
-import { createMock } from '@golevelup/ts-vitest';
 import type {
   ChatInputCommandInteraction,
   PartialMessageReaction,
@@ -15,44 +14,40 @@ import {
 describe('Discord Helper Methods', () => {
   it('hydrates a partial reaction', async () => {
     const fetch = vi.fn().mockResolvedValue({});
-    const reaction = createMock<PartialMessageReaction>({
+    const reaction = {
       partial: true,
-      valueOf: () => '',
       fetch,
-    });
+    } as unknown as PartialMessageReaction;
 
     await hydrateReaction(reaction);
     expect(fetch).toHaveBeenCalled();
   });
 
   it('returns the given reaction if not partial', () => {
-    const reaction = createMock<PartialMessageReaction>({
+    const reaction = {
       partial: undefined,
-      valueOf: () => '',
-    });
+    } as unknown as PartialMessageReaction;
 
     return expect(hydrateReaction(reaction)).resolves.toBe(reaction);
   });
 
   it('hydrates a partial user', async () => {
     const fetch = vi.fn().mockResolvedValue({});
-    const user = createMock<PartialUser>({
+    const user = {
       partial: true,
-      valueOf: () => '',
       fetch,
       toString: () => '<@foo>',
-    });
+    } as unknown as PartialUser;
 
     await hydrateUser(user);
     expect(fetch).toHaveBeenCalled();
   });
 
   it('returns the given user if not partial', () => {
-    const user = createMock<PartialUser>({
+    const user = {
       partial: undefined,
-      valueOf: () => '',
       toString: () => '<@foo>',
-    });
+    } as unknown as PartialUser;
 
     return expect(hydrateUser(user)).resolves.toBe(user);
   });
@@ -97,14 +92,13 @@ describe('safeReply', () => {
     resolvedValue,
   }) => {
     const methodFn = vi.fn().mockResolvedValue(resolvedValue);
-    const interaction = createMock<ChatInputCommandInteraction>({
+    const interaction = {
       deferred: interactionProps.deferred,
       replied: interactionProps.replied,
       editReply: expectedMethod === 'editReply' ? methodFn : vi.fn(),
       followUp: expectedMethod === 'followUp' ? methodFn : vi.fn(),
       reply: expectedMethod === 'reply' ? methodFn : vi.fn(),
-      valueOf: () => '',
-    });
+    } as unknown as ChatInputCommandInteraction;
 
     const result = await safeReply(interaction, payload);
     expect(methodFn).toHaveBeenCalledWith(payload);

--- a/src/encounters/encounters.service.spec.ts
+++ b/src/encounters/encounters.service.spec.ts
@@ -1,21 +1,21 @@
-import type { DeepMocked } from '@golevelup/ts-vitest';
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked } from 'vitest';
 import { EncountersCollection } from '../firebase/collections/encounters-collection.js';
 import type {
   EncounterDocument,
   ProgPointDocument,
 } from '../firebase/models/encounter.model.js';
 import { PartyStatus } from '../firebase/models/signup.model.js';
+import { createAutoMock } from '../test-utils/mock-factory.js';
 import { EncountersService } from './encounters.service.js';
 
 describe('EncountersService', () => {
   let service: EncountersService;
-  let mockEncountersCollection: DeepMocked<EncountersCollection>;
+  let mockEncountersCollection: Mocked<EncountersCollection>;
 
   beforeEach(async () => {
-    mockEncountersCollection = createMock<EncountersCollection>();
+    mockEncountersCollection =
+      createAutoMock() as unknown as Mocked<EncountersCollection>;
 
     const module = await Test.createTestingModule({
       providers: [

--- a/src/firebase/collections/settings-collection.spec.ts
+++ b/src/firebase/collections/settings-collection.spec.ts
@@ -1,7 +1,6 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { Firestore } from 'firebase-admin/firestore';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
 import { FIRESTORE } from '../firebase.consts.js';
 import { SettingsCollection } from './settings-collection.js';
 
@@ -10,20 +9,46 @@ describe.each([
   { cache: false },
 ])('SettingsCollection with cache: $cache', ({ cache }) => {
   let service: SettingsCollection;
-  let firestore: DeepMocked<Firestore>;
+  let firestoreMock: { collection: ReturnType<typeof vi.fn> };
+  let collectionMock: {
+    doc: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+  };
+  let docMock: {
+    set: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
   const guildId = 'guildId';
 
   beforeEach(async () => {
-    firestore = createMock<Firestore>();
+    docMock = {
+      set: vi.fn(),
+      get: vi.fn().mockResolvedValue({ data: () => undefined }),
+      update: vi.fn(),
+      create: vi.fn(),
+    };
+    collectionMock = {
+      doc: vi.fn().mockReturnValue(docMock),
+      where: vi.fn(),
+      limit: vi.fn(),
+      get: vi.fn(),
+    };
+    firestoreMock = { collection: vi.fn().mockReturnValue(collectionMock) };
 
     const module = await Test.createTestingModule({
-      providers: [SettingsCollection],
+      providers: [
+        SettingsCollection,
+        { provide: FIRESTORE, useValue: firestoreMock },
+      ],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     service = module.get<SettingsCollection>(SettingsCollection);
-    firestore = module.get(FIRESTORE);
     // Mock the cache behavior by setting up service internal cache
     if (cache) {
       (service as any).cache.set('settings:guildId', {});
@@ -35,34 +60,32 @@ describe.each([
 
     await service.upsert(guildId, settings);
 
-    expect(firestore.collection).toHaveBeenCalledWith('settings');
-    expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
-    expect(firestore.collection('').doc().set).toHaveBeenCalledWith(settings, {
-      merge: true,
-    });
+    expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
+    expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
+    expect(docMock.set).toHaveBeenCalledWith(settings, { merge: true });
   });
 
   it('should call getReviewChannel with correct arguments', async () => {
     await service.getReviewChannel(guildId);
-    expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
 
     if (cache) {
-      expect(firestore.collection('').doc).not.toHaveBeenCalled();
+      expect(collectionMock.doc).not.toHaveBeenCalled();
     } else {
-      expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
-      expect(firestore.collection('').doc().get).toHaveBeenCalled();
+      expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
+      expect(docMock.get).toHaveBeenCalled();
     }
   });
 
   it('should call getSettings with correct arguments', async () => {
     await service.getSettings(guildId);
-    expect(firestore.collection).toHaveBeenCalledWith('settings');
+    expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
 
     if (cache) {
-      expect(firestore.collection('').doc).not.toHaveBeenCalled();
+      expect(collectionMock.doc).not.toHaveBeenCalled();
     } else {
-      expect(firestore.collection('').doc).toHaveBeenCalledWith(guildId);
-      expect(firestore.collection('').doc().get).toHaveBeenCalled();
+      expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
+      expect(docMock.get).toHaveBeenCalled();
     }
   });
 });

--- a/src/firebase/collections/signup.collection.spec.ts
+++ b/src/firebase/collections/signup.collection.spec.ts
@@ -1,18 +1,16 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import {
+import type {
   CollectionReference,
-  type DocumentData,
+  DocumentData,
   DocumentReference,
   DocumentSnapshot,
   Firestore,
   Query,
-  QueryDocumentSnapshot,
-  QuerySnapshot,
 } from 'firebase-admin/firestore';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { Encounter } from '../../encounters/encounters.consts.js';
 import type { SignupSchema } from '../../slash-commands/signup/signup.schema.js';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
 import { FIRESTORE } from '../firebase.consts.js';
 import { DocumentNotFoundException } from '../firebase.exceptions.js';
 import { type SignupDocument, SignupStatus } from '../models/signup.model.js';
@@ -25,35 +23,33 @@ const SIGNUP_KEY = {
 
 describe('Signup Repository', () => {
   let repository: SignupCollection;
-  let firestore: DeepMocked<Firestore>;
-  let collection: DeepMocked<CollectionReference<DocumentData>>;
-  let doc: DeepMocked<DocumentReference<DocumentData>>;
-  const signupRequest = createMock<SignupSchema>(SIGNUP_KEY);
+  let collection: Mocked<CollectionReference<DocumentData>>;
+  let doc: Mocked<DocumentReference<DocumentData>>;
+  const signupRequest = SIGNUP_KEY as unknown as SignupSchema;
 
   beforeEach(async () => {
-    doc = createMock<DocumentReference>();
+    doc = createAutoMock() as unknown as Mocked<
+      DocumentReference<DocumentData>
+    >;
 
-    collection = createMock<CollectionReference<DocumentData>>({
+    collection = {
       get: vi.fn(),
       where: vi.fn(),
       limit: vi.fn(),
-      doc: vi.fn().mockReturnValue(doc) as any,
-    });
+      doc: vi.fn().mockReturnValue(doc),
+    } as unknown as Mocked<CollectionReference<DocumentData>>;
 
-    firestore = createMock<Firestore>({
-      collection: vi.fn().mockReturnValue(collection) as any,
-    });
+    const firestore = {
+      collection: vi.fn().mockReturnValue(collection),
+    } as unknown as Firestore;
 
     const fixture = await Test.createTestingModule({
       providers: [
         SignupCollection,
-        {
-          provide: FIRESTORE,
-          useValue: firestore,
-        },
+        { provide: FIRESTORE, useValue: firestore },
       ],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     repository = fixture.get(SignupCollection);
@@ -65,12 +61,10 @@ describe('Signup Repository', () => {
       status: SignupStatus.APPROVED,
       reviewedBy: 'someReviewer',
     };
-    doc.get.mockResolvedValueOnce(
-      createMock<DocumentSnapshot>({
-        exists: true,
-        data: () => existingData as any,
-      }),
-    );
+    doc.get.mockResolvedValueOnce({
+      exists: true,
+      data: () => existingData,
+    } as unknown as DocumentSnapshot);
 
     const result = await repository.upsert(signupRequest);
 
@@ -98,12 +92,10 @@ describe('Signup Repository', () => {
       status: SignupStatus.PENDING,
       reviewedBy: null,
     };
-    doc.get.mockResolvedValueOnce(
-      createMock<DocumentSnapshot>({
-        exists: true,
-        data: () => existingData as any,
-      }),
-    );
+    doc.get.mockResolvedValueOnce({
+      exists: true,
+      data: () => existingData,
+    } as unknown as DocumentSnapshot);
 
     const result = await repository.upsert(signupRequest);
 
@@ -120,12 +112,10 @@ describe('Signup Repository', () => {
   });
 
   it('should call create if the document does not exist', async () => {
-    doc.get.mockResolvedValueOnce(
-      createMock<DocumentSnapshot>({
-        exists: false,
-        data: () => null as any,
-      }),
-    );
+    doc.get.mockResolvedValueOnce({
+      exists: false,
+      data: () => null,
+    } as unknown as DocumentSnapshot);
 
     const result = await repository.upsert(signupRequest);
 
@@ -165,34 +155,25 @@ describe('Signup Repository', () => {
   });
 
   describe('#findByReviewId', () => {
-    const mockFetch = (empty: any, signup: SignupDocument) => {
-      collection.where.mockReturnValueOnce(
-        createMock<Query>({
-          limit: () =>
-            createMock<Query>({
-              get: () =>
-                Promise.resolve(
-                  createMock<QuerySnapshot>({
-                    empty,
-                    docs: [
-                      createMock<QueryDocumentSnapshot<SignupDocument>>({
-                        data: () => signup,
-                      }),
-                    ],
-                  }),
-                ),
+    const mockFetch = (empty: boolean, signup: SignupDocument) => {
+      collection.where.mockReturnValueOnce({
+        limit: () => ({
+          get: () =>
+            Promise.resolve({
+              empty,
+              docs: [{ data: () => signup }],
             }),
         }),
-      );
+      } as unknown as Query<DocumentData>);
     };
 
     it('should return a signup by review if exists', async () => {
       const reviewMessageId = 'reviewMessageId';
-      const signup = createMock<SignupDocument>({
-        ...signupRequest,
+      const signup = {
+        ...SIGNUP_KEY,
         reviewMessageId,
         status: SignupStatus.PENDING,
-      });
+      } as SignupDocument;
 
       mockFetch(false, signup);
 

--- a/src/slash-commands/clean-roles/dry-run.strategy.spec.ts
+++ b/src/slash-commands/clean-roles/dry-run.strategy.spec.ts
@@ -1,7 +1,7 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Logger } from '@nestjs/common';
 import { GuildMember, Role, User } from 'discord.js';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
 import type {
   DryRunRoleResult,
   ProcessingContext,
@@ -13,7 +13,7 @@ describe('DryRunStrategy', () => {
   let mockLogger: Logger;
 
   beforeEach(() => {
-    mockLogger = createMock<Logger>();
+    mockLogger = createAutoMock() as unknown as Logger;
     strategy = new DryRunStrategy(mockLogger);
   });
 

--- a/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.spec.ts
+++ b/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.spec.ts
@@ -1,4 +1,3 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
 import {
   ChatInputCommandInteraction,
@@ -15,6 +14,7 @@ import { ErrorService } from '../../../error/error.service.js';
 import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
 import { SignupCollection } from '../../../firebase/collections/signup.collection.js';
 import { SignupStatus } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { CleanRolesCommand } from '../commands/clean-roles.command.js';
 import { CleanRolesCommandHandler } from './clean-roles.command-handler.js';
 
@@ -29,7 +29,7 @@ describe('CleanRolesCommandHandler', () => {
     const fixture = await Test.createTestingModule({
       providers: [CleanRolesCommandHandler],
     })
-      .useMocker(createMock)
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(CleanRolesCommandHandler);
@@ -141,7 +141,7 @@ describe('CleanRolesCommandHandler', () => {
     });
 
     it('should handle settings with no roles configured', async () => {
-      const mockErrorEmbed = createMock<EmbedBuilder>();
+      const mockErrorEmbed = {} as EmbedBuilder;
 
       settingsCollection.getSettings = vi.fn().mockResolvedValue({});
       errorService.handleCommandError = vi.fn().mockReturnValue(mockErrorEmbed);
@@ -158,7 +158,7 @@ describe('CleanRolesCommandHandler', () => {
     });
 
     it('should handle empty role configuration', async () => {
-      const mockErrorEmbed = createMock<EmbedBuilder>();
+      const mockErrorEmbed = {} as EmbedBuilder;
 
       settingsCollection.getSettings = vi.fn().mockResolvedValue({
         progRoles: {},
@@ -214,7 +214,7 @@ describe('CleanRolesCommandHandler', () => {
     it('should handle errors gracefully', async () => {
       const { mock, editReply } = createInteractionMock();
       const error = new Error('Database error');
-      const mockErrorEmbed = createMock<EmbedBuilder>();
+      const mockErrorEmbed = {} as EmbedBuilder;
 
       settingsCollection.getSettings = vi.fn().mockRejectedValue(error);
       errorService.handleCommandError = vi.fn().mockReturnValue(mockErrorEmbed);
@@ -228,7 +228,7 @@ describe('CleanRolesCommandHandler', () => {
     it('should handle settings-related errors with specific message', async () => {
       const { mock, editReply } = createInteractionMock();
       const error = new Error('No clear/prog roles configured in settings');
-      const mockErrorEmbed = createMock<EmbedBuilder>();
+      const mockErrorEmbed = {} as EmbedBuilder;
 
       settingsCollection.getSettings = vi.fn().mockRejectedValue(error);
       errorService.handleCommandError = vi.fn().mockReturnValue(mockErrorEmbed);

--- a/src/slash-commands/clean-roles/normal.strategy.spec.ts
+++ b/src/slash-commands/clean-roles/normal.strategy.spec.ts
@@ -1,7 +1,7 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Logger } from '@nestjs/common';
 import { GuildMember, GuildMemberRoleManager, Role, User } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
 import type {
   NormalRoleResult,
   ProcessingContext,
@@ -13,7 +13,7 @@ describe('NormalStrategy', () => {
   let mockLogger: Logger;
 
   beforeEach(() => {
-    mockLogger = createMock<Logger>();
+    mockLogger = createAutoMock() as unknown as Logger;
     strategy = new NormalStrategy(mockLogger);
   });
 

--- a/src/slash-commands/encounters/handlers/manage-prog-points.command-handler.spec.ts
+++ b/src/slash-commands/encounters/handlers/manage-prog-points.command-handler.spec.ts
@@ -1,13 +1,12 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
-import { Logger } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import {
+import type {
   ButtonInteraction,
-  type ChatInputCommandInteraction,
-  MessageFlags,
+  ChatInputCommandInteraction,
   StringSelectMenuInteraction,
 } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked } from 'vitest';
 import { EncountersService } from '../../../encounters/encounters.service.js';
 import { ErrorService } from '../../../error/error.service.js';
 import type {
@@ -15,16 +14,17 @@ import type {
   ProgPointDocument,
 } from '../../../firebase/models/encounter.model.js';
 import { PartyStatus } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { ManageProgPointsCommand } from '../commands/encounters.commands.js';
 import { ManageProgPointsCommandHandler } from './manage-prog-points.command-handler.js';
 
 describe('ManageProgPointsCommandHandler', () => {
   let handler: ManageProgPointsCommandHandler;
-  let encountersService: DeepMocked<EncountersService>;
-  let errorService: DeepMocked<ErrorService>;
-  let interaction: DeepMocked<ChatInputCommandInteraction<'cached'>>;
-  let mockChannel: DeepMocked<any>;
-  let mockCollector: DeepMocked<any>;
+  let encountersService: Mocked<EncountersService>;
+  let errorService: Mocked<ErrorService>;
+  let interaction: ChatInputCommandInteraction<'cached'>;
+  let mockChannel: ReturnType<typeof createAutoMock>;
+  let mockCollector: ReturnType<typeof createAutoMock>;
 
   const mockEncounter: EncounterDocument = {
     id: 'test-encounter',
@@ -65,8 +65,8 @@ describe('ManageProgPointsCommandHandler', () => {
     const fixture = await Test.createTestingModule({
       providers: [ManageProgPointsCommandHandler],
     })
-      .useMocker(() => createMock())
-      .setLogger(createMock<Logger>())
+      .useMocker(createAutoMock)
+      .setLogger(createAutoMock() as unknown as LoggerService)
       .compile();
 
     handler = fixture.get(ManageProgPointsCommandHandler);
@@ -74,16 +74,17 @@ describe('ManageProgPointsCommandHandler', () => {
     errorService = fixture.get(ErrorService);
 
     // Setup interaction mock
-    interaction = createMock<ChatInputCommandInteraction<'cached'>>();
-    mockChannel = createMock();
-    mockCollector = createMock();
+    interaction =
+      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
+    mockChannel = createAutoMock();
+    mockCollector = createAutoMock();
 
     Object.defineProperty(interaction, 'channel', {
       value: mockChannel,
       writable: true,
     });
     Object.defineProperty(interaction, 'user', {
-      value: createMock({ id: 'test-user' }),
+      value: { id: 'test-user' },
       writable: true,
     });
     mockChannel.createMessageComponentCollector.mockReturnValue(mockCollector);
@@ -132,7 +133,7 @@ describe('ManageProgPointsCommandHandler', () => {
     });
 
     it('should handle encounter not found', async () => {
-      encountersService.getEncounter.mockResolvedValue(null);
+      encountersService.getEncounter.mockResolvedValue(null as never);
       const command = new ManageProgPointsCommand(
         interaction,
         'test-encounter',
@@ -200,7 +201,8 @@ describe('ManageProgPointsCommandHandler', () => {
     });
 
     it('should handle finish interaction', async () => {
-      const buttonInteraction = createMock<ButtonInteraction>();
+      const buttonInteraction =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       buttonInteraction.isButton.mockReturnValue(true);
       buttonInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(buttonInteraction, 'customId', {
@@ -231,7 +233,8 @@ describe('ManageProgPointsCommandHandler', () => {
     });
 
     it('should handle toggle prog point button', async () => {
-      const buttonInteraction = createMock<ButtonInteraction>();
+      const buttonInteraction =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       buttonInteraction.isButton.mockReturnValue(true);
       buttonInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(buttonInteraction, 'customId', {
@@ -325,7 +328,8 @@ describe('ManageProgPointsCommandHandler', () => {
       await handler.execute(command);
 
       // First click toggle button to get into toggle selection state
-      const toggleButton = createMock<ButtonInteraction>();
+      const toggleButton =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       toggleButton.isButton.mockReturnValue(true);
       toggleButton.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(toggleButton, 'customId', {
@@ -349,7 +353,8 @@ describe('ManageProgPointsCommandHandler', () => {
     it('should toggle prog point active status', async () => {
       encountersService.toggleProgPointActive.mockResolvedValue();
 
-      const selectInteraction = createMock<StringSelectMenuInteraction>();
+      const selectInteraction =
+        createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
       selectInteraction.isStringSelectMenu.mockReturnValue(true);
       selectInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(selectInteraction, 'customId', {
@@ -380,7 +385,8 @@ describe('ManageProgPointsCommandHandler', () => {
     });
 
     it('should handle prog point not found during toggle', async () => {
-      const selectInteraction = createMock<StringSelectMenuInteraction>();
+      const selectInteraction =
+        createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
       selectInteraction.isStringSelectMenu.mockReturnValue(true);
       selectInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(selectInteraction, 'customId', {
@@ -422,7 +428,8 @@ describe('ManageProgPointsCommandHandler', () => {
 
     it('should handle expired interaction error', async () => {
       const expiredError = { code: 10062, message: 'Unknown interaction' };
-      const buttonInteraction = createMock<ButtonInteraction>();
+      const buttonInteraction =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       buttonInteraction.isButton.mockReturnValue(true);
       buttonInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(buttonInteraction, 'customId', {
@@ -450,7 +457,8 @@ describe('ManageProgPointsCommandHandler', () => {
     });
 
     it('should validate interaction age', async () => {
-      const oldInteraction = createMock<ButtonInteraction>();
+      const oldInteraction =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       oldInteraction.isButton.mockReturnValue(true);
       oldInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(oldInteraction, 'customId', {
@@ -489,7 +497,8 @@ describe('ManageProgPointsCommandHandler', () => {
     it('should handle return to main menu', async () => {
       encountersService.getAllProgPoints.mockResolvedValue(mockProgPoints);
 
-      const buttonInteraction = createMock<ButtonInteraction>();
+      const buttonInteraction =
+        createAutoMock() as unknown as Mocked<ButtonInteraction>;
       buttonInteraction.isButton.mockReturnValue(true);
       buttonInteraction.isMessageComponent.mockReturnValue(true);
       Object.defineProperty(buttonInteraction, 'customId', {

--- a/src/slash-commands/help/handlers/help.command-handler.spec.ts
+++ b/src/slash-commands/help/handlers/help.command-handler.spec.ts
@@ -1,4 +1,3 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
 import type { ChatInputCommandInteraction } from 'discord.js';
 import {
@@ -8,6 +7,7 @@ import {
   SlashCommandBuilder,
 } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { SLASH_COMMANDS_TOKEN } from '../../slash-commands.provider.js';
 import { HelpCommand } from '../commands/help.command.js';
 import { HelpCommandHandler } from './help.command-handler.js';
@@ -48,7 +48,7 @@ describe('HelpCommandHandler', () => {
         },
       ],
     })
-      .useMocker(createMock)
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(HelpCommandHandler);
@@ -66,17 +66,13 @@ describe('HelpCommandHandler', () => {
       const deferReply = vi.fn().mockResolvedValue(undefined);
       const editReply = vi.fn().mockResolvedValue(undefined);
 
-      const interaction = createMock<ChatInputCommandInteraction<'cached'>>();
-      interaction.deferReply = deferReply;
-      interaction.editReply = editReply;
-
-      // Handle the readonly property correctly
-      Object.defineProperty(interaction, 'memberPermissions', {
-        value: hasPermissions ? new PermissionsBitField(permissions) : null,
-        writable: false,
-      });
-
-      return interaction;
+      return {
+        deferReply,
+        editReply,
+        memberPermissions: hasPermissions
+          ? new PermissionsBitField(permissions)
+          : null,
+      } as unknown as ChatInputCommandInteraction<'cached'>;
     };
 
     it('should show only public commands for regular users', async () => {

--- a/src/slash-commands/lookup/handlers/lookup.command-handler.spec.ts
+++ b/src/slash-commands/lookup/handlers/lookup.command-handler.spec.ts
@@ -1,33 +1,37 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { Colors, EmbedBuilder, MessageFlags } from 'discord.js';
 import {
-  ChatInputCommandInteraction,
-  Colors,
-  EmbedBuilder,
-  MessageFlags,
-} from 'discord.js';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mocked,
+  vi,
+} from 'vitest';
 import { Encounter } from '../../../encounters/encounters.consts.js';
 import { ErrorService } from '../../../error/error.service.js';
 import { BlacklistCollection } from '../../../firebase/collections/blacklist-collection.js';
 import { SignupCollection } from '../../../firebase/collections/signup.collection.js';
 import type { SignupDocument } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { LookupCommand } from '../commands/lookup.command.js';
 import { LookupCommandHandler } from './lookup.command-handler.js';
 
 describe('LookupCommandHandler', () => {
   let handler: LookupCommandHandler;
-  let interaction: DeepMocked<ChatInputCommandInteraction<'cached'>>;
-  let signupsCollection: DeepMocked<SignupCollection>;
-  let blacklistCollection: DeepMocked<BlacklistCollection>;
-  let errorService: DeepMocked<ErrorService>;
+  let interaction: ChatInputCommandInteraction<'cached'>;
+  let signupsCollection: Mocked<SignupCollection>;
+  let blacklistCollection: Mocked<BlacklistCollection>;
+  let errorService: Mocked<ErrorService>;
   const getStringMock = vi.fn();
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [LookupCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(LookupCommandHandler);
@@ -35,12 +39,10 @@ describe('LookupCommandHandler', () => {
     blacklistCollection = fixture.get(BlacklistCollection);
     errorService = fixture.get(ErrorService);
 
-    interaction = createMock<ChatInputCommandInteraction<'cached'>>({
-      options: {
-        getString: getStringMock,
-      },
-      valueOf: () => '',
-    });
+    interaction = {
+      options: { getString: getStringMock },
+      reply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
   });
 
   afterEach(() => {
@@ -71,7 +73,7 @@ describe('LookupCommandHandler', () => {
     signupsCollection.findAll.mockResolvedValue(signups);
 
     // Return null so the user is not blacklisted
-    blacklistCollection.search.mockResolvedValue(null);
+    blacklistCollection.search.mockResolvedValue(null as never);
 
     const command = new LookupCommand(interaction);
 
@@ -136,7 +138,7 @@ describe('LookupCommandHandler', () => {
 
   it('should handle errors gracefully', async () => {
     const error = new Error('Database error');
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
 
     getStringMock.mockImplementation((key) => {
       if (key === 'character') return 'Test Character';

--- a/src/slash-commands/remove-role/handlers/remove-role.command-handler.spec.ts
+++ b/src/slash-commands/remove-role/handlers/remove-role.command-handler.spec.ts
@@ -1,6 +1,6 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { RemoveRoleCommandHandler } from './remove-role.command-handler.js';
 
 describe('RemoveRoleCommandHandler', () => {
@@ -10,7 +10,7 @@ describe('RemoveRoleCommandHandler', () => {
     const fixture = await Test.createTestingModule({
       providers: [RemoveRoleCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(RemoveRoleCommandHandler);

--- a/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.spec.ts
+++ b/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.spec.ts
@@ -1,8 +1,8 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { EventBus } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, Colors, User } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction, User } from 'discord.js';
+import { Colors } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../../discord/discord.service.js';
 import {
   Encounter,
@@ -16,6 +16,7 @@ import {
   SignupStatus,
 } from '../../../firebase/models/signup.model.js';
 import { SheetsService } from '../../../sheets/sheets.service.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { SIGNUP_MESSAGES } from '../../signup/signup.consts.js';
 import {
   REMOVAL_MISSING_PERMISSIONS,
@@ -41,19 +42,19 @@ const DEFAULT_SETTINGS = {
 };
 
 describe('Remove Signup Command Handler', () => {
-  let discordService: DeepMocked<DiscordService>;
-  let eventBus: DeepMocked<EventBus>;
+  let discordService: Mocked<DiscordService>;
+  let eventBus: Mocked<EventBus>;
   let handler: RemoveSignupCommandHandler;
-  let interaction: DeepMocked<ChatInputCommandInteraction<'cached'>>;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let sheetsService: DeepMocked<SheetsService>;
-  let signupsCollection: DeepMocked<SignupCollection>;
+  let interaction: ChatInputCommandInteraction<'cached'>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let sheetsService: Mocked<SheetsService>;
+  let signupsCollection: Mocked<SignupCollection>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [RemoveSignupCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     discordService = fixture.get(DiscordService);
@@ -63,12 +64,8 @@ describe('Remove Signup Command Handler', () => {
     signupsCollection = fixture.get(SignupCollection);
     eventBus = fixture.get(EventBus);
 
-    interaction = createMock<ChatInputCommandInteraction<'cached'>>({
-      user: createMock<User>({
-        id: '1',
-        toString: () => '<@1>',
-        valueOf: () => '',
-      }),
+    interaction = {
+      user: { id: '1', toString: () => '<@1>' } as unknown as User,
       options: {
         getString: (key: string) => {
           switch (key) {
@@ -83,8 +80,9 @@ describe('Remove Signup Command Handler', () => {
           }
         },
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
   });
 
   it('is defined', () => {
@@ -149,11 +147,9 @@ describe('Remove Signup Command Handler', () => {
     if (signup instanceof DocumentNotFoundException) {
       signupsCollection.findOneOrFail.mockRejectedValue(signup);
     } else {
-      signupsCollection.findOne.mockResolvedValue(
-        createMock<SignupDocument>(signup),
-      );
+      signupsCollection.findOne.mockResolvedValue(signup as SignupDocument);
       signupsCollection.findOneOrFail.mockResolvedValueOnce(
-        createMock<SignupDocument>(signup),
+        signup as SignupDocument,
       );
     }
 
@@ -179,12 +175,11 @@ describe('Remove Signup Command Handler', () => {
 
   it('calls removeSignup from SheetService if spreadsheetId is set and signup has been approved', async () => {
     settingsCollection.getSettings.mockResolvedValue(DEFAULT_SETTINGS);
+    discordService.userHasRole.mockResolvedValue(true);
 
-    signupsCollection.findOneOrFail.mockResolvedValueOnce(
-      createMock<SignupDocument>({
-        status: SignupStatus.APPROVED,
-      }),
-    );
+    signupsCollection.findOneOrFail.mockResolvedValueOnce({
+      status: SignupStatus.APPROVED,
+    } as SignupDocument);
 
     await handler.execute({ interaction });
     expect(sheetsService.removeSignup).toHaveBeenCalled();
@@ -193,25 +188,17 @@ describe('Remove Signup Command Handler', () => {
   it('does not call removeSignup from SheetService if the signup has not been approved', async () => {
     settingsCollection.getSettings.mockResolvedValue(DEFAULT_SETTINGS);
 
-    signupsCollection.findOneOrFail.mockResolvedValueOnce(
-      createMock<SignupDocument>({
-        status: SignupStatus.PENDING,
-      }),
-    );
+    signupsCollection.findOneOrFail.mockResolvedValueOnce({
+      status: SignupStatus.PENDING,
+    } as SignupDocument);
 
     await handler.execute({ interaction });
     expect(sheetsService.removeSignup).not.toHaveBeenCalled();
   });
 
   it('responds with validation error when invalid world is provided', async () => {
-    const invalidWorldInteraction = createMock<
-      ChatInputCommandInteraction<'cached'>
-    >({
-      user: createMock<User>({
-        id: '1',
-        toString: () => '<@1>',
-        valueOf: () => '',
-      }),
+    const invalidWorldInteraction = {
+      user: { id: '1', toString: () => '<@1>' } as unknown as User,
       options: {
         getString: (key: string) => {
           switch (key) {
@@ -226,8 +213,9 @@ describe('Remove Signup Command Handler', () => {
           }
         },
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
 
     await handler.execute({ interaction: invalidWorldInteraction });
 

--- a/src/slash-commands/retire/handlers/retire.command-handler.spec.ts
+++ b/src/slash-commands/retire/handlers/retire.command-handler.spec.ts
@@ -1,20 +1,21 @@
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, Colors } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { Colors } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../../discord/discord.service.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { RetireCommand } from '../commands/retire.command.js';
 import { RetireCommandHandler } from './retire.command-handler.js';
 
 describe('RetireCommandHandler', () => {
   let handler: RetireCommandHandler;
-  let discordService: DiscordService;
+  let discordService: Mocked<DiscordService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [RetireCommandHandler],
     })
-      .useMocker(createMock)
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(RetireCommandHandler);
@@ -50,7 +51,7 @@ describe('RetireCommandHandler', () => {
       const editReply = vi.fn().mockResolvedValue(undefined);
 
       return {
-        mock: createMock<ChatInputCommandInteraction<'cached'>>({
+        mock: {
           deferReply,
           editReply,
           guildId,
@@ -69,8 +70,7 @@ describe('RetireCommandHandler', () => {
               };
             },
           },
-          valueOf: () => '',
-        }),
+        } as unknown as ChatInputCommandInteraction<'cached'>,
         deferReply,
         editReply,
       };

--- a/src/slash-commands/search/handlers/search.command-handler.spec.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.spec.ts
@@ -1,16 +1,16 @@
-import type { DeepMocked } from '@golevelup/ts-vitest';
-import { createMock } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import {
+import type {
   ButtonInteraction,
   ChatInputCommandInteraction,
-  MessageFlags,
   StringSelectMenuInteraction,
 } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked } from 'vitest';
 import { Encounter } from '../../../encounters/encounters.consts.js';
 import { EncountersService } from '../../../encounters/encounters.service.js';
 import { SignupCollection } from '../../../firebase/collections/signup.collection.js';
+import { PartyStatus } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { SearchCommand } from '../commands/search.command.js';
 import {
   SEARCH_ENCOUNTER_SELECTOR_ID,
@@ -21,56 +21,58 @@ import { SearchCommandHandler } from './search.command-handler.js';
 
 describe('SearchCommandHandler', () => {
   let handler: SearchCommandHandler;
-  let mockSignupsCollection: DeepMocked<SignupCollection>;
-  let mockEncountersService: DeepMocked<EncountersService>;
-  let mockInteraction: DeepMocked<ChatInputCommandInteraction>;
-  let mockCollector: any; // Using 'any' to avoid complex typing issues
-  let mockReplyMessage: any;
+  let mockSignupsCollection: Mocked<SignupCollection>;
+  let mockEncountersService: Mocked<EncountersService>;
+  let mockInteraction: Mocked<ChatInputCommandInteraction>;
+  let mockCollector: ReturnType<typeof createAutoMock>;
+  let mockReplyMessage: ReturnType<typeof createAutoMock>;
 
   beforeEach(async () => {
-    mockSignupsCollection = createMock<SignupCollection>();
-    mockEncountersService = createMock<EncountersService>();
-    mockInteraction = createMock<ChatInputCommandInteraction>();
+    mockSignupsCollection =
+      createAutoMock() as unknown as Mocked<SignupCollection>;
+    mockEncountersService =
+      createAutoMock() as unknown as Mocked<EncountersService>;
+    mockInteraction =
+      createAutoMock() as unknown as Mocked<ChatInputCommandInteraction>;
 
-    // Force the interaction to have the right cache type
-    Object.defineProperty(mockInteraction, '_cacheType', {
-      value: 'cached',
-      writable: true,
-    });
+    mockCollector = createAutoMock();
+    mockCollector.on.mockReturnValue(mockCollector);
 
-    // Create a simple mock collector
-    mockCollector = {
-      on: vi.fn().mockReturnThis(),
-    };
+    mockReplyMessage = createAutoMock();
+    mockReplyMessage.createMessageComponentCollector.mockReturnValue(
+      mockCollector,
+    );
 
-    mockReplyMessage = {
-      createMessageComponentCollector: vi.fn().mockReturnValue(mockCollector),
-    };
-
-    mockInteraction.editReply.mockResolvedValue(mockReplyMessage);
+    mockInteraction.editReply.mockResolvedValue(mockReplyMessage as any);
     mockInteraction.user = { id: 'user123', username: 'testuser' } as any;
     mockInteraction.guildId = 'guild123';
 
     // Mock EncountersService methods
+    mockEncountersService.getProgPointsAsOptions.mockResolvedValue({
+      'P5 Phase 1': { label: 'P5 Phase 1', partyStatus: PartyStatus.ProgParty },
+      'P6 Enrage': { label: 'P6 Enrage', partyStatus: PartyStatus.ProgParty },
+      Clear: { label: 'Clear', partyStatus: PartyStatus.ClearParty },
+    });
+
     mockEncountersService.getProgPoints.mockResolvedValue([
       {
         id: 'P5 Phase 1',
         label: 'P5 Phase 1',
-        partyStatus: 'ProgParty',
+        partyStatus: PartyStatus.ProgParty,
         order: 0,
         active: true,
       },
       {
         id: 'P6 Enrage',
         label: 'P6 Enrage',
-        partyStatus: 'ProgParty',
+        partyStatus: PartyStatus.ProgParty,
         order: 1,
         active: true,
       },
       {
         id: 'Clear',
         label: 'Clear',
-        partyStatus: 'ClearParty',
+        partyStatus: PartyStatus.ClearParty,
         order: 2,
         active: true,
       },
@@ -156,7 +158,8 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // Create a mock select menu interaction for encounter selection
-    const mockSelectInteraction = createMock<StringSelectMenuInteraction>();
+    const mockSelectInteraction =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockSelectInteraction.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
     mockSelectInteraction.values = [Encounter.TOP];
     mockSelectInteraction.isStringSelectMenu.mockReturnValue(true);
@@ -207,7 +210,7 @@ describe('SearchCommandHandler', () => {
         progPoint: 'P6 Enrage',
       },
     ];
-    mockSignupsCollection.findAll.mockResolvedValue(mockSignups);
+    mockSignupsCollection.findAll.mockResolvedValue(mockSignups as any);
 
     // Mock the editReply responses
     mockInteraction.editReply.mockImplementation(() => {
@@ -231,7 +234,8 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // First, simulate encounter selection
-    const mockEncounterSelect = createMock<StringSelectMenuInteraction>();
+    const mockEncounterSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockEncounterSelect.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
     mockEncounterSelect.values = [Encounter.TOP];
     mockEncounterSelect.isStringSelectMenu.mockReturnValue(true);
@@ -254,7 +258,8 @@ describe('SearchCommandHandler', () => {
     await collectorCallback!(mockEncounterSelect);
 
     // Then, simulate prog point selection
-    const mockProgPointSelect = createMock<StringSelectMenuInteraction>();
+    const mockProgPointSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockProgPointSelect.customId = SEARCH_PROG_POINT_SELECT_ID;
     mockProgPointSelect.values = ['P6 Enrage'];
     mockProgPointSelect.isStringSelectMenu.mockReturnValue(true);
@@ -362,10 +367,10 @@ describe('SearchCommandHandler', () => {
     mockSignupsCollection.findAll.mockImplementation(
       ({ progPoint }: { progPoint?: string }) => {
         if (progPoint === 'P6 Enrage') {
-          return Promise.resolve(p6SignupsMock);
+          return Promise.resolve(p6SignupsMock as any);
         }
         if (progPoint === 'Clear') {
-          return Promise.resolve(clearSignupsMock);
+          return Promise.resolve(clearSignupsMock as any);
         }
         return Promise.resolve([]);
       },
@@ -378,14 +383,16 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // First, simulate encounter selection
-    const mockEncounterSelect = createMock<StringSelectMenuInteraction>();
+    const mockEncounterSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockEncounterSelect.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
     mockEncounterSelect.values = [Encounter.TOP];
     mockEncounterSelect.isStringSelectMenu.mockReturnValue(true);
     await collectorCallback!(mockEncounterSelect);
 
     // Then, simulate prog point selection
-    const mockProgPointSelect = createMock<StringSelectMenuInteraction>();
+    const mockProgPointSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockProgPointSelect.customId = SEARCH_PROG_POINT_SELECT_ID;
     mockProgPointSelect.values = ['P6 Enrage'];
     mockProgPointSelect.isStringSelectMenu.mockReturnValue(true);
@@ -405,7 +412,7 @@ describe('SearchCommandHandler', () => {
 
     // Verify the response contains multiple embeds
     expect(mockProgPointSelect.editReply).toHaveBeenCalled();
-    const editReplyCall = mockProgPointSelect.editReply.mock.calls[0][0];
+    const editReplyCall = mockProgPointSelect.editReply.mock.calls[0][0] as any;
     expect(editReplyCall).toHaveProperty('embeds');
     expect(editReplyCall.embeds).toHaveLength(2); // Should have 2 pages
 
@@ -456,7 +463,8 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // Simulate reset button click
-    const mockButtonInteraction = createMock<ButtonInteraction>();
+    const mockButtonInteraction =
+      createAutoMock() as unknown as Mocked<ButtonInteraction>;
     mockButtonInteraction.customId = SEARCH_RESET_BUTTON_ID;
 
     mockButtonInteraction.editReply.mockImplementation(() => {
@@ -541,9 +549,9 @@ describe('SearchCommandHandler', () => {
 
     // Mock findAll to return different results for different prog points
     mockSignupsCollection.findAll.mockImplementation(
-      ({ progPoint }: { progPoint: string }) => {
-        if (progPoint === 'P6 Enrage') return Promise.resolve(p6Signups);
-        if (progPoint === 'Clear') return Promise.resolve(clearSignups);
+      ({ progPoint }: { progPoint?: string }) => {
+        if (progPoint === 'P6 Enrage') return Promise.resolve(p6Signups as any);
+        if (progPoint === 'Clear') return Promise.resolve(clearSignups as any);
         return Promise.resolve([]);
       },
     );
@@ -555,14 +563,16 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // First, simulate encounter selection
-    const mockEncounterSelect = createMock<StringSelectMenuInteraction>();
+    const mockEncounterSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockEncounterSelect.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
     mockEncounterSelect.values = [Encounter.TOP];
     mockEncounterSelect.isStringSelectMenu.mockReturnValue(true);
     await collectorCallback!(mockEncounterSelect);
 
     // Then, simulate prog point selection (selecting P6 Enrage should include P6 Enrage and Clear)
-    const mockProgPointSelect = createMock<StringSelectMenuInteraction>();
+    const mockProgPointSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockProgPointSelect.customId = SEARCH_PROG_POINT_SELECT_ID;
     mockProgPointSelect.values = ['P6 Enrage'];
     mockProgPointSelect.isStringSelectMenu.mockReturnValue(true);
@@ -633,7 +643,7 @@ describe('SearchCommandHandler', () => {
       },
     ];
 
-    mockSignupsCollection.findAll.mockResolvedValue(clearSignups);
+    mockSignupsCollection.findAll.mockResolvedValue(clearSignups as any);
 
     // Execute the command
     const command = new SearchCommand(
@@ -642,14 +652,16 @@ describe('SearchCommandHandler', () => {
     await handler.execute(command);
 
     // First, simulate encounter selection
-    const mockEncounterSelect = createMock<StringSelectMenuInteraction>();
+    const mockEncounterSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockEncounterSelect.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
     mockEncounterSelect.values = [Encounter.TOP];
     mockEncounterSelect.isStringSelectMenu.mockReturnValue(true);
     await collectorCallback!(mockEncounterSelect);
 
     // Then, simulate prog point selection (selecting Clear should only include Clear)
-    const mockProgPointSelect = createMock<StringSelectMenuInteraction>();
+    const mockProgPointSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
     mockProgPointSelect.customId = SEARCH_PROG_POINT_SELECT_ID;
     mockProgPointSelect.values = ['Clear'];
     mockProgPointSelect.isStringSelectMenu.mockReturnValue(true);

--- a/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/channels/edit-channels.command-handler.spec.ts
@@ -1,21 +1,21 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { EditChannelsCommandHandler } from './edit-channels.command-handler.js';
 
 describe('Edit Channels Command Handler', () => {
   let handler: EditChannelsCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let errorService: DeepMocked<ErrorService>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let errorService: Mocked<ErrorService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [EditChannelsCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(EditChannelsCommandHandler);
@@ -42,24 +42,25 @@ describe('Edit Channels Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getChannel: (name: string) => {
             switch (name) {
               case 'signup-review-channel':
-                return createMock({ id: reviewChannelId });
+                return { id: reviewChannelId };
               case 'signup-public-channel':
-                return createMock({ id: signupChannelId });
+                return { id: signupChannelId };
               case 'moderation-channel':
-                return createMock({ id: autoModChannelId });
+                return { id: autoModChannelId };
               default:
                 return null;
             }
           },
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(
@@ -74,18 +75,19 @@ describe('Edit Channels Command Handler', () => {
 
   it('should handle errors gracefully', async () => {
     const error = new Error('Test error');
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
 
     settingsCollection.getSettings.mockRejectedValueOnce(error);
     errorService.handleCommandError.mockReturnValue(mockErrorEmbed);
 
-    const interaction = createMock<ChatInputCommandInteraction<'cached'>>({
+    const interaction = {
       guildId: '12345',
       options: {
-        getChannel: () => createMock({ id: '67890' }),
+        getChannel: () => ({ id: '67890' }),
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn(),
+      editReply: vi.fn(),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
 
     await handler.execute({ interaction });
 

--- a/src/slash-commands/settings/subcommands/reviewer/edit-reviewer.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/reviewer/edit-reviewer.command-handler.spec.ts
@@ -1,21 +1,25 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, EmbedBuilder, Role } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Role,
+} from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { EditReviewerCommandHandler } from './edit-reviewer.command-handler.js';
 
 describe('Edit Reviewer Command Handler', () => {
   let handler: EditReviewerCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let errorService: DeepMocked<ErrorService>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let errorService: Mocked<ErrorService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [EditReviewerCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(EditReviewerCommandHandler);
@@ -38,20 +42,20 @@ describe('Edit Reviewer Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getRole: (name: string, _required?: boolean) =>
             name === 'reviewer-role'
-              ? createMock<Role>({
+              ? ({
                   id: roleId,
                   toString: () => `<@&${roleId}>`,
-                  valueOf: () => '',
-                })
+                } as unknown as Role)
               : null,
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(
@@ -64,23 +68,20 @@ describe('Edit Reviewer Command Handler', () => {
 
   it('should handle errors gracefully', async () => {
     const error = new Error('Test error');
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
 
     settingsCollection.getSettings.mockRejectedValueOnce(error);
     errorService.handleCommandError.mockReturnValue(mockErrorEmbed);
 
-    const interaction = createMock<ChatInputCommandInteraction<'cached'>>({
+    const interaction = {
       guildId: '12345',
       options: {
         getRole: (_: string, __?: boolean) =>
-          createMock<Role>({
-            id: '67890',
-            toString: () => '<@&67890>',
-            valueOf: () => '',
-          }),
+          ({ id: '67890', toString: () => '<@&67890>' }) as unknown as Role,
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn(),
+      editReply: vi.fn(),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
 
     await handler.execute({ interaction });
 

--- a/src/slash-commands/settings/subcommands/roles/edit-encounter-roles.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/roles/edit-encounter-roles.command-handler.spec.ts
@@ -1,19 +1,19 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, Role } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction, Role } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { EditEncounterRolesCommandHandler } from './edit-encounter-roles.command-handler.js';
 
 describe('Edit Encounter Roles Command Handler', () => {
   let handler: EditEncounterRolesCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
+  let settingsCollection: Mocked<SettingsCollection>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [EditEncounterRolesCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(EditEncounterRolesCommandHandler);
@@ -38,7 +38,7 @@ describe('Edit Encounter Roles Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getString: (name: string, _required?: boolean) =>
@@ -46,24 +46,23 @@ describe('Edit Encounter Roles Command Handler', () => {
           getRole: (name: string, _required?: boolean) => {
             switch (name) {
               case 'prog-role':
-                return createMock<Role>({
+                return {
                   id: progRoleId,
                   toString: () => `<@&${progRoleId}>`,
-                  valueOf: () => '',
-                });
+                } as unknown as Role;
               case 'clear-role':
-                return createMock<Role>({
+                return {
                   id: clearRoleId,
                   toString: () => `<@&${clearRoleId}>`,
-                  valueOf: () => '',
-                });
+                } as unknown as Role;
               default:
                 return null;
             }
           },
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(

--- a/src/slash-commands/settings/subcommands/spreadsheet/edit-spreadsheet.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/spreadsheet/edit-spreadsheet.command-handler.spec.ts
@@ -1,21 +1,21 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { EditSpreadsheetCommandHandler } from './edit-spreadsheet.command-handler.js';
 
 describe('Edit Spreadsheet Command Handler', () => {
   let handler: EditSpreadsheetCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let errorService: DeepMocked<ErrorService>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let errorService: Mocked<ErrorService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [EditSpreadsheetCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(EditSpreadsheetCommandHandler);
@@ -38,14 +38,15 @@ describe('Edit Spreadsheet Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getString: (name: string, _required?: boolean) =>
             name === 'spreadsheet-id' ? spreadsheetId : null,
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(
@@ -58,19 +59,20 @@ describe('Edit Spreadsheet Command Handler', () => {
 
   it('should handle errors gracefully', async () => {
     const error = new Error('Test error');
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
 
     settingsCollection.getSettings.mockRejectedValueOnce(error);
     errorService.handleCommandError.mockReturnValue(mockErrorEmbed);
 
-    const interaction = createMock<ChatInputCommandInteraction<'cached'>>({
+    const interaction = {
       guildId: '12345',
       options: {
         getString: (_name: string, _requiredd?: boolean) =>
           'test-spreadsheet-id',
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn(),
+      editReply: vi.fn(),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
 
     await handler.execute({ interaction });
 

--- a/src/slash-commands/settings/subcommands/turbo-prog/edit-turbo-prog.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/turbo-prog/edit-turbo-prog.command-handler.spec.ts
@@ -1,21 +1,21 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { EditTurboProgCommandHandler } from './edit-turbo-prog.command-handler.js';
 
 describe('Edit Turbo Prog Command Handler', () => {
   let handler: EditTurboProgCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let errorService: DeepMocked<ErrorService>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let errorService: Mocked<ErrorService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [EditTurboProgCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(EditTurboProgCommandHandler);
@@ -40,7 +40,7 @@ describe('Edit Turbo Prog Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getBoolean: (name: string, _required?: boolean) =>
@@ -48,8 +48,9 @@ describe('Edit Turbo Prog Command Handler', () => {
           getString: (name: string) =>
             name === 'spreadsheet-id' ? spreadsheetId : null,
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(
@@ -73,15 +74,16 @@ describe('Edit Turbo Prog Command Handler', () => {
     settingsCollection.getSettings.mockResolvedValueOnce(existingSettings);
 
     await handler.execute({
-      interaction: createMock<ChatInputCommandInteraction<'cached'>>({
+      interaction: {
         guildId,
         options: {
           getBoolean: (name: string, _required?: boolean) =>
             name === 'active' ? active : null,
           getString: () => null,
         },
-        valueOf: () => '',
-      }),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction<'cached'>,
     });
 
     expect(settingsCollection.upsert).toHaveBeenCalledWith(
@@ -95,19 +97,20 @@ describe('Edit Turbo Prog Command Handler', () => {
 
   it('should handle errors gracefully', async () => {
     const error = new Error('Test error');
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
 
     settingsCollection.getSettings.mockRejectedValueOnce(error);
     errorService.handleCommandError.mockReturnValue(mockErrorEmbed);
 
-    const interaction = createMock<ChatInputCommandInteraction<'cached'>>({
+    const interaction = {
       guildId: '12345',
       options: {
         getBoolean: (_: string, __?: boolean) => true,
         getString: (_: string) => 'test-spreadsheet-id',
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn(),
+      editReply: vi.fn(),
+    } as unknown as ChatInputCommandInteraction<'cached'>;
 
     await handler.execute({ interaction });
 

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
@@ -1,19 +1,19 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked } from 'vitest';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { ViewSettingsCommandHandler } from './view-settings.command-handler.js';
 
 describe('View Settings Command Handler', () => {
   let handler: ViewSettingsCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
+  let settingsCollection: Mocked<SettingsCollection>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [ViewSettingsCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(ViewSettingsCommandHandler);
@@ -25,7 +25,8 @@ describe('View Settings Command Handler', () => {
   });
 
   it('should reply with the configured settings', async () => {
-    const interaction = createMock<ChatInputCommandInteraction<'cached'>>();
+    const interaction =
+      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
 
     settingsCollection.getSettings.mockResolvedValueOnce({
       reviewChannel: '12345',

--- a/src/slash-commands/signup/handlers/send-signup-review.command-handler.spec.ts
+++ b/src/slash-commands/signup/handlers/send-signup-review.command-handler.spec.ts
@@ -1,9 +1,8 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
+import type { LoggerService } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { GuildMember, TextChannel } from 'discord.js';
+import type { GuildMember } from 'discord.js';
 import { Timestamp } from 'firebase-admin/firestore';
-import type { Mock } from 'vitest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { MissingChannelException } from '../../../discord/discord.exceptions.js';
 import { DiscordService } from '../../../discord/discord.service.js';
 import { Encounter } from '../../../encounters/encounters.consts.js';
@@ -12,14 +11,14 @@ import {
   type SignupDocument,
   SignupStatus,
 } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { SendSignupReviewCommandHandler } from './send-signup-review.command-handler.js';
 
 describe('Send Signup Review Command Handler', () => {
   let handler: SendSignupReviewCommandHandler;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let discordServiceMock: DeepMocked<DiscordService>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let discordServiceMock: Mocked<DiscordService>;
 
-  let get: Mock;
   const signup: SignupDocument = {
     character: 'foo',
     discordId: '12345',
@@ -36,13 +35,11 @@ describe('Send Signup Review Command Handler', () => {
   };
 
   beforeEach(async () => {
-    get = vi.fn(() => undefined);
-
     const fixture = await Test.createTestingModule({
       providers: [SendSignupReviewCommandHandler],
     })
-      .useMocker(() => createMock())
-      .setLogger(createMock())
+      .useMocker(createAutoMock)
+      .setLogger(createAutoMock() as unknown as LoggerService)
       .compile();
 
     handler = fixture.get(SendSignupReviewCommandHandler);
@@ -56,24 +53,22 @@ describe('Send Signup Review Command Handler', () => {
 
     settingsCollection.getReviewChannel.mockResolvedValueOnce(undefined);
 
-    await handler.execute({ signup: createMock({}), guildId: '' });
+    await handler.execute({ signup: {} as SignupDocument, guildId: '' });
 
     expect(settingsCollection.getReviewChannel).toHaveBeenCalled();
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('sends a review if a review channel has been configured', async () => {
-    const spy = vi.spyOn(handler, 'sendSignupForApproval');
+    const spy = vi
+      .spyOn(handler, 'sendSignupForApproval')
+      .mockResolvedValue('reviewMessageId');
 
     settingsCollection.getReviewChannel.mockResolvedValueOnce('#foo');
-    get.mockReturnValueOnce(createMock<TextChannel>({}));
-    discordServiceMock.getGuildMember.mockResolvedValueOnce(
-      createMock<GuildMember>({
-        displayAvatarURL: () => 'http://foo',
-        toString: () => '<@ay>',
-        valueOf: () => 'some value',
-      }),
-    );
+    discordServiceMock.getGuildMember.mockResolvedValueOnce({
+      displayAvatarURL: () => 'http://foo',
+      toString: () => '<@ay>',
+    } as unknown as GuildMember);
 
     await handler.execute({
       signup,
@@ -88,16 +83,14 @@ describe('Send Signup Review Command Handler', () => {
     settingsCollection.getReviewChannel.mockResolvedValueOnce('#foo');
     discordServiceMock.getTextChannel.mockResolvedValueOnce(null);
 
-    get.mockReturnValueOnce(undefined);
-
     return expect(() =>
       handler.execute({
-        signup: createMock<SignupDocument>({
+        signup: {
           encounter: Encounter.DSR,
           status: SignupStatus.PENDING,
           character: 'foo',
           world: 'bar',
-        }),
+        } as SignupDocument,
         guildId: '',
       }),
     ).rejects.toThrow(MissingChannelException);

--- a/src/slash-commands/signup/handlers/signup-embed.event-handler.spec.ts
+++ b/src/slash-commands/signup/handlers/signup-embed.event-handler.spec.ts
@@ -1,9 +1,10 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { Colors, Message, User } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { Message, User } from 'discord.js';
+import { Colors } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../../discord/discord.service.js';
 import type { SignupDocument } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import {
   SignupApprovedEvent,
   SignupDeclinedEvent,
@@ -12,55 +13,57 @@ import { UpdateApprovalEmbedEventHandler } from './signup-embed.event-handler.js
 
 describe('SignupEmbedEventHandler', () => {
   let handler: UpdateApprovalEmbedEventHandler;
+  let message: Message<true>;
 
-  const message = createMock<Message<true>>({
-    guildId: '',
-    valueOf: () => '',
-  });
-
-  const reviewedBy = createMock<User>({
+  const reviewedBy = {
     id: '12345',
     displayAvatarURL: () => 'http://test-url.png',
-    valueOf: () => '',
     toString: () => '<@12345>',
-  });
+  } as unknown as User;
 
   const cases = [
     {
       color: Colors.Green,
       case: 'handles an approval event',
-      event: new SignupApprovedEvent(
-        createMock(),
-        createMock(),
-        reviewedBy,
-        message,
-      ),
+      createEvent: (msg: Message<true>) =>
+        new SignupApprovedEvent(
+          createAutoMock() as unknown as SignupDocument,
+          createAutoMock() as unknown as SignupDocument,
+          reviewedBy,
+          msg,
+        ),
       footer: 'Approved by Test User',
     },
     {
       color: Colors.Red,
       case: 'handles a declined event',
-      event: new SignupDeclinedEvent(
-        createMock<SignupDocument>({ discordId: '12345' }),
-        reviewedBy,
-        message,
-      ),
+      createEvent: (msg: Message<true>) =>
+        new SignupDeclinedEvent(
+          { discordId: '12345' } as SignupDocument,
+          reviewedBy,
+          msg,
+        ),
       footer: 'Declined by Test User',
       content: 'Declined <@12345>',
     },
   ];
 
   beforeEach(async () => {
+    message = {
+      guildId: '',
+      edit: vi.fn().mockResolvedValue(undefined),
+      embeds: [{}],
+    } as unknown as Message<true>;
+
     const fixture = await Test.createTestingModule({
       providers: [UpdateApprovalEmbedEventHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(UpdateApprovalEmbedEventHandler);
 
-    const discordService =
-      fixture.get<DeepMocked<DiscordService>>(DiscordService);
+    const discordService = fixture.get<Mocked<DiscordService>>(DiscordService);
 
     discordService.getDisplayName.mockResolvedValueOnce('Test User');
   });
@@ -69,7 +72,8 @@ describe('SignupEmbedEventHandler', () => {
     expect(handler).toBeDefined();
   });
 
-  it.each(cases)('$case', async ({ event, footer, color, content }) => {
+  it.each(cases)('$case', async ({ createEvent, footer, color, content }) => {
+    const event = createEvent(message);
     await handler.handle(event);
 
     expect(message.edit).toHaveBeenCalledWith({

--- a/src/slash-commands/signup/handlers/signup.command-handler.spec.ts
+++ b/src/slash-commands/signup/handlers/signup.command-handler.spec.ts
@@ -1,15 +1,22 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
+import type { LoggerService } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import {
+import type {
   ChannelSelectMenuInteraction,
   ChatInputCommandInteraction,
   DiscordjsError,
-  DiscordjsErrorCodes,
   EmbedBuilder,
   Message,
-  MessageFlags,
 } from 'discord.js';
-import { beforeEach, describe, expect, it, test } from 'vitest';
+import { DiscordjsErrorCodes, MessageFlags } from 'discord.js';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mocked,
+  test,
+  vi,
+} from 'vitest';
 import { UnhandledButtonInteractionException } from '../../../discord/discord.exceptions.js';
 import { DiscordService } from '../../../discord/discord.service.js';
 import { Encounter } from '../../../encounters/encounters.consts.js';
@@ -23,29 +30,32 @@ import {
   type SignupDocument,
   SignupStatus,
 } from '../../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { SignupCommand } from '../commands/signup.commands.js';
 import { SIGNUP_MESSAGES } from '../signup.consts.js';
 import { SignupCommandHandler } from './signup.command-handler.js';
 
 describe('Signup Command Handler', () => {
   let handler: SignupCommandHandler;
-  let interaction: DeepMocked<ChatInputCommandInteraction<'cached'>>;
-  let confirmationInteraction: DeepMocked<Message<boolean>>;
-  let settingsCollection: DeepMocked<SettingsCollection>;
-  let discordServiceMock: DeepMocked<DiscordService>;
-  let signupCollectionMock: DeepMocked<SignupCollection>;
-  let fflogsServiceMock: DeepMocked<FFLogsService>;
-  let errorService: DeepMocked<ErrorService>;
+  let interaction: Mocked<ChatInputCommandInteraction<'cached'>>;
+  let confirmationInteraction: Mocked<Message<true>>;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let discordServiceMock: Mocked<DiscordService>;
+  let signupCollectionMock: Mocked<SignupCollection>;
+  let fflogsServiceMock: Mocked<FFLogsService>;
+  let errorService: Mocked<ErrorService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [SignupCommandHandler],
     })
-      .useMocker(() => createMock())
-      .setLogger(createMock())
+      .useMocker(createAutoMock)
+      .setLogger(createAutoMock() as unknown as LoggerService)
       .compile();
 
-    confirmationInteraction = createMock<Message<boolean>>({});
+    confirmationInteraction = createAutoMock() as unknown as Mocked<
+      Message<true>
+    >;
     discordServiceMock = fixture.get(DiscordService);
     handler = fixture.get(SignupCommandHandler);
     settingsCollection = fixture.get(SettingsCollection);
@@ -53,11 +63,8 @@ describe('Signup Command Handler', () => {
     fflogsServiceMock = fixture.get(FFLogsService);
     errorService = fixture.get(ErrorService);
 
-    interaction = createMock<ChatInputCommandInteraction<'cached'>>({
-      user: {
-        username: 'Test User',
-        id: '123456',
-      },
+    interaction = {
+      user: { username: 'Test User', id: '123456' },
       options: {
         getString: (value: string) => {
           switch (value) {
@@ -79,11 +86,17 @@ describe('Signup Command Handler', () => {
         },
         getAttachment: () => null,
       },
-      valueOf: () => '',
-    });
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<ChatInputCommandInteraction<'cached'>>;
 
     discordServiceMock.getDisplayName.mockResolvedValue('Test Character');
-    errorService.handleCommandError.mockReturnValue(createMock<EmbedBuilder>());
+    errorService.handleCommandError.mockReturnValue({} as EmbedBuilder);
+    settingsCollection.getReviewChannel.mockResolvedValue('review-channel-id');
+    fflogsServiceMock.validateReportAge.mockResolvedValue({
+      isValid: true,
+      reportDate: new Date(),
+    });
   });
 
   test('is defined', () => {
@@ -91,12 +104,9 @@ describe('Signup Command Handler', () => {
   });
 
   it('confirms a signup', async () => {
-    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce(
-      createMock<ChannelSelectMenuInteraction>({
-        customId: 'confirm',
-        valueOf: () => '',
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce({
+      customId: 'confirm',
+    } as unknown as ChannelSelectMenuInteraction<'cached'>);
 
     interaction.editReply.mockResolvedValueOnce(confirmationInteraction);
 
@@ -119,21 +129,16 @@ describe('Signup Command Handler', () => {
     SignupStatus.PENDING,
     SignupStatus.UPDATE_PENDING,
   ])('deletes a prior review message on confirm if it exists and has status %s', async (status) => {
-    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce(
-      createMock<ChannelSelectMenuInteraction>({
-        customId: 'confirm',
-        valueOf: () => '',
-        guildId: 'g123',
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce({
+      customId: 'confirm',
+      guildId: 'g123',
+    } as unknown as ChannelSelectMenuInteraction<'cached'>);
 
     interaction.editReply.mockResolvedValueOnce(confirmationInteraction);
-    signupCollectionMock.upsert.mockResolvedValueOnce(
-      createMock<SignupDocument>({
-        status,
-        reviewMessageId: 'messageId123',
-      }),
-    );
+    signupCollectionMock.upsert.mockResolvedValueOnce({
+      status,
+      reviewMessageId: 'messageId123',
+    } as SignupDocument);
 
     const command = new SignupCommand(interaction);
     await handler.execute(command);
@@ -151,21 +156,16 @@ describe('Signup Command Handler', () => {
     SignupStatus.APPROVED,
     SignupStatus.DECLINED,
   ])('does not call delete if the prior approval has status %s', async (status) => {
-    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce(
-      createMock<ChannelSelectMenuInteraction>({
-        customId: 'confirm',
-        valueOf: () => '',
-        guildId: 'g123',
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce({
+      customId: 'confirm',
+      guildId: 'g123',
+    } as unknown as ChannelSelectMenuInteraction<'cached'>);
 
     interaction.editReply.mockResolvedValueOnce(confirmationInteraction);
-    signupCollectionMock.upsert.mockResolvedValueOnce(
-      createMock<SignupDocument>({
-        status,
-        reviewMessageId: 'messageId123',
-      }),
-    );
+    signupCollectionMock.upsert.mockResolvedValueOnce({
+      status,
+      reviewMessageId: 'messageId123',
+    } as SignupDocument);
 
     const command = new SignupCommand(interaction);
     await handler.execute(command);
@@ -174,15 +174,12 @@ describe('Signup Command Handler', () => {
   });
 
   it('handles UnhandledButtonInteractionException with ErrorService', async () => {
-    const mockErrorEmbed = createMock<EmbedBuilder>();
+    const mockErrorEmbed = {} as EmbedBuilder;
     errorService.handleCommandError.mockReturnValue(mockErrorEmbed);
 
-    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce(
-      createMock<ChannelSelectMenuInteraction>({
-        customId: 'foo',
-        valueOf: () => '',
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce({
+      customId: 'foo',
+    } as unknown as ChannelSelectMenuInteraction<'cached'>);
 
     interaction.editReply.mockResolvedValueOnce(confirmationInteraction);
 
@@ -199,12 +196,9 @@ describe('Signup Command Handler', () => {
   });
 
   it('handles cancelling a signup', async () => {
-    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce(
-      createMock<ChannelSelectMenuInteraction<any>>({
-        customId: 'cancel',
-        valueOf: () => '',
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockResolvedValueOnce({
+      customId: 'cancel',
+    } as unknown as ChannelSelectMenuInteraction<'cached'>);
 
     interaction.editReply.mockResolvedValueOnce(confirmationInteraction);
 
@@ -224,11 +218,9 @@ describe('Signup Command Handler', () => {
   });
 
   it('handles a timeout', async () => {
-    confirmationInteraction.awaitMessageComponent.mockRejectedValueOnce(
-      createMock<DiscordjsError>({
-        code: DiscordjsErrorCodes.InteractionCollectorError,
-      }),
-    );
+    confirmationInteraction.awaitMessageComponent.mockRejectedValueOnce({
+      code: DiscordjsErrorCodes.InteractionCollectorError,
+    } as unknown as DiscordjsError);
 
     interaction.editReply.mockResolvedValue(confirmationInteraction);
 
@@ -263,9 +255,7 @@ describe('Signup Command Handler', () => {
   describe('FFLogs Validation', () => {
     beforeEach(() => {
       settingsCollection.getReviewChannel.mockResolvedValue('123456789');
-      errorService.handleCommandError.mockReturnValue(
-        createMock<EmbedBuilder>(),
-      );
+      errorService.handleCommandError.mockReturnValue({} as EmbedBuilder);
       // Set up default values for FFLogs tests
       (interaction.options.getString as any) = (key: string) => {
         switch (key) {

--- a/src/slash-commands/signup/signup.service.spec.ts
+++ b/src/slash-commands/signup/signup.service.spec.ts
@@ -1,59 +1,57 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Message, MessageReaction, ReactionEmoji, User } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Message, MessageReaction, ReactionEmoji, User } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../discord/discord.service.js';
 import { SignupCollection } from '../../firebase/collections/signup.collection.js';
 import type { SettingsDocument } from '../../firebase/models/settings.model.js';
 import type { SignupDocument } from '../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
 import { SIGNUP_REVIEW_REACTIONS } from './signup.consts.js';
 import { SignupService } from './signup.service.js';
 
 // TODO: Actually assert approval/decline functionality, not just that they were called
 describe('SignupService', () => {
   let service: SignupService;
-  let messageReaction: DeepMocked<MessageReaction>;
-  let user: DeepMocked<User>;
-  let settings: DeepMocked<SettingsDocument>;
-  let signup: DeepMocked<SignupDocument>;
-  let repository: DeepMocked<SignupCollection>;
-  let discordService: DeepMocked<DiscordService>;
+  let messageReaction: MessageReaction;
+  let user: User;
+  let settings: SettingsDocument;
+  let signup: SignupDocument;
+  let repository: Mocked<SignupCollection>;
+  let discordService: Mocked<DiscordService>;
 
   beforeEach(async () => {
     const fixture: TestingModule = await Test.createTestingModule({
       providers: [SignupService],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     service = fixture.get(SignupService);
     repository = fixture.get(SignupCollection);
     discordService = fixture.get(DiscordService);
 
-    messageReaction = createMock<MessageReaction>({
-      message: createMock<Message>({
+    messageReaction = {
+      message: {
         id: 'messageId',
-        valueOf: () => '',
-        edit: vi.fn(),
-      }),
-      emoji: createMock<ReactionEmoji>({
+        edit: vi.fn().mockResolvedValue(undefined),
+        inGuild: vi.fn().mockReturnValue(true),
+      } as unknown as Message<boolean>,
+      emoji: {
         name: 'emojiName',
-        valueOf: () => '',
-      }),
-      valueOf: () => '',
-    });
+      } as unknown as ReactionEmoji,
+    } as unknown as MessageReaction;
 
-    user = createMock<User>({
+    user = {
+      id: 'userId',
       displayAvatarURL: () => 'http://someurl.com',
-      valueOf: () => '',
       toString: () => '<@someuser>',
-    });
-    settings = createMock<SettingsDocument>();
-    signup = createMock<SignupDocument>({
+    } as unknown as User;
+    settings = {} as SettingsDocument;
+    signup = {
       reviewMessageId: 'messageId',
       reviewedBy: undefined,
       discordId: 'abc123',
-    });
+    } as SignupDocument;
   });
 
   it('should be defined', () => {
@@ -107,9 +105,9 @@ describe('SignupService', () => {
 
     messageReaction.emoji.name = SIGNUP_REVIEW_REACTIONS.APPROVED;
 
+    const spy = vi.spyOn(service, 'handleApprovedReaction' as any);
     await service['handleReaction'](messageReaction, user, settings);
 
-    const spy = vi.spyOn(service, 'handleApprovedReaction' as any);
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/slash-commands/slash-commands.utils.spec.ts
+++ b/src/slash-commands/slash-commands.utils.spec.ts
@@ -1,5 +1,4 @@
-import { createMock } from '@golevelup/ts-vitest';
-import { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
 import { expect, test } from 'vitest';
 import { LookupCommand } from './lookup/commands/lookup.command.js';
 import { LookupSlashCommand } from './lookup/lookup.slash-command.js';
@@ -30,10 +29,9 @@ const cases = [
 }));
 
 test.each(cases)('$description', ({ input, expected }) => {
-  const interaction = createMock<ChatInputCommandInteraction<'cached'>>({
+  const interaction = {
     commandName: input,
-    valueOf: () => '',
-  });
+  } as unknown as ChatInputCommandInteraction<'cached'>;
 
   const result = getCommandForInteraction(interaction);
   expect(result).toBeInstanceOf(expected);

--- a/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.spec.ts
+++ b/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.spec.ts
@@ -1,6 +1,5 @@
-import { createMock, type DeepMocked } from '@golevelup/ts-vitest';
 import { Test } from '@nestjs/testing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { Encounter } from '../../../encounters/encounters.consts.js';
 import {
   PartyStatus,
@@ -8,6 +7,7 @@ import {
   SignupStatus,
 } from '../../../firebase/models/signup.model.js';
 import { SheetsService } from '../../../sheets/sheets.service.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import { turboProgSignupSchema } from '../turbo-prog-signup.schema.js';
 import { TURBO_PROG_SIGNUP_INVALID } from '../turboprog.consts.js';
 import { TurboProgCommandHandler } from './turbo-prog.command-handler.js';
@@ -50,13 +50,13 @@ const searchableCases: Pick<SignupDocument, 'status' | 'partyStatus'>[] = [
 
 describe('TurboProgCommandHandler', () => {
   let handler: TurboProgCommandHandler;
-  let sheetsService: DeepMocked<SheetsService>;
+  let sheetsService: Mocked<SheetsService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
       providers: [TurboProgCommandHandler],
     })
-      .useMocker(() => createMock())
+      .useMocker(createAutoMock)
       .compile();
 
     handler = fixture.get(TurboProgCommandHandler);
@@ -71,14 +71,14 @@ describe('TurboProgCommandHandler', () => {
     approvedCases,
   )('should return allowed for $status $partyStatus signups', async (signup) => {
     // Include role in the mock to ensure it's used properly in mapSignupToRowData
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       ...signup,
       role: 'TestRole',
       progPoint: 'TestProgPoint',
       character: 'TestCharacter',
       encounter: Encounter.DSR,
       discordId: 'testDiscordId',
-    });
+    } as SignupDocument;
 
     const options = turboProgSignupSchema.parse({
       encounter: Encounter.DSR,
@@ -104,11 +104,11 @@ describe('TurboProgCommandHandler', () => {
   it.each(
     declinedCases,
   )('should return rejected for $status $partyStatus signups', async (signup) => {
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       ...signup,
       encounter: Encounter.DSR,
       discordId: 'testDiscordId',
-    });
+    } as SignupDocument;
 
     const options = turboProgSignupSchema.parse({
       encounter: Encounter.DSR,
@@ -130,13 +130,13 @@ describe('TurboProgCommandHandler', () => {
   it.each(
     searchableCases,
   )('should search the sheet for signups for $status $partyStatus signups', async (signup) => {
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       ...signup,
       encounter: Encounter.DSR,
       discordId: 'testDiscordId',
       character: 'TestCharacter',
       world: 'TestWorld',
-    });
+    } as SignupDocument;
 
     const options = turboProgSignupSchema.parse({
       encounter: Encounter.DSR,
@@ -167,12 +167,12 @@ describe('TurboProgCommandHandler', () => {
     });
 
     // Create a mock signup to pass directly
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       encounter: Encounter.DSR,
       character: 'TestCharacter',
       world: 'TestWorld',
       discordId: 'testDiscordId',
-    });
+    } as SignupDocument;
 
     // Call the private method directly
     const response = await (handler as any).findCharacterRowValues(
@@ -208,15 +208,17 @@ describe('TurboProgCommandHandler', () => {
     });
 
     // Create a mock signup without required sheet data
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       encounter: Encounter.DSR,
       character: 'TestCharacter',
       world: 'TestWorld',
       discordId: 'testDiscordId',
-    });
+    } as SignupDocument;
 
     // Mock the sheet service to return null (no data found)
-    sheetsService.findCharacterRowValues.mockResolvedValueOnce(null);
+    sheetsService.findCharacterRowValues.mockResolvedValueOnce(
+      null as unknown as string[],
+    );
 
     // Call the private method directly
     const response = await (handler as any).findCharacterRowValues(
@@ -238,12 +240,12 @@ describe('TurboProgCommandHandler', () => {
     });
 
     // Create a mock signup
-    const mockSignup = createMock<SignupDocument>({
+    const mockSignup = {
       encounter: Encounter.DSR,
       character: 'TestCharacter',
       world: 'TestWorld',
       discordId: 'testDiscordId',
-    });
+    } as SignupDocument;
 
     // Mock the sheet service to return invalid data
     sheetsService.findCharacterRowValues.mockResolvedValueOnce([

--- a/src/test-utils/mock-factory.ts
+++ b/src/test-utils/mock-factory.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+
+// Prevent proxy being treated as a Promise, iterable, or primitive
+const TRANSPARENT_PROPS = new Set<string | symbol>([
+  'then',
+  'catch',
+  'finally',
+  Symbol.toPrimitive,
+  Symbol.iterator,
+  Symbol.asyncIterator,
+]);
+
+/**
+ * Creates a shallow auto-mock for use with NestJS `.useMocker()` and simple
+ * dependency injection. Every property returns a consistent `vi.fn()` — calling
+ * those functions returns `undefined` by default. Tests must call
+ * `.mockResolvedValue()` etc. to specify return values, which makes test intent
+ * explicit rather than relying on deep auto-mocking.
+ */
+export function createAutoMock(
+  _token?: unknown,
+): Record<string, ReturnType<typeof vi.fn>> {
+  const cache = new Map<string | symbol, ReturnType<typeof vi.fn>>();
+  return new Proxy({} as Record<string, ReturnType<typeof vi.fn>>, {
+    get(_, prop) {
+      if (TRANSPARENT_PROPS.has(prop)) return undefined;
+      if (!cache.has(prop))
+        cache.set(prop, vi.fn().mockResolvedValue(undefined));
+      return cache.get(prop)!;
+    },
+    set(_, prop, value) {
+      cache.set(prop, value);
+      return true;
+    },
+    defineProperty(_, prop, descriptor) {
+      if ('value' in descriptor) {
+        cache.set(prop, descriptor.value);
+      }
+      return true;
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces `@golevelup/ts-vitest` (now removed from `package.json`) with a custom `createAutoMock` Proxy factory in `src/test-utils/mock-factory.ts`
- Migrates all 29 spec files and the hygen command template to use `createAutoMock` / `.useMocker(createAutoMock)`
- Fixes three test quality issues found during QC: a false-negative spy assertion (spy created after execution), dead `get: Mock` variable leftover from the old library, and shared mutable `message` mock accumulated across `it.each` cases

## Test plan

- [ ] `pnpm test:ci` — all 292 tests pass
- [ ] `pnpm typecheck` — no type errors
- [ ] `pnpm lint` — no lint errors

> Re-opening of #1053 after git history was restored.