### PR TITLE
fix(settings): gracefully handle sheet metadata fetch failures in view cmd

### DIFF
--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
@@ -1,13 +1,15 @@
 import { Test } from '@nestjs/testing';
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, type Mocked } from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { SheetsService } from '../../../../sheets/sheets.service.js';
 import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { ViewSettingsCommandHandler } from './view-settings.command-handler.js';
 
 describe('View Settings Command Handler', () => {
   let handler: ViewSettingsCommandHandler;
   let settingsCollection: Mocked<SettingsCollection>;
+  let sheetsService: Mocked<SheetsService>;
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
@@ -18,6 +20,7 @@ describe('View Settings Command Handler', () => {
 
     handler = fixture.get(ViewSettingsCommandHandler);
     settingsCollection = fixture.get(SettingsCollection);
+    sheetsService = fixture.get(SheetsService);
   });
 
   it('should be defined', () => {
@@ -39,5 +42,33 @@ describe('View Settings Command Handler', () => {
 
     expect(interaction.deferReply).toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalled();
+  });
+
+  it('replies with a fallback field when sheet metadata fetch fails', async () => {
+    const interaction =
+      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
+
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      reviewChannel: '12345',
+      progRoles: {},
+      spreadsheetId: 'sheet-abc',
+    });
+
+    sheetsService.getSheetMetadata.mockRejectedValueOnce(
+      new Error('The operation was aborted'),
+    );
+
+    await handler.execute({ interaction });
+
+    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
+      { embeds: { data: { fields: unknown[] } }[] },
+    ];
+
+    expect(embeds[0].data.fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Managed Spreadsheet',
+        value: 'Unable to fetch sheet info',
+      }),
+    );
   });
 });

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
@@ -44,6 +44,21 @@ class ViewSettingsCommandHandler
     private readonly errorService: ErrorService,
   ) {}
 
+  private async buildSpreadsheetField(name: string, spreadsheetId: string) {
+    try {
+      const { title, url } =
+        await this.sheetsService.getSheetMetadata(spreadsheetId);
+      return { name, value: `[${title}](${url})`, inline: true };
+    } catch (error) {
+      this.errorService.captureError(error);
+      return {
+        name,
+        value: 'Unable to fetch sheet info',
+        inline: true,
+      };
+    }
+  }
+
   @SentryTraced()
   async execute({ interaction }: ViewSettingsCommand): Promise<void> {
     const scope = Sentry.getCurrentScope();
@@ -132,24 +147,21 @@ class ViewSettingsCommandHandler
       ];
 
       if (turboProgSpreadsheetId) {
-        const { title, url } = await this.sheetsService.getSheetMetadata(
-          turboProgSpreadsheetId,
+        fields.push(
+          await this.buildSpreadsheetField(
+            'Turbo Prog Spreadsheet',
+            turboProgSpreadsheetId,
+          ),
         );
-        fields.push({
-          name: 'Turbo Prog Spreadsheet',
-          value: `[${title}](${url})`,
-          inline: true,
-        });
       }
 
       if (spreadsheetId) {
-        const { title, url } =
-          await this.sheetsService.getSheetMetadata(spreadsheetId);
-        fields.push({
-          name: 'Managed Spreadsheet',
-          value: `[${title}](${url})`,
-          inline: true,
-        });
+        fields.push(
+          await this.buildSpreadsheetField(
+            'Managed Spreadsheet',
+            spreadsheetId,
+          ),
+        );
       }
 
       const embed = new EmbedBuilder()


### PR DESCRIPTION
## Summary
- `/settings view` previously failed entirely (returning a generic error embed) when a Google Sheets metadata fetch timed out, since `getSheetMetadata` re-throws on non-404 errors.
- Sheet metadata fetches are now wrapped so a failure renders an **"Unable to fetch sheet info"** field instead of aborting the whole command. All other settings still display, and the error is reported to Sentry.

## Test plan
- [x] Added a unit test covering the timeout-fallback path
- [x] `pnpm typecheck` clean
- [x] All 330 tests pass