### PR TITLE
build: use platformatic/node-caged Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26.1.0-slim AS base
+FROM platformatic/node-caged:26-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm install --global corepack@latest
@@ -20,7 +20,7 @@ COPY src ./src
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM node:26.1.0-slim
+FROM platformatic/node-caged:26-slim
 WORKDIR /app
 
 COPY package.json instrumentation.mjs ./


### PR DESCRIPTION
Replace the standard Node.js Docker image with `platformatic/node-caged`, a hardened Node.js image with additional security constraints.

## Changes

- Updated both the build stage and runtime stage in the Dockerfile to use `platformatic/node-caged:26-slim` instead of `node:26.1.0-slim`
- This provides a more secure execution environment while maintaining compatibility with the existing build and runtime setup

## Details

The `platformatic/node-caged` image is a security-hardened variant of Node.js that includes additional sandboxing and constraint mechanisms, reducing the attack surface in containerized deployments. The version tag remains compatible (Node.js 26 slim variant).

https://claude.ai/code/session_01T7op9yjaMf3CaEJCqPwpqB