### PR TITLE
chore: remove redundant JSDoc from utility functions

### DIFF
--- a/src/slash-commands/signup/handlers/signup.command-handler.ts
+++ b/src/slash-commands/signup/handlers/signup.command-handler.ts
@@ -261,26 +261,11 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
       .setTimestamp();
   }
 
-  /**
-   * Validates an FFLogs URL for security and report age requirements.
-   *
-   * This method performs comprehensive validation of FFLogs URLs to prevent
-   * security vulnerabilities like URL spoofing while ensuring reports meet
-   * age requirements for competitive integrity.
-   *
-   * Security considerations:
-   * - Uses exact hostname matching to prevent subdomain spoofing attacks
-   * - Validates URL format before attempting report code extraction
-   * - Only accepts fflogs.com and www.fflogs.com as valid domains
-   *
-   * @param proofOfProgLink The URL string to validate, or null if none provided
-   * @returns Promise<FFLogsValidationResult> - Validation result with success status and error details
-   */
   private async validateFFLogsUrl(
     proofOfProgLink: string | null,
   ): Promise<FFLogsValidationResult> {
     if (!proofOfProgLink) {
-      return { success: true }; // No URL to validate
+      return { success: true };
     }
 
     try {
@@ -299,7 +284,6 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
       }
 
       if (reportCode) {
-        // Only proceed with FFLogs validation if we successfully extracted a report code
         try {
           const fflogsValidation =
             await this.fflogsService.validateReportAge(reportCode);
@@ -325,9 +309,8 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
         }
       }
 
-      return { success: true }; // Validation passed or no FFLogs URL provided
+      return { success: true };
     } catch (_: unknown) {
-      // Handle URL parsing errors
       return {
         success: false,
         errorMessage: 'Invalid URL format. Please provide a valid URL.',
@@ -438,10 +421,8 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
     error: unknown,
     interaction: ChatInputCommandInteraction<'cached'>,
   ): Promise<void> {
-    // Enhanced error handling with ErrorService
     const errorEmbed = this.errorService.handleCommandError(error, interaction);
 
-    // Preserve Discord-specific error handling
     if (error && typeof error === 'object' && 'code' in error) {
       if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {
         await interaction.editReply({
@@ -453,7 +434,6 @@ class SignupCommandHandler implements ICommandHandler<SignupCommand> {
       }
     }
 
-    // Default error response
     await interaction.editReply({ embeds: [errorEmbed] });
   }
 }

--- a/src/slash-commands/signup/signup.utils.ts
+++ b/src/slash-commands/signup/signup.utils.ts
@@ -23,57 +23,26 @@ export function hasClearedStatus({
   return partyStatus === PartyStatus.Cleared;
 }
 
-/**
- * Securely checks if a URL belongs to the FFLogs domain.
- *
- * This method provides secure domain validation by using exact hostname
- * matching instead of string inclusion checks. This prevents various
- * URL spoofing attacks where malicious domains could contain 'fflogs.com'
- * in their path, query parameters, or as part of a longer hostname.
- *
- * Security rationale:
- * - Prevents path injection: https://evil.com/fflogs.com/fake
- * - Prevents subdomain spoofing: https://fflogs.com.evil.com
- * - Prevents query parameter injection: https://evil.com?redirect=fflogs.com
- * - Only allows exact matches for fflogs.com and www.fflogs.com
- *
- * @param url The URL string to check
- * @returns boolean - true if URL is from a valid FFLogs domain, false otherwise
- */
+// exact hostname match prevents subdomain spoofing (e.g. fflogs.com.evil.com)
 export function isFFLogsUrl(url: URL): boolean {
   return url.hostname === 'fflogs.com' || url.hostname === 'www.fflogs.com';
 }
 
-/**
- * Extract report code from FFLogs URL
- * Supports various FFLogs URL formats:
- * - https://www.fflogs.com/reports/ABC123
- * - https://fflogs.com/reports/ABC123/
- * - https://www.fflogs.com/reports/ABC123#fight=1
- * @param url FFLogs URL
- * @returns Report code or null if not found
- */
 export function extractFflogsReportCode(url: string | URL): string | null {
   try {
-    // Check if it's an FFLogs domain (exact match or www subdomain only)
     const parsedUrl = url instanceof URL ? url : new URL(url);
     if (!isFFLogsUrl(parsedUrl)) {
       return null;
     }
 
-    // Extract report code from path: /reports/ABC123
     const pathMatch = parsedUrl.pathname.match(/\/reports\/([a-zA-Z0-9]+)/);
 
     return pathMatch ? pathMatch[1] : null;
   } catch {
-    // Invalid URL
     return null;
   }
 }
 
-/**
- * Checks if the reaction emoji is a valid signup review reaction
- */
 export function isValidReactionEmoji(emojiName: string | null): boolean {
   return (
     emojiName === SIGNUP_REVIEW_REACTIONS.APPROVED ||
@@ -81,9 +50,6 @@ export function isValidReactionEmoji(emojiName: string | null): boolean {
   );
 }
 
-/**
- * Checks if the reaction is from a bot (same as message author)
- */
 export function isBotReaction(
   messageAuthorId: string,
   userId: string,
@@ -91,9 +57,6 @@ export function isBotReaction(
   return messageAuthorId === userId;
 }
 
-/**
- * Maps error types to appropriate user-facing messages
- */
 export function getErrorReplyMessage(error: unknown): string {
   return match(error)
     .with(
@@ -107,9 +70,6 @@ export function getErrorReplyMessage(error: unknown): string {
     .otherwise(() => SIGNUP_MESSAGES.GENERIC_APPROVAL_ERROR);
 }
 
-/**
- * Builds an embed for prog point confirmation, optionally showing existing prog point
- */
 export function buildProgPointConfirmationEmbed(
   sourceEmbed: Embed,
   existingProgPoint?: string,


### PR DESCRIPTION
## Summary

- Removes redundant JSDoc and inline comments from `signup.utils.ts` and `signup.command-handler.ts` that restate function names, parameter names, return types, or implementation steps
- Replaces the 10-line `isFFLogsUrl` JSDoc with a single-line security note explaining *why* exact hostname matching is used
- Keeps only the `shouldDeleteReviewMessageForSignup` comment that explains a non-obvious business reason

Closes #1178

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (Biome)
- [x] All 329 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)