### PR TITLE
refactor(cli): remove Bun dependency, compile via tsgo

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 pnpm       = "11.3.0"
 node       = "26.2.0"
-bun        = "1.3.14"
 docker-cli = "29.5.2"
 yamlfmt    = "0.21.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "rimraf dist && tsgo -p tsconfig.build.json",
     "build:cli": "rimraf dist/cli && tsgo -p tsconfig.cli.json",
+    "build:all": "rimraf dist && tsgo -p tsconfig.build.json && tsgo -p tsconfig.cli.json",
     "check": "biome check",
     "commit": "git-cz",
     "commitlint": "commitlint --edit",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "lint:ci": "biome ci --diagnostic-level=error",
     "prepare": "node scripts/install-hooks.js",
     "start:dev:sentry": "NODE_OPTIONS=\"--import=./instrumentation.ts\" pnpm start:dev",
-    "cli": "dotenvx run -f .env -f .env.development -- bun src/cli/main.ts",
-    "cli:prod": "dotenvx run -f .env -f .env.development -- bun src/cli/main.ts",
+    "cli": "dotenvx run -f .env -f .env.development -- bun --env-file /dev/null src/cli/main.ts",
+    "cli:prod": "dotenvx run -f .env -f .env.production -- bun --env-file /dev/null src/cli/main.ts",
     "start": "dotenvx run -f .env -f .env.production -- node dist/main",
     "start:dev": "dotenvx run -f .env -f .env.development -- node dist/main.js",
     "test": "vitest",
@@ -57,6 +57,7 @@
     "rxjs": "^7.8.2",
     "title-case": "^4.3.2",
     "ts-pattern": "^5.9.0",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "@graphql-codegen/typescript-graphql-request": "^7.0.1",
     "@nestjs/schematics": "^11.1.0",
     "@nestjs/testing": "^11.1.23",
-    "@types/bun": "^1.3.14",
     "@types/node": "^25.9.1",
     "@typescript/native-preview": "7.0.0-dev.20260527.1",
     "@vitest/coverage-v8": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsgo -p tsconfig.build.json",
+    "build:cli": "rimraf dist/cli && tsgo -p tsconfig.cli.json",
     "check": "biome check",
     "commit": "git-cz",
     "commitlint": "commitlint --edit",
@@ -24,8 +25,8 @@
     "lint:ci": "biome ci --diagnostic-level=error",
     "prepare": "node scripts/install-hooks.js",
     "start:dev:sentry": "NODE_OPTIONS=\"--import=./instrumentation.ts\" pnpm start:dev",
-    "cli": "dotenvx run -f .env -f .env.development -- bun --env-file /dev/null src/cli/main.ts",
-    "cli:prod": "dotenvx run -f .env -f .env.production -- bun --env-file /dev/null src/cli/main.ts",
+    "cli": "dotenvx run -f .env -f .env.development -- node dist/cli/main.js",
+    "cli:prod": "dotenvx run -f .env -f .env.production -- node dist/cli/main.js",
     "start": "dotenvx run -f .env -f .env.production -- node dist/main",
     "start:dev": "dotenvx run -f .env -f .env.development -- node dist/main.js",
     "test": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -114,9 +117,6 @@ importers:
       '@nestjs/testing':
         specifier: ^11.1.23
         version: 11.1.23(@nestjs/common@11.1.23(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.23(@nestjs/common@11.1.23(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
-      '@types/bun':
-        specifier: ^1.3.14
-        version: 1.3.14
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -152,7 +152,7 @@ importers:
         version: 1.5.9(@swc/core@1.7.3)(rollup@4.60.4)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
 
 packages:
 
@@ -1809,9 +1809,6 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
-  '@types/bun@1.3.14':
-    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
-
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
@@ -2136,9 +2133,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  bun-types@1.3.14:
-    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   cachedir@2.3.0:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
@@ -4334,6 +4328,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -6151,10 +6150,6 @@ snapshots:
   '@tootallnate/once@2.0.1':
     optional: true
 
-  '@types/bun@1.3.14':
-    dependencies:
-      bun-types: 1.3.14
-
   '@types/caseless@0.12.5':
     optional: true
 
@@ -6245,7 +6240,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -6256,13 +6251,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -6291,7 +6286,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -6478,10 +6473,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  bun-types@1.3.14:
-    dependencies:
-      '@types/node': 25.9.1
 
   cachedir@2.3.0: {}
 
@@ -8689,7 +8680,7 @@ snapshots:
   uuid@9.0.1:
     optional: true
 
-  vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8701,12 +8692,12 @@ snapshots:
       '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -8723,7 +8714,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -8817,6 +8808,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./**/*.ts"],
+  "include": [
+    "./**/*.ts",
+    "../firebase/**/*.ts",
+    "../encounters/**/*.ts",
+    "../config/**/*.ts",
+    "../global.d.ts"
+  ],
   "compilerOptions": {
     "rootDir": "../../src"
   }

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["./**/*.ts"],
   "compilerOptions": {
-    "rootDir": "../../src",
-    "types": ["bun"]
+    "rootDir": "../../src"
   }
 }

--- a/src/cli/utils/config-loader.spec.ts
+++ b/src/cli/utils/config-loader.spec.ts
@@ -2,6 +2,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { stringify } from 'yaml';
 import { PartyStatus } from '../../firebase/models/signup.model.js';
 import { loadEncounterConfig } from './config-loader.js';
 
@@ -37,6 +38,13 @@ const validConfig = {
 describe('loadEncounterConfig', () => {
   it('loads and validates a JSON config file', () => {
     const filePath = writeConfig('enc.json', JSON.stringify(validConfig));
+    const result = loadEncounterConfig(filePath);
+    expect(result.id).toBe('DSR');
+    expect(result.progPoints).toHaveLength(2);
+  });
+
+  it('loads and validates a YAML config file', () => {
+    const filePath = writeConfig('enc.yaml', stringify(validConfig));
     const result = loadEncounterConfig(filePath);
     expect(result.id).toBe('DSR');
     expect(result.progPoints).toHaveLength(2);

--- a/src/cli/utils/config-loader.ts
+++ b/src/cli/utils/config-loader.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { extname } from 'node:path';
+import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import { PartyStatus } from '../../firebase/models/signup.model.js';
 
@@ -34,7 +35,7 @@ export function loadEncounterConfig(filePath: string): EncounterConfig {
 
   let parsed: unknown;
   if (ext === '.yaml' || ext === '.yml') {
-    parsed = Bun.YAML.parse(raw);
+    parsed = parseYaml(raw);
   } else if (ext === '.json') {
     parsed = JSON.parse(raw);
   } else {

--- a/src/cli/utils/encounter-yaml.spec.ts
+++ b/src/cli/utils/encounter-yaml.spec.ts
@@ -42,15 +42,15 @@ describe('writeEncounterYaml', () => {
     expect(content).toMatch(
       /^# yaml-language-server: \$schema=\.\/encounter\.schema\.yaml/,
     );
-    expect(content).toContain('"id": "TOP"');
-    expect(content).toContain('"active": true');
+    expect(content).toContain('id: TOP');
+    expect(content).toContain('active: true');
   });
 
   it('creates the directory if it does not exist', () => {
     const nested = join(TMP_DIR, 'nested', 'dir');
     writeEncounterYaml(nested, sampleConfig);
     const content = readFileSync(join(nested, 'TOP.yaml'), 'utf-8');
-    expect(content).toContain('"id": "TOP"');
+    expect(content).toContain('id: TOP');
   });
 });
 
@@ -68,7 +68,7 @@ describe('readEncounterYaml', () => {
 
   it('throws on invalid content', () => {
     const filePath = join(TMP_DIR, 'bad.yaml');
-    writeFileSync(filePath, JSON.stringify({ id: 123, active: 'notbool' }));
+    writeFileSync(filePath, 'id: 123\nactive: notbool');
     expect(() => readEncounterYaml(filePath)).toThrow('Invalid encounter YAML');
   });
 });

--- a/src/cli/utils/encounter-yaml.spec.ts
+++ b/src/cli/utils/encounter-yaml.spec.ts
@@ -1,30 +1,13 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { PartyStatus } from '../../firebase/models/signup.model.js';
 import {
   type EncounterYamlConfig,
   readEncounterYaml,
   writeEncounterYaml,
 } from './encounter-yaml.js';
-
-// Bun.YAML is only available in the Bun runtime; provide a minimal stub for
-// vitest (which runs under Node). JSON round-tripping is sufficient because
-// the tests care about schema validation, not YAML formatting.
-vi.stubGlobal('Bun', {
-  YAML: {
-    parse: (raw: string) => {
-      // Strip comment lines and blank lines that precede the JSON body
-      const stripped = raw
-        .split('\n')
-        .filter((line) => !line.startsWith('#') && line.trim() !== '')
-        .join('\n');
-      return JSON.parse(stripped);
-    },
-    stringify: (obj: unknown) => JSON.stringify(obj, null, 2),
-  },
-});
 
 const TMP_DIR = join(tmpdir(), 'cli-encounter-yaml-test');
 

--- a/src/cli/utils/encounter-yaml.ts
+++ b/src/cli/utils/encounter-yaml.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parse as parseYaml } from 'yaml';
+import { parse as parseYaml, stringify } from 'yaml';
 import { z } from 'zod';
 import { PartyStatus } from '../../firebase/models/signup.model.js';
 
@@ -55,7 +55,7 @@ export function writeEncounterYaml(
 ): void {
   mkdirSync(dirPath, { recursive: true });
   const filePath = join(dirPath, `${config.id}.yaml`);
-  const content = JSON.stringify(config, null, 2);
-  const withHeader = `${YAML_SCHEMA_HEADER}\n\n${content}\n`;
+  const content = stringify(config, { indent: 2 });
+  const withHeader = `${YAML_SCHEMA_HEADER}\n\n${content}`;
   writeFileSync(filePath, withHeader);
 }

--- a/src/cli/utils/encounter-yaml.ts
+++ b/src/cli/utils/encounter-yaml.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import { PartyStatus } from '../../firebase/models/signup.model.js';
 
@@ -35,7 +36,7 @@ export type EncounterYamlConfig = z.infer<typeof EncounterYamlConfigSchema>;
 
 export function readEncounterYaml(filePath: string): EncounterYamlConfig {
   const raw = readFileSync(filePath, 'utf-8');
-  const parsed: unknown = Bun.YAML.parse(raw);
+  const parsed: unknown = parseYaml(raw);
 
   const result = EncounterYamlConfigSchema.safeParse(parsed);
   if (!result.success) {
@@ -54,7 +55,7 @@ export function writeEncounterYaml(
 ): void {
   mkdirSync(dirPath, { recursive: true });
   const filePath = join(dirPath, `${config.id}.yaml`);
-  const content = Bun.YAML.stringify(config, null, 2);
+  const content = JSON.stringify(config, null, 2);
   const withHeader = `${YAML_SCHEMA_HEADER}\n\n${content}\n`;
   writeFileSync(filePath, withHeader);
 }

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "**/*.spec.ts"],
+  "include": [
+    "src/global.d.ts",
+    "src/cli/**/*.ts",
+    "src/firebase/**/*.ts",
+    "src/encounters/**/*.ts",
+    "src/config/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces `Bun.YAML` with the [`yaml`](https://www.npmjs.com/package/yaml) npm package in `encounter-yaml.ts` and `config-loader.ts` — the only Bun API surface in the CLI
- Adds `tsconfig.cli.json` that compiles `src/cli/` (plus shared firebase/encounters/config modules) to `dist/cli/` via tsgo
- Removes `@types/bun` from devDependencies; removes `"types": ["bun"]` from `src/cli/tsconfig.json`
- Adds `build:cli` script (`rimraf dist/cli && tsgo -p tsconfig.cli.json`) and `build:all` composite script
- Updates `cli` / `cli:prod` scripts to run `node dist/cli/main.js` instead of `bun src/cli/main.ts`
- Removes the `vi.stubGlobal('Bun', ...)` workaround from `encounter-yaml.spec.ts`; adds a YAML roundtrip test to `config-loader.spec.ts`
- Aligns `src/cli/tsconfig.json` (used by `pnpm typecheck`) to include the same shared modules as `tsconfig.cli.json` (used by `pnpm build:cli`)

## Test Plan

- [ ] `pnpm typecheck` — passes clean
- [ ] `pnpm test:ci` — 307 tests pass
- [ ] `pnpm build:cli` — produces `dist/cli/main.js`
- [ ] `pnpm build:all` — produces both `dist/main.js` and `dist/cli/main.js`
- [ ] `grep -r "Bun\." src/cli` — no results

🤖 Generated with [Claude Code](https://claude.ai/claude-code)