### PR TITLE
refactor(signup): replace flat SignupDocument with discriminated union by status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ pr-description.md
 *.db
 *.astro
 ai-docs/
+.worktrees/

--- a/src/firebase/collections/signup.collection.spec.ts
+++ b/src/firebase/collections/signup.collection.spec.ts
@@ -13,7 +13,11 @@ import type { SignupSchema } from '../../slash-commands/signup/signup.schema.js'
 import { createAutoMock } from '../../test-utils/mock-factory.js';
 import { FIRESTORE } from '../firebase.consts.js';
 import { DocumentNotFoundException } from '../firebase.exceptions.js';
-import { type SignupDocument, SignupStatus } from '../models/signup.model.js';
+import {
+  PartyStatus,
+  type SignupDocument,
+  SignupStatus,
+} from '../models/signup.model.js';
 import { SignupCollection } from './signup.collection.js';
 
 const SIGNUP_KEY = {
@@ -133,16 +137,27 @@ describe('Signup Repository', () => {
     });
   });
 
-  it('should call updateSignupStatus with the correct arguments', async () => {
-    await repository.updateSignupStatus(
-      SignupStatus.APPROVED,
+  it('should call approveSignup with the correct arguments', async () => {
+    await repository.approveSignup(
       SIGNUP_KEY,
-      'reviewedBy',
+      { progPoint: 'P8S', partyStatus: PartyStatus.ProgParty },
+      'reviewerUser',
     );
 
     expect(doc.update).toHaveBeenCalledWith({
       status: SignupStatus.APPROVED,
-      reviewedBy: 'reviewedBy',
+      reviewedBy: 'reviewerUser',
+      progPoint: 'P8S',
+      partyStatus: PartyStatus.ProgParty,
+    });
+  });
+
+  it('should call declineSignup with the correct arguments', async () => {
+    await repository.declineSignup(SIGNUP_KEY, 'reviewerUser');
+
+    expect(doc.update).toHaveBeenCalledWith({
+      status: SignupStatus.DECLINED,
+      reviewedBy: 'reviewerUser',
     });
   });
 

--- a/src/firebase/collections/signup.collection.ts
+++ b/src/firebase/collections/signup.collection.ts
@@ -7,15 +7,27 @@ import {
   Firestore,
   type Query,
   Timestamp,
+  type UpdateData,
 } from 'firebase-admin/firestore';
 import { InjectFirestore } from '../firebase.decorators.js';
 import { DocumentNotFoundException } from '../firebase.exceptions.js';
 import {
+  type ApprovedSignupDocument,
   type CreateSignupDocumentProps,
+  type DeclinedSignupDocument,
+  type PendingSignupDocument,
   type SignupCompositeKeyProps as SignupCompositeKey,
   type SignupDocument,
   SignupStatus,
 } from '../models/signup.model.js';
+
+// Internal type for Firestore field-based queries — not exported.
+// All fields optional; status-specific fields are included so callers can filter by them.
+type SignupFilter = Partial<
+  Omit<PendingSignupDocument, 'status'> &
+    Omit<ApprovedSignupDocument, 'status'> &
+    Omit<DeclinedSignupDocument, 'status'> & { status: SignupStatus }
+>;
 
 @Injectable()
 class SignupCollection {
@@ -58,8 +70,8 @@ class SignupCollection {
         // reset the reviewedBy field because it now has to be reviewed again
         reviewedBy: null,
         expiresAt,
-      };
-      await document.update(signupData);
+      } as unknown as SignupDocument;
+      await document.update(signupData as unknown as UpdateData<DocumentData>);
       return signupData;
     }
 
@@ -67,7 +79,7 @@ class SignupCollection {
       ...props,
       expiresAt,
       status: SignupStatus.PENDING,
-    };
+    } satisfies SignupDocument;
 
     await document.create(signupData);
     return signupData;
@@ -81,16 +93,14 @@ class SignupCollection {
 
   @SentryTraced()
   public async findOne(
-    query: Partial<SignupDocument>,
+    query: SignupFilter,
   ): Promise<SignupDocument | undefined> {
     const snapshot = await this.where(query).limit(1).get();
     return snapshot.docs.at(0)?.data();
   }
 
   @SentryTraced()
-  public async findOneOrFail(
-    query: Partial<SignupDocument>,
-  ): Promise<SignupDocument> {
+  public async findOneOrFail(query: SignupFilter): Promise<SignupDocument> {
     const signup = await this.findOne(query);
 
     if (!signup) {
@@ -101,9 +111,7 @@ class SignupCollection {
   }
 
   @SentryTraced()
-  public async findAll(
-    query: Partial<SignupDocument>,
-  ): Promise<SignupDocument[]> {
+  public async findAll(query: SignupFilter): Promise<SignupDocument[]> {
     const snapshot = await this.where(query).get();
     return snapshot.docs.map((doc) => doc.data() as SignupDocument);
   }
@@ -130,27 +138,36 @@ class SignupCollection {
   }
 
   /**
-   * Updates the approval status of a signup. Does not modify the timestamp of the signup
-   * @param status - new status for the signup
-   * @param key - composite key for the signup
-   * @param reviewedBy - discordId of the user that reviewed the signup
-   * @returns
+   * Records coordinator approval: sets status to APPROVED and captures
+   * the prog point and party type determined during review.
    */
   @SentryTraced()
-  public updateSignupStatus(
-    status: SignupStatus,
+  public approveSignup(
+    key: SignupCompositeKey,
     {
-      partyStatus,
       progPoint,
-      ...key
-    }: SignupCompositeKey & Pick<SignupDocument, 'progPoint' | 'partyStatus'>,
+      partyStatus,
+    }: Pick<ApprovedSignupDocument, 'progPoint' | 'partyStatus'>,
     reviewedBy: string,
   ) {
     return this.collection.doc(SignupCollection.getKeyForSignup(key)).update({
-      status,
+      status: SignupStatus.APPROVED,
       progPoint,
       reviewedBy,
       partyStatus,
+    });
+  }
+
+  /**
+   * Records coordinator decline: sets status to DECLINED.
+   * The decline reason is persisted separately via updateDeclineReason
+   * because it is collected asynchronously.
+   */
+  @SentryTraced()
+  public declineSignup(key: SignupCompositeKey, reviewedBy: string) {
+    return this.collection.doc(SignupCollection.getKeyForSignup(key)).update({
+      status: SignupStatus.DECLINED,
+      reviewedBy,
     });
   }
 
@@ -196,7 +213,7 @@ class SignupCollection {
    * @param props
    * @returns
    */
-  private where(props: Partial<SignupDocument>) {
+  private where(props: SignupFilter) {
     let query: Query = this.collection;
 
     for (const [key, value] of Object.entries(props)) {

--- a/src/firebase/models/signup.model.ts
+++ b/src/firebase/models/signup.model.ts
@@ -19,45 +19,64 @@ export enum PartyStatus {
   Cleared = 'Cleared',
 }
 
-// TODO: Some fields here _will_ be defined depending on the value of `status`. So we should improve the types to reflect this.
-export interface SignupDocument {
-  // Preserved for potential future use - no longer used in presentation layer
+interface SignupDocumentBase {
+  /** Preserved for potential future use - no longer used in presentation layer */
   availability?: string;
   character: string;
   discordId: string;
   encounter: Encounter;
   notes?: string | null;
   proofOfProgLink?: string | null;
-  // freeform field representing the characters job/role/class
+  /** freeform field representing the character's job/role/class */
   role: string;
-  // the prog point specified by the coodinator upon review
-  progPoint?: string;
-  // The prog point specified by the signup user
+  /** The prog point specified by the signup user */
   progPointRequested: string;
-  // the party type we determined they should be
-  partyStatus?: PartyStatus;
-  // discordId of the user that reviewed this signup
-  reviewedBy?: string | null;
-  // the message id of the review message posted to discord
+  /** the message id of the review message posted to discord */
   reviewMessageId?: string;
-  // discord uploaded screenshot link. These only last for 2 weeks on discord
+  /** discord uploaded screenshot link. These only last for 2 weeks on discord */
   screenshot?: string | null;
-  // the friendly name of the user that signed up
+  /** the friendly name of the user that signed up */
   username: string;
-  status: SignupStatus;
-  // user characters home world
+  /** user character's home world */
   world: string;
-  // reason provided by reviewer when declining a signup
-  declineReason?: string;
   expiresAt: Timestamp;
 }
 
+export interface PendingSignupDocument extends SignupDocumentBase {
+  status: SignupStatus.PENDING | SignupStatus.UPDATE_PENDING;
+  /** Only present for UPDATE_PENDING: prog point carried forward from the previous approval */
+  progPoint?: string;
+}
+
+export interface ApprovedSignupDocument extends SignupDocumentBase {
+  status: SignupStatus.APPROVED;
+  /** discordId of the user that reviewed this signup */
+  reviewedBy: string;
+  /** the prog point confirmed by the coordinator upon review */
+  progPoint?: string;
+  /** the party type we determined they should be */
+  partyStatus?: PartyStatus;
+}
+
+export interface DeclinedSignupDocument extends SignupDocumentBase {
+  status: SignupStatus.DECLINED;
+  /** discordId of the user that reviewed this signup */
+  reviewedBy: string;
+  /** reason provided by reviewer when declining a signup */
+  declineReason?: string;
+}
+
+export type SignupDocument =
+  | PendingSignupDocument
+  | ApprovedSignupDocument
+  | DeclinedSignupDocument;
+
 export type CreateSignupDocumentProps = Omit<
-  SignupDocument,
-  'status' | 'expiresAt' | 'declineReason' | 'availability'
+  SignupDocumentBase,
+  'expiresAt' | 'availability'
 >;
 
 export type SignupCompositeKeyProps = Pick<
-  SignupDocument,
+  SignupDocumentBase,
   'discordId' | 'encounter'
 >;

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -10,6 +10,7 @@ import { Encounter } from '../encounters/encounters.consts.js';
 import { EncountersService } from '../encounters/encounters.service.js';
 import { ErrorService } from '../error/error.service.js';
 import {
+  type ApprovedSignupDocument,
   PartyStatus,
   type SignupDocument,
 } from '../firebase/models/signup.model.js';
@@ -67,7 +68,7 @@ class SheetsService implements OnApplicationShutdown {
    */
   @SentryTraced()
   public upsertSignup(
-    { partyStatus, ...signup }: SignupDocument,
+    { partyStatus, ...signup }: ApprovedSignupDocument,
     spreadsheetId: string,
   ) {
     switch (partyStatus) {
@@ -443,7 +444,7 @@ class SheetsService implements OnApplicationShutdown {
 
   @SentryTraced()
   private async upsertRow(
-    signup: Omit<SignupDocument, 'partyStatus'>,
+    signup: Omit<ApprovedSignupDocument, 'partyStatus'>,
     spreadsheetId: string,
     partyStatus:
       | PartyStatus.ClearParty
@@ -514,7 +515,7 @@ class SheetsService implements OnApplicationShutdown {
     world,
     role,
     progPoint = '',
-  }: SignupDocument): string[] {
+  }: Omit<ApprovedSignupDocument, 'partyStatus'>): string[] {
     return [titleCase(character), titleCase(world), role, progPoint];
   }
 

--- a/src/slash-commands/lookup/handlers/lookup.command-handler.ts
+++ b/src/slash-commands/lookup/handlers/lookup.command-handler.ts
@@ -24,6 +24,7 @@ import { type LookupSchema, lookupSchema } from '../lookup.schema.js';
 type BlacklistStatus = 'No' | 'Yes' | 'Unknown';
 type SignupWithBlacklistStatus = SignupDocument & {
   blacklistStatus: BlacklistStatus;
+  progPoint?: string;
 };
 
 @CommandHandler(LookupCommand)

--- a/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.ts
+++ b/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.ts
@@ -152,12 +152,12 @@ class RemoveSignupCommandHandler
     signup,
   }: RemoveSignupProps): Promise<string> {
     let description = REMOVAL_SUCCESS;
-    // If the signup exists and has been approved, we expect to find it on the sheet
-    const validStatus =
+    // If the signup was approved (or re-submitted after approval), expect it on the sheet
+    const wasOnSheet =
       signup.status === SignupStatus.APPROVED ||
       signup.status === SignupStatus.UPDATE_PENDING;
 
-    if (spreadsheetId && validStatus) {
+    if (spreadsheetId && wasOnSheet) {
       const response = await this.sheetsService.removeSignup(
         dto,
         spreadsheetId,

--- a/src/slash-commands/search/handlers/search.command-handler.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.ts
@@ -15,7 +15,7 @@ import { type ApplicationModeConfig, appConfig } from '../../../config/app.js';
 import { Encounter } from '../../../encounters/encounters.consts.js';
 import { EncountersService } from '../../../encounters/encounters.service.js';
 import { SignupCollection } from '../../../firebase/collections/signup.collection.js';
-import type { SignupDocument } from '../../../firebase/models/signup.model.js';
+import type { ApprovedSignupDocument } from '../../../firebase/models/signup.model.js';
 import { SearchCommand } from '../commands/search.command.js';
 import {
   createEncounterSelectMenu,
@@ -202,8 +202,8 @@ class SearchCommandHandler implements ICommandHandler<SearchCommand> {
 
     const signupArrays = await Promise.all(signupPromises);
 
-    // Flatten the arrays (no deduplication needed since each user can only have one signup per encounter)
-    return signupArrays.flat();
+    // Signups filtered by progPoint are approved signups — only approved signups have progPoint set in Firestore.
+    return signupArrays.flat() as ApprovedSignupDocument[];
   }
 
   /**
@@ -212,7 +212,7 @@ class SearchCommandHandler implements ICommandHandler<SearchCommand> {
   private createResultsEmbed(
     encounter: Encounter,
     progPoint: string,
-    signups: SignupDocument[],
+    signups: ApprovedSignupDocument[],
   ): EmbedBuilder[] {
     // If no results found
     if (signups.length === 0) {
@@ -250,8 +250,11 @@ class SearchCommandHandler implements ICommandHandler<SearchCommand> {
       const fields = pageSignups.flatMap((signup) => [
         characterField(signup.character, { memberId: signup.discordId }),
         { name: 'Role', value: signup.role, inline: true },
-        // biome-ignore lint/style/noNonNullAssertion: prog point won't be undefined here but we should improve types of Signups to fix this kind of issue
-        { name: 'Prog Point', value: signup.progPoint!, inline: true },
+        {
+          name: 'Prog Point',
+          value: signup.progPoint ?? signup.progPointRequested,
+          inline: true,
+        },
       ]);
 
       return embed.addFields(fields);

--- a/src/slash-commands/signup/events/signup.events.ts
+++ b/src/slash-commands/signup/events/signup.events.ts
@@ -1,6 +1,10 @@
 import { Message, User } from 'discord.js';
 import type { SettingsDocument } from '../../../firebase/models/settings.model.js';
-import type { SignupDocument } from '../../../firebase/models/signup.model.js';
+import type {
+  ApprovedSignupDocument,
+  DeclinedSignupDocument,
+  SignupDocument,
+} from '../../../firebase/models/signup.model.js';
 
 export class SignupCreatedEvent {
   constructor(
@@ -18,7 +22,7 @@ export class SignupReviewCreatedEvent {
 
 export class SignupApprovedEvent {
   constructor(
-    public readonly signup: SignupDocument,
+    public readonly signup: ApprovedSignupDocument,
     public readonly settings: SettingsDocument,
     public readonly reviewedBy: User,
     public readonly message: Message<true>,
@@ -27,7 +31,7 @@ export class SignupApprovedEvent {
 
 export class SignupDeclinedEvent {
   constructor(
-    public readonly signup: SignupDocument,
+    public readonly signup: DeclinedSignupDocument,
     public readonly reviewedBy: User,
     public readonly message: Message<true>,
   ) {}

--- a/src/slash-commands/signup/handlers/send-approved-message.event-handler.ts
+++ b/src/slash-commands/signup/handlers/send-approved-message.event-handler.ts
@@ -15,8 +15,8 @@ import {
   EncounterFriendlyDescription,
 } from '../../../encounters/encounters.consts.js';
 import {
+  type ApprovedSignupDocument,
   PartyStatus,
-  type SignupDocument,
 } from '../../../firebase/models/signup.model.js';
 import { SignupApprovedEvent } from '../events/signup.events.js';
 
@@ -95,7 +95,7 @@ class SendApprovedMessageEventHandler
       discordId,
       proofOfProgLink,
       screenshot,
-    }: SignupDocument,
+    }: ApprovedSignupDocument,
   ): Promise<EmbedBuilder> {
     const progPointFieldValue = progPoint ?? progPointRequested;
     const emoji = this.discordService.getEmojiString(EncounterEmoji[encounter]);

--- a/src/slash-commands/signup/handlers/signup-embed.event-handler.spec.ts
+++ b/src/slash-commands/signup/handlers/signup-embed.event-handler.spec.ts
@@ -3,7 +3,10 @@ import type { Message, User } from 'discord.js';
 import { Colors } from 'discord.js';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../../discord/discord.service.js';
-import type { SignupDocument } from '../../../firebase/models/signup.model.js';
+import type {
+  ApprovedSignupDocument,
+  DeclinedSignupDocument,
+} from '../../../firebase/models/signup.model.js';
 import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import {
   SignupApprovedEvent,
@@ -27,8 +30,8 @@ describe('SignupEmbedEventHandler', () => {
       case: 'handles an approval event',
       createEvent: (msg: Message<true>) =>
         new SignupApprovedEvent(
-          createAutoMock() as unknown as SignupDocument,
-          createAutoMock() as unknown as SignupDocument,
+          createAutoMock() as unknown as ApprovedSignupDocument,
+          createAutoMock() as unknown as ApprovedSignupDocument,
           reviewedBy,
           msg,
         ),
@@ -39,7 +42,7 @@ describe('SignupEmbedEventHandler', () => {
       case: 'handles a declined event',
       createEvent: (msg: Message<true>) =>
         new SignupDeclinedEvent(
-          { discordId: '12345' } as SignupDocument,
+          { discordId: '12345' } as unknown as DeclinedSignupDocument,
           reviewedBy,
           msg,
         ),

--- a/src/slash-commands/signup/signup.service.spec.ts
+++ b/src/slash-commands/signup/signup.service.spec.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { DiscordService } from '../../discord/discord.service.js';
 import { SignupCollection } from '../../firebase/collections/signup.collection.js';
 import type { SettingsDocument } from '../../firebase/models/settings.model.js';
-import type { SignupDocument } from '../../firebase/models/signup.model.js';
+import {
+  type SignupDocument,
+  SignupStatus,
+} from '../../firebase/models/signup.model.js';
 import { createAutoMock } from '../../test-utils/mock-factory.js';
 import { SIGNUP_REVIEW_REACTIONS } from './signup.consts.js';
 import { SignupService } from './signup.service.js';
@@ -49,9 +52,9 @@ describe('SignupService', () => {
     settings = {} as SettingsDocument;
     signup = {
       reviewMessageId: 'messageId',
-      reviewedBy: undefined,
       discordId: 'abc123',
-    } as SignupDocument;
+      status: SignupStatus.PENDING,
+    } as unknown as SignupDocument;
   });
 
   it('should be defined', () => {
@@ -83,7 +86,7 @@ describe('SignupService', () => {
 
     repository.findByReviewId.mockResolvedValueOnce(signup);
     discordService.getDisplayName.mockResolvedValueOnce('someuser');
-    repository.updateSignupStatus.mockResolvedValueOnce({} as any);
+    repository.declineSignup.mockResolvedValueOnce({} as any);
     vi.spyOn(messageReaction.message, 'edit').mockResolvedValueOnce({} as any);
 
     const handleDeclineSpy = vi.spyOn(service, 'handleDeclinedReaction' as any);
@@ -100,8 +103,8 @@ describe('SignupService', () => {
   it('should return early if a signup has been reviewed', async () => {
     repository.findByReviewId.mockResolvedValue({
       ...signup,
-      reviewedBy: user.id,
-    });
+      status: SignupStatus.APPROVED,
+    } as unknown as SignupDocument);
 
     messageReaction.emoji.name = SIGNUP_REVIEW_REACTIONS.APPROVED;
 

--- a/src/slash-commands/signup/signup.service.ts
+++ b/src/slash-commands/signup/signup.service.ts
@@ -47,8 +47,10 @@ import { SettingsCollection } from '../../firebase/collections/settings-collecti
 import { SignupCollection } from '../../firebase/collections/signup.collection.js';
 import type { SettingsDocument } from '../../firebase/models/settings.model.js';
 import {
+  type ApprovedSignupDocument,
+  type DeclinedSignupDocument,
   PartyStatus,
-  type SignupDocument,
+  type PendingSignupDocument,
   SignupStatus,
 } from '../../firebase/models/signup.model.js';
 import { SheetsService } from '../../sheets/sheets.service.js';
@@ -187,7 +189,10 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
     // that there is no associated signup anymore
     const signup = await this.repository.findByReviewId(message.id);
 
-    if (signup.reviewedBy) {
+    if (
+      signup.status === SignupStatus.APPROVED ||
+      signup.status === SignupStatus.DECLINED
+    ) {
       this.logger.log(
         `signup ${signup.reviewMessageId} already reviewed by ${user.displayName}`,
       );
@@ -241,7 +246,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async handleApprovedReaction(
-    signup: SignupDocument,
+    signup: PendingSignupDocument,
     message: Message<true>,
     user: User,
     settings: SettingsDocument,
@@ -254,7 +259,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async confirmProgPoint(
-    signup: SignupDocument,
+    signup: PendingSignupDocument,
     message: Message<true>,
     user: User,
   ): Promise<string | undefined> {
@@ -264,22 +269,24 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async buildConfirmedSignup(
-    signup: SignupDocument,
+    signup: PendingSignupDocument,
     progPoint: string | undefined,
-  ): Promise<SignupDocument> {
+  ): Promise<ApprovedSignupDocument> {
     const partyStatus = progPoint
       ? await this.getPartyStatus(signup.encounter, progPoint)
       : undefined;
 
     return {
       ...signup,
+      status: SignupStatus.APPROVED,
+      reviewedBy: '',
       progPoint,
       partyStatus,
     };
   }
 
   private async persistApprovedSignup(
-    confirmedSignup: SignupDocument,
+    confirmedSignup: ApprovedSignupDocument,
     settings: SettingsDocument,
     user: User,
   ): Promise<void> {
@@ -299,29 +306,33 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
         encounter: confirmedSignup.encounter,
       });
     } else {
-      await this.repository.updateSignupStatus(
-        SignupStatus.APPROVED,
+      await this.repository.approveSignup(
         confirmedSignup,
+        {
+          progPoint: confirmedSignup.progPoint,
+          partyStatus: confirmedSignup.partyStatus,
+        },
         user.username,
       );
     }
   }
 
   private async handleDeclinedReaction(
-    signup: SignupDocument,
+    signup: PendingSignupDocument,
     message: Message<true>,
     user: User,
   ): Promise<SignupDeclinedEvent> {
-    // Update signup status immediately (for sequential reaction processing)
-    await this.repository.updateSignupStatus(
-      SignupStatus.DECLINED,
-      signup,
-      user.username,
-    );
+    await this.repository.declineSignup(signup, user.username);
+
+    const declinedSignup: DeclinedSignupDocument = {
+      ...signup,
+      status: SignupStatus.DECLINED,
+      reviewedBy: user.username,
+    };
 
     // Fire decline reason request with event dispatch context (non-blocking)
     this.declineReasonRequestService
-      .requestDeclineReason(signup, user, message)
+      .requestDeclineReason(declinedSignup, user, message)
       .catch((error) => {
         this.logger.error(
           error,
@@ -330,7 +341,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
       });
 
     // Return event immediately for embed footer update
-    return new SignupDeclinedEvent(signup, user, message);
+    return new SignupDeclinedEvent(declinedSignup, user, message);
   }
 
   private async handleError(
@@ -357,7 +368,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
 
   @SentryTraced()
   private async requestProgPointConfirmation(
-    signup: SignupDocument,
+    signup: PendingSignupDocument,
     sourceEmbed: Embed,
     user: User,
   ): Promise<string | undefined> {

--- a/src/slash-commands/signup/signup.utils.ts
+++ b/src/slash-commands/signup/signup.utils.ts
@@ -3,6 +3,7 @@ import { DiscordjsErrorCodes, Embed, EmbedBuilder } from 'discord.js';
 import { match, P } from 'ts-pattern';
 import { DocumentNotFoundException } from '../../firebase/firebase.exceptions.js';
 import {
+  type ApprovedSignupDocument,
   PartyStatus,
   type SignupDocument,
   SignupStatus,
@@ -19,7 +20,7 @@ export function shouldDeleteReviewMessageForSignup({ status }: SignupDocument) {
 
 export function hasClearedStatus({
   partyStatus,
-}: Pick<SignupDocument, 'partyStatus'>) {
+}: Pick<ApprovedSignupDocument, 'partyStatus'>) {
   return partyStatus === PartyStatus.Cleared;
 }
 

--- a/src/slash-commands/status/handlers/status.command-handler.ts
+++ b/src/slash-commands/status/handlers/status.command-handler.ts
@@ -8,6 +8,7 @@ import {
   type SignupDocument,
   SignupStatus,
 } from '../../../firebase/models/signup.model.js';
+
 import { SIGNUP_REVIEW_REACTIONS } from '../../signup/signup.consts.js';
 import { StatusCommand } from '../commands/status.command.js';
 import { StatusService } from '../status.service.js';
@@ -46,7 +47,8 @@ class StatusCommandHandler implements ICommandHandler<StatusCommand> {
   }
 
   private createStatusEmbed(signups: SignupDocument[]) {
-    const fields = signups.flatMap(({ encounter, status, partyStatus }) => {
+    const fields = signups.flatMap((signup) => {
+      const { encounter, status } = signup;
       const subfields = [
         {
           name: 'Encounter',
@@ -59,6 +61,11 @@ class StatusCommandHandler implements ICommandHandler<StatusCommand> {
           inline: true,
         },
       ];
+
+      const partyStatus =
+        signup.status === SignupStatus.APPROVED
+          ? signup.partyStatus
+          : undefined;
 
       if (partyStatus) {
         subfields.push({

--- a/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.spec.ts
+++ b/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { Encounter } from '../../../encounters/encounters.consts.js';
 import {
+  type ApprovedSignupDocument,
   PartyStatus,
   type SignupDocument,
   SignupStatus,
@@ -12,40 +13,25 @@ import { turboProgSignupSchema } from '../turbo-prog-signup.schema.js';
 import { TURBO_PROG_SIGNUP_INVALID } from '../turboprog.consts.js';
 import { TurboProgCommandHandler } from './turbo-prog.command-handler.js';
 
-const approvedCases: Pick<SignupDocument, 'status' | 'partyStatus'>[] = [
-  { status: SignupStatus.APPROVED, partyStatus: PartyStatus.ClearParty },
-  { status: SignupStatus.APPROVED, partyStatus: PartyStatus.ProgParty },
-];
+// APPROVED with an eligible party status → allowed into TurboProg
+const approvedCases: Pick<ApprovedSignupDocument, 'status' | 'partyStatus'>[] =
+  [
+    { status: SignupStatus.APPROVED, partyStatus: PartyStatus.ClearParty },
+    { status: SignupStatus.APPROVED, partyStatus: PartyStatus.ProgParty },
+  ];
 
-const declinedCases: Pick<SignupDocument, 'status' | 'partyStatus'>[] = [
+// APPROVED with an ineligible party status → rejected from TurboProg
+const invalidCases: Pick<ApprovedSignupDocument, 'status' | 'partyStatus'>[] = [
   { status: SignupStatus.APPROVED, partyStatus: PartyStatus.EarlyProgParty },
-  // any where status is cleared
   { status: SignupStatus.APPROVED, partyStatus: PartyStatus.Cleared },
-  { status: SignupStatus.PENDING, partyStatus: PartyStatus.Cleared },
-  { status: SignupStatus.UPDATE_PENDING, partyStatus: PartyStatus.Cleared },
-  { status: SignupStatus.DECLINED, partyStatus: PartyStatus.Cleared },
 ];
 
-const searchableCases: Pick<SignupDocument, 'status' | 'partyStatus'>[] = [
-  { status: SignupStatus.APPROVED, partyStatus: undefined },
-  // any pending signups might have had one prior to the bot and need to look at the sheet
-  { status: SignupStatus.PENDING, partyStatus: PartyStatus.ClearParty },
-  { status: SignupStatus.PENDING, partyStatus: PartyStatus.ProgParty },
-  { status: SignupStatus.PENDING, partyStatus: PartyStatus.EarlyProgParty },
-  { status: SignupStatus.PENDING, partyStatus: undefined },
-  { status: SignupStatus.UPDATE_PENDING, partyStatus: PartyStatus.ClearParty },
-  { status: SignupStatus.UPDATE_PENDING, partyStatus: PartyStatus.ProgParty },
-  {
-    status: SignupStatus.UPDATE_PENDING,
-    partyStatus: PartyStatus.EarlyProgParty,
-  },
-  { status: SignupStatus.UPDATE_PENDING, partyStatus: undefined },
-  // any signups that have been declined may be getting declined for a different reason
-  // and could still have a prior valid signup on the sheet
-  { status: SignupStatus.DECLINED, partyStatus: PartyStatus.ClearParty },
-  { status: SignupStatus.DECLINED, partyStatus: PartyStatus.ProgParty },
-  { status: SignupStatus.DECLINED, partyStatus: PartyStatus.EarlyProgParty },
-  { status: SignupStatus.DECLINED, partyStatus: undefined },
+// Non-APPROVED signups, or APPROVED with no party status → fall through to sheet search
+const searchableCases: { status: SignupStatus }[] = [
+  { status: SignupStatus.APPROVED },
+  { status: SignupStatus.PENDING },
+  { status: SignupStatus.UPDATE_PENDING },
+  { status: SignupStatus.DECLINED },
 ];
 
 describe('TurboProgCommandHandler', () => {
@@ -102,7 +88,7 @@ describe('TurboProgCommandHandler', () => {
   });
 
   it.each(
-    declinedCases,
+    invalidCases,
   )('should return rejected for $status $partyStatus signups', async (signup) => {
     const mockSignup = {
       ...signup,

--- a/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.ts
+++ b/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.ts
@@ -6,6 +6,7 @@ import { match, P } from 'ts-pattern';
 import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
 import { SignupCollection } from '../../../firebase/collections/signup.collection.js';
 import {
+  type ApprovedSignupDocument,
   PartyStatus,
   type SignupDocument,
   SignupStatus,
@@ -100,50 +101,33 @@ class TurboProgCommandHandler {
     spreadsheetId: string,
     signup?: SignupDocument,
   ): Promise<ProggerAllowedResponse> | ProggerAllowedResponse {
-    // if the progger has an entry already in the database we can check its status
     const scope = Sentry.getCurrentScope();
-    if (signup) {
-      return (
-        match([signup.status, signup.partyStatus])
-          .with(
-            // has a bot signup that was approved with a party status
-            [SignupStatus.APPROVED, PartyStatus.ClearParty],
-            [SignupStatus.APPROVED, PartyStatus.ProgParty],
-            () => ({
-              allowed: true as true,
-              data: this.mapSignupToRowData(signup, options),
-            }),
-          )
-          .with(
-            // has a bot signup that was approved but not an eligible party status
-            [SignupStatus.APPROVED, PartyStatus.EarlyProgParty],
-            [P.any, PartyStatus.Cleared],
-            () => {
-              scope.setExtra('options', options);
-              scope.captureMessage('Turbo Prog Signup Invalid', 'debug');
-              return {
-                error: TURBO_PROG_SIGNUP_INVALID,
-                allowed: undefined,
-              };
-            },
-          )
-          // they have a bot signup thats not been approved, but may have a prior signup on the sheet
-          .with(
-            [SignupStatus.APPROVED, P.nullish],
-            [SignupStatus.DECLINED, P.any],
-            [SignupStatus.PENDING, P.any],
-            [SignupStatus.UPDATE_PENDING, P.any],
-            () => this.findCharacterRowValues(options, spreadsheetId, signup),
-          )
-          .exhaustive()
-      );
+
+    if (!signup) {
+      scope.captureMessage('No Signup Found for Turbo Prog', 'debug');
+      return { allowed: undefined, error: TURBO_PROG_NO_SIGNUP_FOUND };
     }
 
-    scope.captureMessage('No Signup Found for Turbo Prog', 'debug');
-    return {
-      allowed: undefined,
-      error: TURBO_PROG_NO_SIGNUP_FOUND,
-    };
+    if (signup.status !== SignupStatus.APPROVED) {
+      // Not yet approved — check the sheet for a prior signup
+      return this.findCharacterRowValues(options, spreadsheetId, signup);
+    }
+
+    // signup is ApprovedSignupDocument here — partyStatus is type-safe
+    return match(signup.partyStatus)
+      .with(PartyStatus.ClearParty, PartyStatus.ProgParty, () => ({
+        allowed: true as true,
+        data: this.mapSignupToRowData(signup, options),
+      }))
+      .with(PartyStatus.EarlyProgParty, PartyStatus.Cleared, () => {
+        scope.setExtra('options', options);
+        scope.captureMessage('Turbo Prog Signup Invalid', 'debug');
+        return { error: TURBO_PROG_SIGNUP_INVALID, allowed: undefined };
+      })
+      .with(P.nullish, () =>
+        this.findCharacterRowValues(options, spreadsheetId, signup),
+      )
+      .exhaustive();
   }
 
   private async findCharacterRowValues(
@@ -180,14 +164,14 @@ class TurboProgCommandHandler {
   }
 
   private mapSignupToRowData(
-    { progPointRequested, progPoint, role, character }: SignupDocument,
+    { progPointRequested, progPoint, role, character }: ApprovedSignupDocument,
     { encounter }: TurboProgSignupSchema,
   ) {
     return {
       character,
       job: role,
       encounter,
-      progPoint: progPoint || progPointRequested,
+      progPoint: progPoint ?? progPointRequested,
     };
   }
 


### PR DESCRIPTION
## Summary

- Replaces the flat `SignupDocument` interface with a discriminated union: `PendingSignupDocument | ApprovedSignupDocument | DeclinedSignupDocument`, keyed on `status`
- Splits `SignupCollection.updateSignupStatus` into `approveSignup` and `declineSignup` with typed parameters
- Updates all consumers to narrow on `status` before accessing status-specific fields (`progPoint`, `partyStatus`, `reviewedBy`), eliminating `!` assertions and redundant null-checks

## Test Plan
- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm test:ci` — 318 tests passing
- [ ] `pnpm check` — no lint errors