### PR TITLE
refactor: move RemoveRolesCommandHandler to RoleManagerModule

### DIFF
--- a/src/role-manager/remove-roles.command-handler.ts
+++ b/src/role-manager/remove-roles.command-handler.ts
@@ -2,11 +2,10 @@ import { Logger } from '@nestjs/common';
 import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
 import * as Sentry from '@sentry/nestjs';
 import { SentryTraced } from '@sentry/nestjs';
-import { DiscordService } from '../../../discord/discord.service.js';
-import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
-import { RemoveRolesCommand } from '../commands/signup.commands.js';
+import { DiscordService } from '../discord/discord.service.js';
+import { SettingsCollection } from '../firebase/collections/settings-collection.js';
+import { RemoveRolesCommand } from '../slash-commands/signup/commands/signup.commands.js';
 
-// TODO: Re-locate under `roles-manager` module
 @CommandHandler(RemoveRolesCommand)
 export class RemoveRolesCommandHandler
   implements ICommandHandler<RemoveRolesCommand>

--- a/src/role-manager/role-manager.module.ts
+++ b/src/role-manager/role-manager.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { DiscordModule } from '../discord/discord.module.js';
 import { FirebaseModule } from '../firebase/firebase.module.js';
+import { RemoveRolesCommandHandler } from './remove-roles.command-handler.js';
 import { RoleManagerService } from './role-manager.service.js';
 
 @Module({
-  imports: [DiscordModule, FirebaseModule],
-  providers: [RoleManagerService],
+  imports: [CqrsModule, DiscordModule, FirebaseModule],
+  providers: [RemoveRolesCommandHandler, RoleManagerService],
   exports: [RoleManagerService],
 })
 export class RoleManagerModule {}

--- a/src/slash-commands/signup/signup.module.ts
+++ b/src/slash-commands/signup/signup.module.ts
@@ -8,7 +8,6 @@ import { FirebaseModule } from '../../firebase/firebase.module.js';
 import { SheetsModule } from '../../sheets/sheets.module.js';
 import { DeclineReasonRequestService } from './decline-reason-request.service.js';
 import { AssignRolesEventHandler } from './handlers/assign-roles.event-handler.js';
-import { RemoveRolesCommandHandler } from './handlers/remove-roles.command-handler.js';
 import { SendApprovedMessageEventHandler } from './handlers/send-approved-message.event-handler.js';
 import { SendSignupReviewCommandHandler } from './handlers/send-signup-review.command-handler.js';
 import { SignupCommandHandler } from './handlers/signup.command-handler.js';
@@ -29,7 +28,6 @@ import { SignupService } from './signup.service.js';
   providers: [
     AssignRolesEventHandler,
     DeclineReasonRequestService,
-    RemoveRolesCommandHandler,
     SendApprovedMessageEventHandler,
     SendSignupReviewCommandHandler,
     SignupCommandHandler,

--- a/src/slash-commands/slash-commands.module.ts
+++ b/src/slash-commands/slash-commands.module.ts
@@ -3,6 +3,7 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { appConfig } from '../config/app.js';
 import { DiscordModule } from '../discord/discord.module.js';
 import { ErrorModule } from '../error/error.module.js';
+import { RoleManagerModule } from '../role-manager/role-manager.module.js';
 import { BlacklistModule } from './blacklist/blacklist.module.js';
 import { CleanRolesModule } from './clean-roles/clean-roles.module.js';
 import { EncountersSlashCommandModule } from './encounters/encounters.module.js';
@@ -24,6 +25,7 @@ import { TurboProgModule } from './turboprog/turbo-prog.module.js';
     DiscordModule,
     ErrorModule,
     CqrsModule,
+    RoleManagerModule,
     SlashCommandsSharedModule,
     BlacklistModule,
     CleanRolesModule,


### PR DESCRIPTION
## Summary

- Moves `RemoveRolesCommandHandler` from `src/slash-commands/signup/handlers/` to `src/role-manager/`, resolving the `// TODO: Re-locate under 'roles-manager' module` comment
- Updates all relative imports in the moved file to resolve correctly from the new location
- Adds `CqrsModule` and `RemoveRolesCommandHandler` to `RoleManagerModule` providers
- Removes `RemoveRolesCommandHandler` from `SignupModule` providers and import
- Imports `RoleManagerModule` into `SlashCommandsModule` so the CQRS command handler is registered in the application

Closes #1175

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` passes (329 tests)
- [x] Pre-commit hooks pass (typecheck, lint, test, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)