### PR TITLE
ci: run CI checks in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,16 @@ jobs:
       - run: pnpm graphql:codegen
         env:
           FFLOGS_API_ACCESS_TOKEN: ${{ secrets.FFLOGS_API_ACCESS_TOKEN }}
-      - run: pnpm typecheck
-      - run: pnpm build
-      - run: pnpm lint:ci
-      - run: pnpm test:ci
+      # These checks are mutually independent — they all consume the source and
+      # the codegen output but never each other's results (typecheck is
+      # --noEmit, build only writes dist/, test only writes coverage/, lint is
+      # read-only). Run them concurrently; the parallel block waits for all of
+      # them before continuing to the coverage upload.
+      - parallel:
+          - run: pnpm typecheck
+          - run: pnpm build
+          - run: pnpm lint:ci
+          - run: pnpm test:ci
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:


### PR DESCRIPTION
Restructure the CI workflow to run independent checks concurrently instead of sequentially.

## Summary
The typecheck, build, lint, and test steps are mutually independent—they all consume the source code and codegen output but never depend on each other's results. Running them in parallel reduces overall CI time while maintaining correctness.

## Changes
- Converted sequential CI checks to run concurrently using the `parallel` block
- Added explanatory comment documenting why these checks can safely run in parallel:
  - `typecheck` uses `--noEmit` (no output)
  - `build` only writes to `dist/`
  - `test` only writes to `coverage/`
  - `lint` is read-only
- The parallel block ensures all checks complete before proceeding to the coverage upload step

## Benefits
- Faster CI feedback loop
- No change to which checks run or their requirements
- Coverage upload still waits for all checks to complete

https://claude.ai/code/session_01K9fpWwY8LSqcqrKe55ww5G