### PR TITLE
refactor: register RemoveSignupCommandHandler in RemoveSignupModule

### DIFF
--- a/src/slash-commands/remove-signup/remove-signup.module.ts
+++ b/src/slash-commands/remove-signup/remove-signup.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { DiscordModule } from '../../discord/discord.module.js';
+import { FirebaseModule } from '../../firebase/firebase.module.js';
+import { SheetsModule } from '../../sheets/sheets.module.js';
+import { RemoveSignupCommandHandler } from './handlers/remove-signup.command-handler.js';
+
+@Module({
+  imports: [CqrsModule, DiscordModule, FirebaseModule, SheetsModule],
+  providers: [RemoveSignupCommandHandler],
+})
+export class RemoveSignupModule {}

--- a/src/slash-commands/signup/signup.module.ts
+++ b/src/slash-commands/signup/signup.module.ts
@@ -6,7 +6,6 @@ import { ErrorModule } from '../../error/error.module.js';
 import { FfLogsModule } from '../../fflogs/fflogs.module.js';
 import { FirebaseModule } from '../../firebase/firebase.module.js';
 import { SheetsModule } from '../../sheets/sheets.module.js';
-import { RemoveSignupCommandHandler } from '../remove-signup/handlers/remove-signup.command-handler.js';
 import { DeclineReasonRequestService } from './decline-reason-request.service.js';
 import { AssignRolesEventHandler } from './handlers/assign-roles.event-handler.js';
 import { RemoveRolesCommandHandler } from './handlers/remove-roles.command-handler.js';
@@ -31,7 +30,6 @@ import { SignupService } from './signup.service.js';
     AssignRolesEventHandler,
     DeclineReasonRequestService,
     RemoveRolesCommandHandler,
-    RemoveSignupCommandHandler,
     SendApprovedMessageEventHandler,
     SendSignupReviewCommandHandler,
     SignupCommandHandler,

--- a/src/slash-commands/slash-commands.module.ts
+++ b/src/slash-commands/slash-commands.module.ts
@@ -9,6 +9,7 @@ import { EncountersSlashCommandModule } from './encounters/encounters.module.js'
 import { HelpModule } from './help/help.module.js';
 import { LookupModule } from './lookup/lookup.module.js';
 import { RemoveRoleModule } from './remove-role/remove-role.module.js';
+import { RemoveSignupModule } from './remove-signup/remove-signup.module.js';
 import { RetireModule } from './retire/retire.module.js';
 import { SearchModule } from './search/search.module.js';
 import { SettingsModule } from './settings/settings.module.js';
@@ -30,6 +31,7 @@ import { TurboProgModule } from './turboprog/turbo-prog.module.js';
     HelpModule,
     LookupModule,
     RemoveRoleModule,
+    RemoveSignupModule,
     RetireModule,
     SearchModule,
     SettingsModule,


### PR DESCRIPTION
## Summary

- Created `RemoveSignupModule` at `src/slash-commands/remove-signup/remove-signup.module.ts` with `CqrsModule`, `DiscordModule`, `FirebaseModule`, and `SheetsModule` imports to satisfy `RemoveSignupCommandHandler`'s dependencies
- Registered `RemoveSignupCommandHandler` as a provider in `RemoveSignupModule` instead of `SignupModule`
- Removed `RemoveSignupCommandHandler` from `SignupModule` providers and removed its import
- Added `RemoveSignupModule` to `SlashCommandsModule` imports

Closes #1174

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` passes (329 tests in worktree, all green)
- [x] Pre-commit hooks (lint, typecheck, test) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)