### PR TITLE
fix(signup): recover and retry decline-reason modal on token expiry

### DIFF
--- a/src/slash-commands/signup/decline-reason-request.service.spec.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Message, StringSelectMenuInteraction, User } from 'discord.js';
+import { DiscordAPIError } from 'discord.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SignupDocument } from '../../firebase/models/signup.model.js';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
+import {
+  DeclineReasonRequestService,
+  MAX_MODAL_SHOW_ATTEMPTS,
+} from './decline-reason-request.service.js';
+import { CUSTOM_DECLINE_REASON_VALUE } from './signup.consts.js';
+
+const unknownInteractionError = () =>
+  new DiscordAPIError(
+    { message: 'Unknown interaction', code: 10062 },
+    10062,
+    404,
+    'POST',
+    '/interactions/123/abc/callback',
+    { body: undefined, files: undefined },
+  );
+
+describe('DeclineReasonRequestService', () => {
+  let service: DeclineReasonRequestService;
+  let signup: SignupDocument;
+  let reviewer: User;
+  let reviewMessage: Message<true>;
+  let signupId: string;
+
+  beforeEach(async () => {
+    const fixture: TestingModule = await Test.createTestingModule({
+      providers: [DeclineReasonRequestService],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    service = fixture.get(DeclineReasonRequestService);
+
+    signup = {
+      discordId: 'abc123',
+      encounter: 'DSR',
+    } as SignupDocument;
+    reviewer = { id: 'reviewerId' } as User;
+    reviewMessage = {} as Message<true>;
+    signupId = `${signup.discordId}-${signup.encounter}`;
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('handleReasonSelection', () => {
+    it('returns false and asks the reviewer to retry when the modal token has already expired', async () => {
+      const userSend = vi.fn().mockResolvedValue(undefined);
+      const interaction = {
+        values: [CUSTOM_DECLINE_REASON_VALUE],
+        showModal: vi.fn().mockRejectedValue(unknownInteractionError()),
+        user: { send: userSend },
+      } as unknown as StringSelectMenuInteraction;
+
+      const result = await service['handleReasonSelection'](
+        interaction,
+        signup,
+        signupId,
+        reviewer,
+        reviewMessage,
+      );
+
+      expect(result).toBe(false);
+      expect(userSend).toHaveBeenCalledWith(
+        expect.stringContaining('click the dropdown again'),
+      );
+    });
+
+    it('rethrows errors from showModal that are not a 10062', async () => {
+      const interaction = {
+        values: [CUSTOM_DECLINE_REASON_VALUE],
+        showModal: vi.fn().mockRejectedValue(new Error('boom')),
+        user: { send: vi.fn() },
+      } as unknown as StringSelectMenuInteraction;
+
+      await expect(
+        service['handleReasonSelection'](
+          interaction,
+          signup,
+          signupId,
+          reviewer,
+          reviewMessage,
+        ),
+      ).rejects.toThrow('boom');
+    });
+  });
+
+  describe('MAX_MODAL_SHOW_ATTEMPTS (reserved for retry loop, not yet implemented)', () => {
+    it('is exported with a sane default', () => {
+      expect(MAX_MODAL_SHOW_ATTEMPTS).toBeGreaterThan(1);
+    });
+  });
+});

--- a/src/slash-commands/signup/decline-reason-request.service.spec.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.spec.ts
@@ -4,6 +4,7 @@ import { DiscordAPIError } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SignupDocument } from '../../firebase/models/signup.model.js';
 import { createAutoMock } from '../../test-utils/mock-factory.js';
+import { DECLINE_REASON_SELECT_ID } from './decline-reason.components.js';
 import {
   DeclineReasonRequestService,
   MAX_MODAL_SHOW_ATTEMPTS,
@@ -91,9 +92,64 @@ describe('DeclineReasonRequestService', () => {
     });
   });
 
-  describe('MAX_MODAL_SHOW_ATTEMPTS (reserved for retry loop, not yet implemented)', () => {
-    it('is exported with a sane default', () => {
-      expect(MAX_MODAL_SHOW_ATTEMPTS).toBeGreaterThan(1);
+  describe('handleDeclineReasonInteractions retry loop', () => {
+    const buildSelectInteraction = () =>
+      ({
+        customId: `${DECLINE_REASON_SELECT_ID}-${signupId}`,
+      }) as StringSelectMenuInteraction;
+
+    it('re-listens for a selection and retries after a recoverable modal failure', async () => {
+      const selectInteraction = buildSelectInteraction();
+      const awaitMessageComponent = vi
+        .fn()
+        .mockResolvedValue(selectInteraction);
+      const dmMessage = {
+        awaitMessageComponent,
+      } as unknown as Message<false>;
+
+      const handleReasonSelectionSpy = vi
+        .spyOn(service as any, 'handleReasonSelection')
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      await service['handleDeclineReasonInteractions'](
+        dmMessage,
+        signup,
+        reviewer,
+        reviewMessage,
+      );
+
+      expect(awaitMessageComponent).toHaveBeenCalledTimes(2);
+      expect(handleReasonSelectionSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up and dispatches a no-reason decline after exhausting retry attempts', async () => {
+      const selectInteraction = buildSelectInteraction();
+      const awaitMessageComponent = vi
+        .fn()
+        .mockResolvedValue(selectInteraction);
+      const dmMessage = {
+        awaitMessageComponent,
+      } as unknown as Message<false>;
+
+      vi.spyOn(service as any, 'handleReasonSelection').mockResolvedValue(
+        false,
+      );
+      const dispatchSpy = vi
+        .spyOn(service as any, 'dispatchDeclineReasonEvent')
+        .mockImplementation(() => undefined);
+
+      await service['handleDeclineReasonInteractions'](
+        dmMessage,
+        signup,
+        reviewer,
+        reviewMessage,
+      );
+
+      expect(awaitMessageComponent).toHaveBeenCalledTimes(
+        MAX_MODAL_SHOW_ATTEMPTS,
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(signup, reviewer, reviewMessage);
     });
   });
 });

--- a/src/slash-commands/signup/decline-reason-request.service.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.ts
@@ -92,23 +92,45 @@ export class DeclineReasonRequestService {
     const timeout = 5 * 60 * 1000; // 5 minutes
 
     try {
-      const selectInteraction = await dmMessage.awaitMessageComponent({
-        filter: isSameUserFilter(reviewer),
-        componentType: ComponentType.StringSelect,
-        time: timeout,
-      });
+      let attempts = 0;
 
-      if (
-        selectInteraction.customId === `${DECLINE_REASON_SELECT_ID}-${signupId}`
-      ) {
-        await this.handleReasonSelection(
+      while (attempts < MAX_MODAL_SHOW_ATTEMPTS) {
+        const selectInteraction = await dmMessage.awaitMessageComponent({
+          filter: isSameUserFilter(reviewer),
+          componentType: ComponentType.StringSelect,
+          time: timeout,
+        });
+
+        if (
+          selectInteraction.customId !==
+          `${DECLINE_REASON_SELECT_ID}-${signupId}`
+        ) {
+          // Some other component interaction on this message — not a failed
+          // modal attempt, so it doesn't count against the retry budget.
+          continue;
+        }
+
+        const handled = await this.handleReasonSelection(
           selectInteraction as StringSelectMenuInteraction,
           signup,
           signupId,
           reviewer,
           reviewMessage,
         );
+
+        if (handled) {
+          return;
+        }
+
+        // Only reaches here when the modal failed to show (handleReasonSelection
+        // returned false) — counts toward the bounded retry budget.
+        attempts++;
       }
+
+      this.logger.warn(
+        `Gave up on the custom decline reason modal for signup ${signupId} after ${MAX_MODAL_SHOW_ATTEMPTS} attempts`,
+      );
+      this.dispatchDeclineReasonEvent(signup, reviewer, reviewMessage);
     } catch (error) {
       this.handleTimeoutError(
         error,

--- a/src/slash-commands/signup/decline-reason-request.service.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.ts
@@ -5,6 +5,7 @@ import { SentryTraced } from '@sentry/nestjs';
 import {
   ActionRowBuilder,
   ComponentType,
+  DiscordAPIError,
   DiscordjsError,
   DiscordjsErrorCodes,
   type InteractionResponse,
@@ -28,6 +29,8 @@ import {
 } from './decline-reason.components.js';
 import { SignupDeclineReasonCollectedEvent } from './events/signup.events.js';
 import { CUSTOM_DECLINE_REASON_VALUE } from './signup.consts.js';
+
+export const MAX_MODAL_SHOW_ATTEMPTS = 3;
 
 @Injectable()
 export class DeclineReasonRequestService {
@@ -123,13 +126,27 @@ export class DeclineReasonRequestService {
     signupId: string,
     reviewer: User,
     reviewMessage: Message<true>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const selectedValue = interaction.values[0];
 
     if (selectedValue === CUSTOM_DECLINE_REASON_VALUE) {
       // Show modal for custom reason
       const modal = createCustomDeclineReasonModal(signupId);
-      await interaction.showModal(modal);
+
+      try {
+        await interaction.showModal(modal);
+      } catch (error) {
+        if (error instanceof DiscordAPIError && error.code === 10062) {
+          this.logger.warn(
+            `Modal token expired before it could be shown for signup ${signupId}, asking reviewer to retry`,
+          );
+          await interaction.user.send(
+            'That took a moment too long to open — please click the dropdown again to provide a custom decline reason.',
+          );
+          return false;
+        }
+        throw error;
+      }
 
       try {
         const modalInteraction = await interaction.awaitModalSubmit({
@@ -170,6 +187,8 @@ export class DeclineReasonRequestService {
         flags: MessageFlags.Ephemeral,
       });
     }
+
+    return true;
   }
 
   private async handleCustomReasonSubmit(


### PR DESCRIPTION
## Summary
- Fixes a production Sentry error (`DiscordAPIError[10062]: Unknown interaction`, ULTI-PROJECT-BOT-4N) thrown from `interaction.showModal(modal)` in the decline-reason flow when the interaction token expires before the bot can acknowledge it. `showModal()` must be the interaction's first response (a hard Discord API constraint), so `deferReply()` can't be used to buy more time here.
- `DeclineReasonRequestService.handleReasonSelection` now catches `DiscordAPIError` code `10062` specifically, DMs the reviewer asking them to click the dropdown again, and returns `false` instead of rethrowing into the generic error-reporting path (which previously double-reported to Sentry through two unrelated try/catch layers).
- `handleDeclineReasonInteractions` now retries (re-arms the select-menu collector) up to `MAX_MODAL_SHOW_ATTEMPTS` (3) times whenever a recoverable failure is signaled, then gives up gracefully — logging a warning and dispatching a no-reason decline — if attempts are exhausted.

## Test plan
- [x] New spec file `decline-reason-request.service.spec.ts` (none existed before) covers: 10062 recovery + reviewer notification, rethrow of non-10062 errors, retry-then-succeed, and exhaust-attempts-then-give-up
- [x] `pnpm typecheck` — clean
- [x] `pnpm check` (Biome) — clean
- [x] `pnpm test:ci` — 41 files, 312 tests passing
- [x] Implemented via subagent-driven development with spec-compliance + code-quality review (with one fix round each) on every commit, plus a final whole-branch review

🤖 Generated with [Claude Code](https://claude.com/claude-code)