### PR TITLE
refactor: replace dayjs with Temporal API

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@sentry/nestjs": "^10.53.1",
     "@sentry/profiling-node": "^10.53.1",
     "cron": "^4.4.0",
-    "dayjs": "^1.11.20",
     "discord.js": "^14.26.4",
     "firebase-admin": "^13.10.0",
     "google-auth-library": "^10.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       cron:
         specifier: ^4.4.0
         version: 4.4.0
-      dayjs:
-        specifier: ^1.11.20
-        version: 1.11.20
       discord.js:
         specifier: ^14.26.4
         version: 14.26.4
@@ -2549,9 +2546,6 @@ packages:
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-
-  dayjs@1.11.20:
-    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debounce@3.0.0:
     resolution: {integrity: sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==}
@@ -7243,8 +7237,6 @@ snapshots:
   dataloader@2.2.3: {}
 
   dateformat@4.6.3: {}
-
-  dayjs@1.11.20: {}
 
   debounce@3.0.0: {}
 

--- a/src/fflogs/fflogs.service.spec.ts
+++ b/src/fflogs/fflogs.service.spec.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { expiredReportError } from './fflogs.consts.js';
 import { FFLogsService } from './fflogs.service.js';
@@ -17,7 +16,9 @@ describe('FFLogsService', () => {
 
   describe('validateReportAge', () => {
     test('should return valid for report within 28 days', async () => {
-      const recentDate = dayjs().subtract(15, 'day').valueOf(); // 15 days ago
+      const recentDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 15,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {
@@ -37,7 +38,9 @@ describe('FFLogsService', () => {
     });
 
     test('should return invalid for report older than 28 days', async () => {
-      const oldDate = dayjs().subtract(35, 'day').valueOf(); // 35 days ago
+      const oldDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 35,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {
@@ -52,7 +55,7 @@ describe('FFLogsService', () => {
       const result = await service.validateReportAge('ABC123');
 
       expect(result.isValid).toBe(false);
-      expect(result.errorMessage).toBe(expiredReportError(34, 28));
+      expect(result.errorMessage).toBe(expiredReportError(35, 28));
       expect(result.reportDate).toEqual(new Date(oldDate + 1000000));
     });
 
@@ -87,7 +90,9 @@ describe('FFLogsService', () => {
     });
 
     test('should use custom max age days', async () => {
-      const testDate = dayjs().subtract(40, 'day').valueOf(); // 40 days ago
+      const testDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 40,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {
@@ -105,7 +110,9 @@ describe('FFLogsService', () => {
     });
 
     test('should handle report exactly at boundary', async () => {
-      const boundaryDate = dayjs().subtract(28, 'day').valueOf(); // Exactly 28 days ago
+      const boundaryDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 28,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {
@@ -123,10 +130,10 @@ describe('FFLogsService', () => {
     });
 
     test('should handle report just over boundary', async () => {
-      const overBoundaryDate = dayjs()
-        .subtract(29, 'day')
-        .subtract(1, 'hour')
-        .valueOf(); // Just over 29 days ago
+      const overBoundaryDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 29,
+        hours: 1,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {
@@ -145,7 +152,9 @@ describe('FFLogsService', () => {
     });
 
     test('should handle concurrent validation requests', async () => {
-      const recentDate = dayjs().subtract(15, 'day').valueOf();
+      const recentDate = Temporal.Now.zonedDateTimeISO().subtract({
+        days: 15,
+      }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {
           report: {

--- a/src/fflogs/fflogs.service.ts
+++ b/src/fflogs/fflogs.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
-import dayjs from 'dayjs';
 import {
   catchError,
   EmptyError,
@@ -90,9 +89,13 @@ class FFLogsService {
 
       // FFLogs timestamps are in milliseconds
       const reportDate = new Date(report.endTime);
-      const now = dayjs();
-      const reportDayjs = dayjs(reportDate);
-      const daysDifference = now.diff(reportDayjs, 'day');
+      const now = Temporal.Now.plainDateISO();
+      const reportDatePlain = new Temporal.PlainDate(
+        reportDate.getFullYear(),
+        reportDate.getMonth() + 1,
+        reportDate.getDate(),
+      );
+      const daysDifference = now.since(reportDatePlain).days;
 
       if (daysDifference > maxAgeDays) {
         return {

--- a/src/firebase/collections/signup.collection.ts
+++ b/src/firebase/collections/signup.collection.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { SentryTraced } from '@sentry/nestjs';
-import day from 'dayjs';
 import {
   type CollectionReference,
   type DocumentData,
@@ -42,7 +41,9 @@ class SignupCollection {
   ): Promise<SignupDocument> {
     const key = SignupCollection.getKeyForSignup(props);
     const document = this.collection.doc(key);
-    const expiresAt = Timestamp.fromDate(day().add(28, 'days').toDate());
+    const expiresAt = Timestamp.fromMillis(
+      Temporal.Now.zonedDateTimeISO().add({ days: 28 }).epochMilliseconds,
+    );
     const snapshot = await document.get();
     const existing = snapshot.data();
 


### PR DESCRIPTION
## Summary

- Replace `dayjs()` calls with Node's built-in Temporal API across 3 files
- Remove dayjs dependency from `package.json`
- Behavioral improvement: `Temporal.PlainDate.since().days` uses calendar-day comparison (drops time component) — more correct than dayjs's time-truncated diff for the FFLogs age check

## Files Changed

- `src/fflogs/fflogs.service.ts` — `dayjs().diff()` → `Temporal.PlainDate.since()`
- `src/fflogs/fflogs.service.spec.ts` — 6 fixture generators → `Temporal.ZonedDateTime.subtract().epochMilliseconds`
- `src/firebase/collections/signup.collection.ts` — `day().add().toDate()` → `Temporal.Instant.add().epochMilliseconds` + `Timestamp.fromMillis()`
- `package.json` / `pnpm-lock.yaml` — remove dayjs dependency

## Test Plan

- [x] 306/306 tests passing
- [x] Typecheck clean (tsgo)
- [x] Biome lint clean