### PR TITLE
test(fflogs): make report-age boundary test deterministic

### DIFF
--- a/src/fflogs/fflogs.service.spec.ts
+++ b/src/fflogs/fflogs.service.spec.ts
@@ -132,7 +132,6 @@ describe('FFLogsService', () => {
     test('should handle report just over boundary', async () => {
       const overBoundaryDate = Temporal.Now.zonedDateTimeISO().subtract({
         days: 29,
-        hours: 1,
       }).epochMilliseconds;
       mockClient.reportData.mockResolvedValue({
         reportData: {


### PR DESCRIPTION
The "just over boundary" test subtracted `{ days: 29, hours: 1 }` and
asserted "29 days old". Since the dayjs->Temporal refactor (824e24a),
validateReportAge measures age in whole calendar days, so the 1-hour
offset crosses midnight when run shortly after local midnight, yielding
30 calendar days and a flaky failure (CI ran at 00:07). Dropping the
offset makes the report exactly 29 calendar days old at any hour.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012kGfCohqZzDGatsvK6BqW9