### PR TITLE
refactor: move AppSagas into SignupModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { LoggerModule } from 'nestjs-pino';
 import { AppController } from './app.controller.js';
-import { AppSagas } from './app.sagas.js';
 import { AppService } from './app.service.js';
 import { appConfig } from './config/app.js';
 import { DiscordModule } from './discord/discord.module.js';
@@ -31,7 +30,7 @@ import { SlashCommandsModule } from './slash-commands/slash-commands.module.js';
       },
     }),
   ],
-  providers: [AppService, AppSagas],
+  providers: [AppService],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/src/slash-commands/signup/signup.module.ts
+++ b/src/slash-commands/signup/signup.module.ts
@@ -15,6 +15,7 @@ import { SendSignupReviewCommandHandler } from './handlers/send-signup-review.co
 import { SignupCommandHandler } from './handlers/signup.command-handler.js';
 import { SignupDeclineReasonEventHandler } from './handlers/signup-decline-reason.event-handler.js';
 import { UpdateApprovalEmbedEventHandler } from './handlers/signup-embed.event-handler.js';
+import { SignupSagas } from './signup.sagas.js';
 import { SignupService } from './signup.service.js';
 
 @Module({
@@ -36,6 +37,7 @@ import { SignupService } from './signup.service.js';
     SendSignupReviewCommandHandler,
     SignupCommandHandler,
     SignupDeclineReasonEventHandler,
+    SignupSagas,
     SignupService,
     UpdateApprovalEmbedEventHandler,
   ],

--- a/src/slash-commands/signup/signup.sagas.ts
+++ b/src/slash-commands/signup/signup.sagas.ts
@@ -1,21 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { type ICommand, type IEvent, ofType, Saga } from '@nestjs/cqrs';
 import { filter, map, mergeMap, Observable } from 'rxjs';
-import { BlacklistSearchCommand } from './slash-commands/blacklist/blacklist.commands.js';
-import { RemoveSignupEvent } from './slash-commands/remove-signup/remove-signup.events.js';
-import { RemoveRolesCommand } from './slash-commands/signup/commands/signup.commands.js';
+import { BlacklistSearchCommand } from '../blacklist/blacklist.commands.js';
+import { RemoveSignupEvent } from '../remove-signup/remove-signup.events.js';
+import { TurboProgRemoveSignupCommand } from '../turboprog/commands/turbo-prog.commands.js';
+import { RemoveRolesCommand } from './commands/signup.commands.js';
 import {
   SignupApprovalSentEvent,
   SignupApprovedEvent,
   SignupCreatedEvent,
-} from './slash-commands/signup/events/signup.events.js';
-import { SendSignupReviewCommand } from './slash-commands/signup/handlers/send-signup-review.command.js';
-import { hasClearedStatus } from './slash-commands/signup/signup.utils.js';
-import { TurboProgRemoveSignupCommand } from './slash-commands/turboprog/commands/turbo-prog.commands.js';
+} from './events/signup.events.js';
+import { SendSignupReviewCommand } from './handlers/send-signup-review.command.js';
+import { hasClearedStatus } from './signup.utils.js';
 
-// TODO: Why are these at the app level? They should be in the signup module
 @Injectable()
-class AppSagas {
+class SignupSagas {
   /**
    * When a signup event is created, dispatch a command that sends a signup to a designated channel for review
    * @param event$
@@ -85,4 +84,4 @@ class AppSagas {
     );
 }
 
-export { AppSagas };
+export { SignupSagas };


### PR DESCRIPTION
## Summary

- Moves the four signup-domain sagas (`handleSignupCreated`, `handleClearedSignup`, `handleSignupRemoved`, `handleSignupApprovalSend`) out of the app-level `AppSagas` class into a new `SignupSagas` class in `src/slash-commands/signup/signup.sagas.ts`
- Registers `SignupSagas` as a provider in `SignupModule` (which already imports `CqrsModule`)
- Removes `AppSagas` from `AppModule` providers and deletes `src/app.sagas.ts`
- Resolves the `// TODO: Why are these at the app level?` comment

Closes #1173

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` passes (329 tests)
- [x] `pnpm lint` (Biome) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)