### PR TITLE
feat(settings): improve settings view UX

### DIFF
--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
@@ -1,15 +1,94 @@
 import { Test } from '@nestjs/testing';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type {
+  ButtonInteraction,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+import { Encounter } from '../../../../encounters/encounters.consts.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import type { SettingsDocument } from '../../../../firebase/models/settings.model.js';
 import { SheetsService } from '../../../../sheets/sheets.service.js';
 import { createAutoMock } from '../../../../test-utils/mock-factory.js';
 import { ViewSettingsCommandHandler } from './view-settings.command-handler.js';
+import {
+  SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
+  SETTINGS_VIEW_ENCOUNTER_SELECT_ID,
+  SETTINGS_VIEW_OVERVIEW_BUTTON_ID,
+  SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID,
+} from './view-settings.components.js';
+
+type EmbedPayload = {
+  embeds: {
+    data: {
+      title?: string;
+      description?: string;
+      fields?: { name: string; value: string }[];
+    };
+  }[];
+  components: { toJSON: () => { components: unknown[] } }[];
+};
 
 describe('ViewSettingsCommandHandler', () => {
   let command: ViewSettingsCommandHandler;
   let settingsCollection: Mocked<SettingsCollection>;
   let sheetsService: Mocked<SheetsService>;
+
+  const baseSettings: SettingsDocument = {
+    autoModChannelId: 'automod-chan',
+    reviewChannel: 'review-chan',
+    signupChannel: 'signup-chan',
+    reviewerRole: 'reviewer-role',
+    turboProgActive: true,
+    progRoles: { TOP: 'top-prog' },
+    clearRoles: { TOP: 'top-clear', DSR: 'dsr-clear' },
+    progPointRoles: { TOP: { P1: 'r1', P2: 'r2' }, DSR: { P3: 'r3' } },
+  };
+
+  function createInteraction() {
+    const interaction = createAutoMock() as unknown as Mocked<
+      ChatInputCommandInteraction<'cached'>
+    >;
+    const collector = createAutoMock();
+    const callbacks: {
+      collect?: (i: unknown) => Promise<void>;
+      end?: () => Promise<void>;
+    } = {};
+
+    collector.on.mockImplementation((event: string, cb: never) => {
+      if (event === 'collect') callbacks.collect = cb;
+      if (event === 'end') callbacks.end = cb;
+      return collector;
+    });
+
+    const replyMessage = createAutoMock();
+    replyMessage.createMessageComponentCollector.mockReturnValue(collector);
+
+    vi.mocked(interaction.editReply).mockResolvedValue(replyMessage as never);
+    interaction.user = { id: 'user123' } as never;
+
+    return { interaction, replyMessage, callbacks };
+  }
+
+  function createButtonInteraction(customId: string) {
+    const button = createAutoMock() as unknown as Mocked<ButtonInteraction>;
+    button.customId = customId;
+    button.isStringSelectMenu.mockReturnValue(false);
+    return button;
+  }
+
+  function createSelectInteraction(customId: string, values: string[]) {
+    const select =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
+    select.customId = customId;
+    select.values = values;
+    select.isStringSelectMenu.mockReturnValue(true);
+    return select;
+  }
+
+  function lastReplyPayload(mock: { mock: { calls: unknown[][] } }) {
+    return mock.mock.calls.at(-1)?.[0] as EmbedPayload;
+  }
 
   beforeEach(async () => {
     const fixture = await Test.createTestingModule({
@@ -27,42 +106,72 @@ describe('ViewSettingsCommandHandler', () => {
     expect(command).toBeDefined();
   });
 
-  it('should reply with the configured settings', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
-
-    settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-      reviewerRole: '67890',
-      signupChannel: '09876',
-      progRoles: {},
-    });
+  it('replies with an overview embed of core settings and role summary counts', async () => {
+    const { interaction } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
 
     await command.execute(interaction);
 
-    expect(interaction.deferReply).toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalled();
+    const { embeds, components } = lastReplyPayload(
+      vi.mocked(interaction.editReply),
+    );
+    const fields = embeds[0].data.fields ?? [];
+
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Review Channel',
+        value: '<#review-chan>',
+      }),
+    );
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Reviewer Role',
+        value: '<@&reviewer-role>',
+      }),
+    );
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Prog Roles',
+        value: '1 encounter configured',
+      }),
+    );
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Clear Roles',
+        value: '2 encounters configured',
+      }),
+    );
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Prog Point Roles',
+        value: '2 encounters configured (3 prog points)',
+      }),
+    );
+
+    // no per-encounter prog point fields on the overview anymore
+    expect(fields.some((f) => f.name.startsWith('Prog Point Roles — '))).toBe(
+      false,
+    );
+
+    // a single nav button row
+    expect(components).toHaveLength(1);
+    expect(components[0].toJSON().components).toHaveLength(3);
   });
 
   it('replies with a fallback field when sheet metadata fetch fails', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
+    const { interaction } = createInteraction();
 
     settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-      progRoles: {},
+      ...baseSettings,
       spreadsheetId: 'sheet-abc',
     });
-
     sheetsService.getSheetMetadata.mockRejectedValueOnce(
       new Error('The operation was aborted'),
     );
 
     await command.execute(interaction);
 
-    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
-      { embeds: { data: { fields: unknown[] } }[] },
-    ];
+    const { embeds } = lastReplyPayload(vi.mocked(interaction.editReply));
 
     expect(embeds[0].data.fields).toContainEqual(
       expect.objectContaining({
@@ -72,111 +181,174 @@ describe('ViewSettingsCommandHandler', () => {
     );
   });
 
-  it('renders prog point role mappings', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
-
-    settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-      progPointRoles: {
-        TOP: { P1: 'role-p1', P2: 'role-p2' },
-      },
-    });
+  it('shows prog and clear role mappings when the encounter roles button is clicked', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
 
     await command.execute(interaction);
 
-    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
-      { embeds: { data: { fields: { name: string; value: string }[] } }[] },
-    ];
-
-    const field = embeds[0].data.fields.find(
-      (f) => f.name === 'Prog Point Roles — TOP',
+    const button = createButtonInteraction(
+      SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
     );
+    await callbacks.collect?.(button);
 
-    expect(field?.value).toContain('**P1:** <@&role-p1>');
-    expect(field?.value).toContain('**P2:** <@&role-p2>');
+    expect(button.deferUpdate).toHaveBeenCalled();
+
+    const { embeds } = lastReplyPayload(vi.mocked(button.editReply));
+    const fields = embeds[0].data.fields ?? [];
+
+    expect(embeds[0].data.title).toBe('Settings — Encounter Roles');
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Prog Roles',
+        value: '**TOP:** <@&top-prog>',
+      }),
+    );
+    expect(fields.find((f) => f.name === 'Clear Roles')?.value).toContain(
+      '**DSR:** <@&dsr-clear>',
+    );
   });
 
-  it('renders a separate field per encounter with prog point role mappings', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
-
+  it('shows an encounter select menu when the prog point roles button is clicked', async () => {
+    const { interaction, callbacks } = createInteraction();
     settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-      progPointRoles: {
-        TOP: { P1: 'role-p1' },
-        DSR: { P1: 'role-dsr-p1' },
-      },
+      ...baseSettings,
+      progPointRoles: { TOP: { P1: 'r1' }, DSR: {} },
     });
 
     await command.execute(interaction);
 
-    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
-      { embeds: { data: { fields: { name: string; value: string }[] } }[] },
-    ];
-
-    const topField = embeds[0].data.fields.find(
-      (f) => f.name === 'Prog Point Roles — TOP',
+    const button = createButtonInteraction(
+      SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID,
     );
-    const dsrField = embeds[0].data.fields.find(
-      (f) => f.name === 'Prog Point Roles — DSR',
+    await callbacks.collect?.(button);
+
+    const { embeds, components } = lastReplyPayload(
+      vi.mocked(button.editReply),
     );
 
-    expect(topField?.value).toContain('**P1:** <@&role-p1>');
-    expect(dsrField?.value).toContain('**P1:** <@&role-dsr-p1>');
-  });
-
-  it('truncates an oversized prog point role field to fit the embed limit', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
-
-    const mapping: Record<string, string> = {};
-    for (let i = 0; i < 30; i++) {
-      mapping[`ProgPointWithALongIdentifier${i}`] =
-        `role-id-that-is-quite-long-${i}`;
-    }
-
-    settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-      progPointRoles: {
-        TOP: mapping,
-      },
-    });
-
-    await command.execute(interaction);
-
-    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
-      { embeds: { data: { fields: { name: string; value: string }[] } }[] },
-    ];
-
-    const field = embeds[0].data.fields.find(
-      (f) => f.name === 'Prog Point Roles — TOP',
+    expect(embeds[0].data.description).toBe(
+      'Select an encounter below to view its prog point role mappings.',
     );
+    expect(components).toHaveLength(2);
 
-    expect(field?.value.length).toBeLessThanOrEqual(1024);
-    expect(field?.value).toMatch(/… and \d+ more$/);
-  });
-
-  it('renders a single "No roles set" field when no prog point roles are configured', async () => {
-    const interaction =
-      createAutoMock() as unknown as ChatInputCommandInteraction<'cached'>;
-
-    settingsCollection.getSettings.mockResolvedValueOnce({
-      reviewChannel: '12345',
-    });
-
-    await command.execute(interaction);
-
-    const [{ embeds }] = vi.mocked(interaction.editReply).mock.calls.at(-1) as [
-      { embeds: { data: { fields: { name: string; value: string }[] } }[] },
-    ];
-
-    const progPointFields = embeds[0].data.fields.filter((f) =>
-      f.name.startsWith('Prog Point Roles'),
-    );
-
-    expect(progPointFields).toEqual([
-      { name: 'Prog Point Roles', value: 'No roles set', inline: true },
+    // encounters with an empty mapping are not selectable
+    const selectRow = components[1].toJSON() as {
+      components: { options: { value: string }[] }[];
+    };
+    expect(selectRow.components[0].options).toEqual([
+      expect.objectContaining({ value: Encounter.TOP }),
     ]);
+  });
+
+  it('shows the selected encounter prog point role mappings', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
+
+    await command.execute(interaction);
+
+    const select = createSelectInteraction(SETTINGS_VIEW_ENCOUNTER_SELECT_ID, [
+      Encounter.TOP,
+    ]);
+    await callbacks.collect?.(select);
+
+    const { embeds, components } = lastReplyPayload(
+      vi.mocked(select.editReply),
+    );
+
+    expect(embeds[0].data.title).toBe('Settings — Prog Point Roles — TOP');
+    expect(embeds[0].data.description).toContain('**P1:** <@&r1>');
+    expect(embeds[0].data.description).toContain('**P2:** <@&r2>');
+    expect(components).toHaveLength(2);
+  });
+
+  it('returns to the overview without re-fetching sheet metadata', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      ...baseSettings,
+      spreadsheetId: 'sheet-abc',
+    });
+    sheetsService.getSheetMetadata.mockResolvedValue({
+      title: 'My Sheet',
+      url: 'https://sheets.example/abc',
+    } as never);
+
+    await command.execute(interaction);
+    const fetchCount = sheetsService.getSheetMetadata.mock.calls.length;
+
+    await callbacks.collect?.(
+      createButtonInteraction(SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID),
+    );
+    const overviewButton = createButtonInteraction(
+      SETTINGS_VIEW_OVERVIEW_BUTTON_ID,
+    );
+    await callbacks.collect?.(overviewButton);
+
+    const { embeds } = lastReplyPayload(vi.mocked(overviewButton.editReply));
+
+    expect(embeds[0].data.fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Managed Spreadsheet',
+        value: '[My Sheet](https://sheets.example/abc)',
+      }),
+    );
+    expect(sheetsService.getSheetMetadata.mock.calls.length).toBe(fetchCount);
+  });
+
+  it('omits the select menu when no prog point roles are configured', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      ...baseSettings,
+      progPointRoles: undefined,
+    });
+
+    await command.execute(interaction);
+
+    const button = createButtonInteraction(
+      SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID,
+    );
+    await callbacks.collect?.(button);
+
+    const { embeds, components } = lastReplyPayload(
+      vi.mocked(button.editReply),
+    );
+
+    expect(embeds[0].data.description).toBe('No prog point roles configured.');
+    expect(components).toHaveLength(1);
+  });
+
+  it('does not create a collector when no settings are found', async () => {
+    const { interaction, replyMessage } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await command.execute(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith('No settings found!');
+    expect(replyMessage.createMessageComponentCollector).not.toHaveBeenCalled();
+  });
+
+  it('removes the components when the collector ends', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
+
+    await command.execute(interaction);
+    await callbacks.end?.();
+
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content: 'Settings view has expired. Run /settings view again if needed.',
+      components: [],
+    });
+  });
+
+  it('creates the collector scoped to the invoking user with a timeout', async () => {
+    const { interaction, replyMessage } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
+
+    await command.execute(interaction);
+
+    expect(replyMessage.createMessageComponentCollector).toHaveBeenCalledWith({
+      filter: expect.any(Function),
+      time: 300000,
+    });
   });
 });

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
@@ -6,6 +6,7 @@ import type {
 } from 'discord.js';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { Encounter } from '../../../../encounters/encounters.consts.js';
+import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
 import type { SettingsDocument } from '../../../../firebase/models/settings.model.js';
 import { SheetsService } from '../../../../sheets/sheets.service.js';
@@ -33,6 +34,7 @@ describe('ViewSettingsCommandHandler', () => {
   let command: ViewSettingsCommandHandler;
   let settingsCollection: Mocked<SettingsCollection>;
   let sheetsService: Mocked<SheetsService>;
+  let errorService: Mocked<ErrorService>;
 
   const baseSettings: SettingsDocument = {
     autoModChannelId: 'automod-chan',
@@ -100,6 +102,7 @@ describe('ViewSettingsCommandHandler', () => {
     command = fixture.get(ViewSettingsCommandHandler);
     settingsCollection = fixture.get(SettingsCollection);
     sheetsService = fixture.get(SheetsService);
+    errorService = fixture.get(ErrorService);
   });
 
   it('should be defined', () => {
@@ -338,6 +341,37 @@ describe('ViewSettingsCommandHandler', () => {
       content: 'Settings view has expired. Run /settings view again if needed.',
       components: [],
     });
+  });
+
+  it('captures component interaction errors instead of rejecting', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
+
+    await command.execute(interaction);
+
+    const button = createButtonInteraction(SETTINGS_VIEW_OVERVIEW_BUTTON_ID);
+    vi.mocked(button.deferUpdate).mockRejectedValueOnce(
+      new Error('Unknown interaction'),
+    );
+
+    // an unhandled rejection here would crash the bot via the
+    // process-level unhandledRejection handler in main.ts
+    await expect(callbacks.collect?.(button)).resolves.toBeUndefined();
+    expect(errorService.captureError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('ignores select values that are not valid encounters', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(baseSettings);
+
+    await command.execute(interaction);
+
+    const select = createSelectInteraction(SETTINGS_VIEW_ENCOUNTER_SELECT_ID, [
+      'NOT_AN_ENCOUNTER',
+    ]);
+    await callbacks.collect?.(select);
+
+    expect(select.editReply).not.toHaveBeenCalled();
   });
 
   it('creates the collector scoped to the invoking user with a timeout', async () => {

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
@@ -1,94 +1,40 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 import { SentryTraced } from '@sentry/nestjs';
-import type { APIEmbedField, ChatInputCommandInteraction } from 'discord.js';
-import {
-  channelMention,
-  EmbedBuilder,
-  MessageFlags,
-  roleMention,
+import type {
+  ActionRowBuilder,
+  APIEmbedField,
+  ButtonBuilder,
+  ChatInputCommandInteraction,
+  StringSelectMenuBuilder,
 } from 'discord.js';
+import { MessageFlags } from 'discord.js';
+import { isSameUserFilter } from '../../../../common/collection-filters.js';
+import type { Encounter } from '../../../../encounters/encounters.consts.js';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
-import type { SettingsDocument } from '../../../../firebase/models/settings.model.js';
 import { SheetsService } from '../../../../sheets/sheets.service.js';
 import { SlashCommand } from '../../../slash-command.decorator.js';
 import type { ISlashCommand } from '../../../slash-command.interface.js';
 import { SettingsSlashCommand } from '../../settings.slash-command.js';
-
-function formatRole(roleId?: string) {
-  return roleId ? roleMention(roleId) : 'No Role Set';
-}
-
-function formatChannel(channelId?: string) {
-  return channelId ? channelMention(channelId) : 'No Channel Set';
-}
-
-function reduceRoleSettings(
-  roleSettings: Record<string, string | undefined> | undefined,
-): string[] {
-  return Object.entries(roleSettings || {}).reduce<string[]>(
-    (acc, [encounter, role]) => {
-      if (role) {
-        acc.push(`**${encounter}:** ${roleMention(role)}`);
-      }
-      return acc;
-    },
-    [],
-  );
-}
-
-const EMBED_FIELD_VALUE_LIMIT = 1024;
-
-function buildProgPointFieldValue(lines: string[]): string {
-  const full = lines.join('\n');
-  if (full.length <= EMBED_FIELD_VALUE_LIMIT) {
-    return full;
-  }
-
-  for (let keepCount = lines.length - 1; keepCount > 0; keepCount--) {
-    const omitted = lines.length - keepCount;
-    const candidate = `${lines
-      .slice(0, keepCount)
-      .join('\n')}\n… and ${omitted} more`;
-    if (candidate.length <= EMBED_FIELD_VALUE_LIMIT) {
-      return candidate;
-    }
-  }
-
-  return `… and ${lines.length} more`;
-}
-
-function reduceProgPointRoleSettings(
-  progPointRoles: SettingsDocument['progPointRoles'],
-): APIEmbedField[] {
-  const fields = Object.entries(progPointRoles || {}).reduce<APIEmbedField[]>(
-    (acc, [encounter, mapping]) => {
-      const lines = Object.entries(mapping ?? {}).map(
-        ([progPoint, roleId]) => `**${progPoint}:** ${roleMention(roleId)}`,
-      );
-
-      if (lines.length) {
-        acc.push({
-          name: `Prog Point Roles — ${encounter}`,
-          value: buildProgPointFieldValue(lines),
-          inline: true,
-        });
-      }
-
-      return acc;
-    },
-    [],
-  );
-
-  return fields.length
-    ? fields
-    : [{ name: 'Prog Point Roles', value: 'No roles set', inline: true }];
-}
+import {
+  buildEncounterRolesEmbed,
+  buildOverviewEmbed,
+  buildProgPointRolesEmbed,
+  createEncounterSelectRow,
+  createNavRow,
+  getConfiguredProgPointEncounters,
+  SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
+  SETTINGS_VIEW_ENCOUNTER_SELECT_ID,
+  SETTINGS_VIEW_OVERVIEW_BUTTON_ID,
+  SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID,
+} from './view-settings.components.js';
 
 @Injectable()
 @SlashCommand({ builder: SettingsSlashCommand, subcommand: 'view' })
 class ViewSettingsCommandHandler implements ISlashCommand {
+  private readonly logger = new Logger(ViewSettingsCommandHandler.name);
+
   constructor(
     private readonly settingsCollection: SettingsCollection,
     private readonly sheetsService: SheetsService,
@@ -145,90 +91,108 @@ class ViewSettingsCommandHandler implements ISlashCommand {
           ),
       });
 
-      const {
-        autoModChannelId,
-        progRoles,
-        clearRoles,
-        progPointRoles,
-        reviewChannel,
-        reviewerRole,
-        signupChannel,
-        spreadsheetId,
-        turboProgActive,
-        turboProgSpreadsheetId,
-      } = settings;
+      // fetched once so navigating back to the overview never re-hits the Sheets API
+      const spreadsheetFields: APIEmbedField[] = [];
 
-      const progRoleSettings = reduceRoleSettings(progRoles);
-      const clearRoleSettings = reduceRoleSettings(clearRoles);
-      const progPointRoleFields = reduceProgPointRoleSettings(progPointRoles);
-
-      const fields = [
-        {
-          name: 'Auto-Moderation Channel',
-          value: formatChannel(autoModChannelId),
-          inline: true,
-        },
-        {
-          name: 'Review Channel',
-          value: formatChannel(reviewChannel),
-          inline: true,
-        },
-        {
-          name: 'Signup Channel',
-          value: formatChannel(signupChannel),
-          inline: true,
-        },
-        {
-          name: 'Reviewer Role',
-          value: formatRole(reviewerRole),
-          inline: true,
-        },
-        {
-          name: 'Clear Roles',
-          value: clearRoleSettings.length
-            ? clearRoleSettings.join('\n')
-            : 'No roles set',
-          inline: true,
-        },
-        {
-          name: 'Prog Roles',
-          value: progRoleSettings.length
-            ? progRoleSettings.join('\n')
-            : 'No roles set',
-          inline: true,
-        },
-        ...progPointRoleFields,
-        {
-          name: 'Turbo Prog Active',
-          value: turboProgActive ? 'Yes' : 'No',
-          inline: true,
-        },
-      ];
-
-      if (turboProgSpreadsheetId) {
-        fields.push(
+      if (settings.turboProgSpreadsheetId) {
+        spreadsheetFields.push(
           await this.buildSpreadsheetField(
             'Turbo Prog Spreadsheet',
-            turboProgSpreadsheetId,
+            settings.turboProgSpreadsheetId,
           ),
         );
       }
 
-      if (spreadsheetId) {
-        fields.push(
+      if (settings.spreadsheetId) {
+        spreadsheetFields.push(
           await this.buildSpreadsheetField(
             'Managed Spreadsheet',
-            spreadsheetId,
+            settings.spreadsheetId,
           ),
         );
       }
 
-      const embed = new EmbedBuilder()
-        .setTitle('Settings')
-        .setDescription('Ulti-Project Bot Settings')
-        .addFields(fields);
+      const configuredEncounters = getConfiguredProgPointEncounters(
+        settings.progPointRoles,
+      );
 
-      await interaction.editReply({ embeds: [embed] });
+      const replyMessage = await interaction.editReply({
+        embeds: [buildOverviewEmbed(settings, spreadsheetFields)],
+        components: [createNavRow('overview')],
+      });
+
+      const collector = replyMessage.createMessageComponentCollector({
+        filter: isSameUserFilter(interaction.user),
+        time: 300000, // 5 minutes timeout
+      });
+
+      let selectedEncounter: Encounter | null = null;
+
+      collector.on('collect', async (i) => {
+        await i.deferUpdate();
+
+        if (i.customId === SETTINGS_VIEW_OVERVIEW_BUTTON_ID) {
+          await i.editReply({
+            embeds: [buildOverviewEmbed(settings, spreadsheetFields)],
+            components: [createNavRow('overview')],
+          });
+        } else if (i.customId === SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID) {
+          await i.editReply({
+            embeds: [buildEncounterRolesEmbed(settings)],
+            components: [createNavRow('encounterRoles')],
+          });
+        } else if (i.customId === SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID) {
+          const components: (
+            | ActionRowBuilder<ButtonBuilder>
+            | ActionRowBuilder<StringSelectMenuBuilder>
+          )[] = [createNavRow('progPointRoles')];
+
+          // an empty select menu is a Discord API error, so omit the row entirely
+          if (configuredEncounters.length > 0) {
+            components.push(
+              createEncounterSelectRow(
+                configuredEncounters,
+                selectedEncounter ?? undefined,
+              ),
+            );
+          }
+
+          await i.editReply({
+            embeds: [
+              buildProgPointRolesEmbed(
+                settings,
+                selectedEncounter ?? undefined,
+              ),
+            ],
+            components,
+          });
+        } else if (
+          i.customId === SETTINGS_VIEW_ENCOUNTER_SELECT_ID &&
+          i.isStringSelectMenu()
+        ) {
+          selectedEncounter = i.values[0] as Encounter;
+
+          await i.editReply({
+            embeds: [buildProgPointRolesEmbed(settings, selectedEncounter)],
+            components: [
+              createNavRow('progPointRoles'),
+              createEncounterSelectRow(configuredEncounters, selectedEncounter),
+            ],
+          });
+        }
+      });
+
+      collector.on('end', async () => {
+        try {
+          await interaction.editReply({
+            content:
+              'Settings view has expired. Run /settings view again if needed.',
+            components: [],
+          });
+        } catch (error) {
+          this.logger.error('Failed to update expired settings view', error);
+        }
+      });
     } catch (error) {
       const errorEmbed = this.errorService.handleCommandError(
         error,

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.ts
@@ -1,16 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 import { SentryTraced } from '@sentry/nestjs';
-import type {
-  ActionRowBuilder,
-  APIEmbedField,
-  ButtonBuilder,
-  ChatInputCommandInteraction,
-  StringSelectMenuBuilder,
-} from 'discord.js';
+import type { APIEmbedField, ChatInputCommandInteraction } from 'discord.js';
 import { MessageFlags } from 'discord.js';
 import { isSameUserFilter } from '../../../../common/collection-filters.js';
-import type { Encounter } from '../../../../encounters/encounters.consts.js';
+import {
+  type Encounter,
+  isEncounter,
+} from '../../../../encounters/encounters.consts.js';
 import { ErrorService } from '../../../../error/error.service.js';
 import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
 import { SheetsService } from '../../../../sheets/sheets.service.js';
@@ -21,8 +18,8 @@ import {
   buildEncounterRolesEmbed,
   buildOverviewEmbed,
   buildProgPointRolesEmbed,
-  createEncounterSelectRow,
   createNavRow,
+  createProgPointSectionComponents,
   getConfiguredProgPointEncounters,
   SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
   SETTINGS_VIEW_ENCOUNTER_SELECT_ID,
@@ -128,57 +125,53 @@ class ViewSettingsCommandHandler implements ISlashCommand {
 
       let selectedEncounter: Encounter | null = null;
 
+      // a rejection escaping this listener would hit the process-level
+      // unhandledRejection handler in main.ts and take the bot down
       collector.on('collect', async (i) => {
-        await i.deferUpdate();
+        try {
+          await i.deferUpdate();
 
-        if (i.customId === SETTINGS_VIEW_OVERVIEW_BUTTON_ID) {
-          await i.editReply({
-            embeds: [buildOverviewEmbed(settings, spreadsheetFields)],
-            components: [createNavRow('overview')],
-          });
-        } else if (i.customId === SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID) {
-          await i.editReply({
-            embeds: [buildEncounterRolesEmbed(settings)],
-            components: [createNavRow('encounterRoles')],
-          });
-        } else if (i.customId === SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID) {
-          const components: (
-            | ActionRowBuilder<ButtonBuilder>
-            | ActionRowBuilder<StringSelectMenuBuilder>
-          )[] = [createNavRow('progPointRoles')];
-
-          // an empty select menu is a Discord API error, so omit the row entirely
-          if (configuredEncounters.length > 0) {
-            components.push(
-              createEncounterSelectRow(
+          if (i.customId === SETTINGS_VIEW_OVERVIEW_BUTTON_ID) {
+            await i.editReply({
+              embeds: [buildOverviewEmbed(settings, spreadsheetFields)],
+              components: [createNavRow('overview')],
+            });
+          } else if (i.customId === SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID) {
+            await i.editReply({
+              embeds: [buildEncounterRolesEmbed(settings)],
+              components: [createNavRow('encounterRoles')],
+            });
+          } else if (i.customId === SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID) {
+            await i.editReply({
+              embeds: [
+                buildProgPointRolesEmbed(
+                  settings,
+                  selectedEncounter ?? undefined,
+                ),
+              ],
+              components: createProgPointSectionComponents(
                 configuredEncounters,
                 selectedEncounter ?? undefined,
               ),
-            );
-          }
+            });
+          } else if (
+            i.customId === SETTINGS_VIEW_ENCOUNTER_SELECT_ID &&
+            i.isStringSelectMenu() &&
+            isEncounter(i.values[0])
+          ) {
+            selectedEncounter = i.values[0];
 
-          await i.editReply({
-            embeds: [
-              buildProgPointRolesEmbed(
-                settings,
-                selectedEncounter ?? undefined,
+            await i.editReply({
+              embeds: [buildProgPointRolesEmbed(settings, selectedEncounter)],
+              components: createProgPointSectionComponents(
+                configuredEncounters,
+                selectedEncounter,
               ),
-            ],
-            components,
-          });
-        } else if (
-          i.customId === SETTINGS_VIEW_ENCOUNTER_SELECT_ID &&
-          i.isStringSelectMenu()
-        ) {
-          selectedEncounter = i.values[0] as Encounter;
-
-          await i.editReply({
-            embeds: [buildProgPointRolesEmbed(settings, selectedEncounter)],
-            components: [
-              createNavRow('progPointRoles'),
-              createEncounterSelectRow(configuredEncounters, selectedEncounter),
-            ],
-          });
+            });
+          }
+        } catch (error) {
+          this.logger.error('Failed to update settings view section', error);
+          this.errorService.captureError(error);
         }
       });
 

--- a/src/slash-commands/settings/subcommands/view/view-settings.components.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.components.spec.ts
@@ -1,0 +1,117 @@
+import { ButtonStyle } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+import { Encounter } from '../../../../encounters/encounters.consts.js';
+import {
+  buildProgPointRolesEmbed,
+  buildTruncatedList,
+  createEncounterSelectRow,
+  createNavRow,
+  getConfiguredProgPointEncounters,
+  SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
+} from './view-settings.components.js';
+
+describe('view-settings components', () => {
+  describe('createNavRow', () => {
+    it('disables and highlights the active section button', () => {
+      const row = createNavRow('encounterRoles').toJSON();
+
+      const [overview, encounterRoles, progPointRoles] = row.components as {
+        custom_id: string;
+        style: ButtonStyle;
+        disabled?: boolean;
+      }[];
+
+      expect(encounterRoles.custom_id).toBe(
+        SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
+      );
+      expect(encounterRoles.style).toBe(ButtonStyle.Primary);
+      expect(encounterRoles.disabled).toBe(true);
+
+      for (const button of [overview, progPointRoles]) {
+        expect(button.style).toBe(ButtonStyle.Secondary);
+        expect(button.disabled).toBe(false);
+      }
+    });
+  });
+
+  describe('getConfiguredProgPointEncounters', () => {
+    it('returns only encounters with a non-empty mapping', () => {
+      expect(
+        getConfiguredProgPointEncounters({
+          TOP: { P1: 'r1' },
+          DSR: {},
+          UWU: undefined,
+        }),
+      ).toEqual([Encounter.TOP]);
+    });
+
+    it('returns an empty array for undefined settings', () => {
+      expect(getConfiguredProgPointEncounters(undefined)).toEqual([]);
+    });
+  });
+
+  describe('createEncounterSelectRow', () => {
+    it('marks the selected encounter as the default option', () => {
+      const row = createEncounterSelectRow(
+        [Encounter.TOP, Encounter.DSR],
+        Encounter.DSR,
+      ).toJSON();
+
+      const [menu] = row.components as {
+        options: { value: string; default?: boolean }[];
+      }[];
+
+      expect(menu.options).toEqual([
+        expect.objectContaining({ value: Encounter.TOP, default: false }),
+        expect.objectContaining({ value: Encounter.DSR, default: true }),
+      ]);
+    });
+  });
+
+  describe('buildTruncatedList', () => {
+    it('joins lines untouched when under the limit', () => {
+      expect(buildTruncatedList(['a', 'b'], 1024)).toBe('a\nb');
+    });
+
+    it('truncates an oversized list to fit the limit', () => {
+      const lines = Array.from(
+        { length: 30 },
+        (_, i) =>
+          `**ProgPointWithALongIdentifier${i}:** <@&role-id-that-is-quite-long-${i}>`,
+      );
+
+      const value = buildTruncatedList(lines, 1024);
+
+      expect(value.length).toBeLessThanOrEqual(1024);
+      expect(value).toMatch(/… and \d+ more$/);
+    });
+  });
+
+  describe('buildProgPointRolesEmbed', () => {
+    it('states when nothing is configured', () => {
+      const embed = buildProgPointRolesEmbed({ progPointRoles: {} });
+
+      expect(embed.data.description).toBe('No prog point roles configured.');
+    });
+
+    it('prompts for a selection when no encounter is chosen', () => {
+      const embed = buildProgPointRolesEmbed({
+        progPointRoles: { TOP: { P1: 'r1' } },
+      });
+
+      expect(embed.data.description).toBe(
+        'Select an encounter below to view its prog point role mappings.',
+      );
+    });
+
+    it('lists the selected encounter mappings in the description', () => {
+      const embed = buildProgPointRolesEmbed(
+        { progPointRoles: { TOP: { P1: 'r1', P2: 'r2' } } },
+        Encounter.TOP,
+      );
+
+      expect(embed.data.title).toBe('Settings — Prog Point Roles — TOP');
+      expect(embed.data.description).toBe('**P1:** <@&r1>\n**P2:** <@&r2>');
+    });
+  });
+});

--- a/src/slash-commands/settings/subcommands/view/view-settings.components.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.components.ts
@@ -130,6 +130,26 @@ export function createEncounterSelectRow(
   return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
 }
 
+export function createProgPointSectionComponents(
+  configuredEncounters: Encounter[],
+  selected?: Encounter,
+): (
+  | ActionRowBuilder<ButtonBuilder>
+  | ActionRowBuilder<StringSelectMenuBuilder>
+)[] {
+  const components: (
+    | ActionRowBuilder<ButtonBuilder>
+    | ActionRowBuilder<StringSelectMenuBuilder>
+  )[] = [createNavRow('progPointRoles')];
+
+  // an empty select menu is a Discord API error, so omit the row entirely
+  if (configuredEncounters.length > 0) {
+    components.push(createEncounterSelectRow(configuredEncounters, selected));
+  }
+
+  return components;
+}
+
 function countConfiguredRoles(
   roleSettings: Record<string, string | undefined> | undefined,
 ): number {

--- a/src/slash-commands/settings/subcommands/view/view-settings.components.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.components.ts
@@ -1,0 +1,280 @@
+import type { APIEmbedField } from 'discord.js';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  channelMention,
+  EmbedBuilder,
+  roleMention,
+  StringSelectMenuBuilder,
+} from 'discord.js';
+import {
+  type Encounter,
+  EncounterFriendlyDescription,
+} from '../../../../encounters/encounters.consts.js';
+import type { SettingsDocument } from '../../../../firebase/models/settings.model.js';
+
+export const SETTINGS_VIEW_OVERVIEW_BUTTON_ID = 'settingsViewOverview';
+export const SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID =
+  'settingsViewEncounterRoles';
+export const SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID =
+  'settingsViewProgPointRoles';
+export const SETTINGS_VIEW_ENCOUNTER_SELECT_ID = 'settingsViewEncounterSelect';
+
+export type SettingsViewSection =
+  | 'overview'
+  | 'encounterRoles'
+  | 'progPointRoles';
+
+const EMBED_FIELD_VALUE_LIMIT = 1024;
+const EMBED_DESCRIPTION_LIMIT = 4096;
+
+export function formatRole(roleId?: string) {
+  return roleId ? roleMention(roleId) : 'No Role Set';
+}
+
+export function formatChannel(channelId?: string) {
+  return channelId ? channelMention(channelId) : 'No Channel Set';
+}
+
+export function reduceRoleSettings(
+  roleSettings: Record<string, string | undefined> | undefined,
+): string[] {
+  return Object.entries(roleSettings || {}).reduce<string[]>(
+    (acc, [encounter, role]) => {
+      if (role) {
+        acc.push(`**${encounter}:** ${roleMention(role)}`);
+      }
+      return acc;
+    },
+    [],
+  );
+}
+
+export function buildTruncatedList(lines: string[], limit: number): string {
+  const full = lines.join('\n');
+  if (full.length <= limit) {
+    return full;
+  }
+
+  for (let keepCount = lines.length - 1; keepCount > 0; keepCount--) {
+    const omitted = lines.length - keepCount;
+    const candidate = `${lines
+      .slice(0, keepCount)
+      .join('\n')}\n… and ${omitted} more`;
+    if (candidate.length <= limit) {
+      return candidate;
+    }
+  }
+
+  return `… and ${lines.length} more`;
+}
+
+export function getConfiguredProgPointEncounters(
+  progPointRoles: SettingsDocument['progPointRoles'],
+): Encounter[] {
+  return Object.entries(progPointRoles ?? {}).reduce<Encounter[]>(
+    (acc, [encounter, mapping]) => {
+      if (Object.keys(mapping ?? {}).length > 0) {
+        acc.push(encounter as Encounter);
+      }
+      return acc;
+    },
+    [],
+  );
+}
+
+export function createNavRow(active: SettingsViewSection) {
+  const buttons: [SettingsViewSection, string, string][] = [
+    ['overview', SETTINGS_VIEW_OVERVIEW_BUTTON_ID, 'Overview'],
+    [
+      'encounterRoles',
+      SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID,
+      'Encounter Roles',
+    ],
+    [
+      'progPointRoles',
+      SETTINGS_VIEW_PROG_POINT_ROLES_BUTTON_ID,
+      'Prog Point Roles',
+    ],
+  ];
+
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    buttons.map(([section, customId, label]) =>
+      new ButtonBuilder()
+        .setCustomId(customId)
+        .setLabel(label)
+        .setStyle(
+          section === active ? ButtonStyle.Primary : ButtonStyle.Secondary,
+        )
+        .setDisabled(section === active),
+    ),
+  );
+}
+
+export function createEncounterSelectRow(
+  configuredEncounters: Encounter[],
+  selected?: Encounter,
+) {
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(SETTINGS_VIEW_ENCOUNTER_SELECT_ID)
+    .setPlaceholder('Select an encounter')
+    .addOptions(
+      configuredEncounters.map((encounter) => ({
+        label: EncounterFriendlyDescription[encounter],
+        value: encounter,
+        default: encounter === selected,
+      })),
+    );
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+function countConfiguredRoles(
+  roleSettings: Record<string, string | undefined> | undefined,
+): number {
+  return Object.values(roleSettings ?? {}).filter(Boolean).length;
+}
+
+function summarizeEncounterCount(count: number): string {
+  if (count === 0) {
+    return 'None configured';
+  }
+  return count === 1
+    ? '1 encounter configured'
+    : `${count} encounters configured`;
+}
+
+export function buildOverviewEmbed(
+  settings: SettingsDocument,
+  spreadsheetFields: APIEmbedField[],
+): EmbedBuilder {
+  const {
+    autoModChannelId,
+    clearRoles,
+    progPointRoles,
+    progRoles,
+    reviewChannel,
+    reviewerRole,
+    signupChannel,
+    turboProgActive,
+  } = settings;
+
+  const progPointEncounters = getConfiguredProgPointEncounters(progPointRoles);
+  const progPointCount = Object.values(progPointRoles ?? {}).reduce<number>(
+    (sum, mapping) => sum + Object.keys(mapping ?? {}).length,
+    0,
+  );
+
+  const fields: APIEmbedField[] = [
+    {
+      name: 'Auto-Moderation Channel',
+      value: formatChannel(autoModChannelId),
+      inline: true,
+    },
+    {
+      name: 'Review Channel',
+      value: formatChannel(reviewChannel),
+      inline: true,
+    },
+    {
+      name: 'Signup Channel',
+      value: formatChannel(signupChannel),
+      inline: true,
+    },
+    {
+      name: 'Reviewer Role',
+      value: formatRole(reviewerRole),
+      inline: true,
+    },
+    {
+      name: 'Turbo Prog Active',
+      value: turboProgActive ? 'Yes' : 'No',
+      inline: true,
+    },
+    ...spreadsheetFields,
+    {
+      name: 'Prog Roles',
+      value: summarizeEncounterCount(countConfiguredRoles(progRoles)),
+      inline: true,
+    },
+    {
+      name: 'Clear Roles',
+      value: summarizeEncounterCount(countConfiguredRoles(clearRoles)),
+      inline: true,
+    },
+    {
+      name: 'Prog Point Roles',
+      value: progPointEncounters.length
+        ? `${summarizeEncounterCount(progPointEncounters.length)} (${progPointCount} prog points)`
+        : 'None configured',
+      inline: true,
+    },
+  ];
+
+  return new EmbedBuilder()
+    .setTitle('Settings')
+    .setDescription(
+      'Ulti-Project Bot Settings — use the buttons below to view role mappings',
+    )
+    .addFields(fields);
+}
+
+export function buildEncounterRolesEmbed(
+  settings: SettingsDocument,
+): EmbedBuilder {
+  const progRoleLines = reduceRoleSettings(settings.progRoles);
+  const clearRoleLines = reduceRoleSettings(settings.clearRoles);
+
+  return new EmbedBuilder().setTitle('Settings — Encounter Roles').addFields(
+    {
+      name: 'Prog Roles',
+      value: progRoleLines.length
+        ? buildTruncatedList(progRoleLines, EMBED_FIELD_VALUE_LIMIT)
+        : 'No roles set',
+      inline: true,
+    },
+    {
+      name: 'Clear Roles',
+      value: clearRoleLines.length
+        ? buildTruncatedList(clearRoleLines, EMBED_FIELD_VALUE_LIMIT)
+        : 'No roles set',
+      inline: true,
+    },
+  );
+}
+
+export function buildProgPointRolesEmbed(
+  settings: SettingsDocument,
+  encounter?: Encounter,
+): EmbedBuilder {
+  const configuredEncounters = getConfiguredProgPointEncounters(
+    settings.progPointRoles,
+  );
+
+  if (configuredEncounters.length === 0) {
+    return new EmbedBuilder()
+      .setTitle('Settings — Prog Point Roles')
+      .setDescription('No prog point roles configured.');
+  }
+
+  if (!encounter) {
+    return new EmbedBuilder()
+      .setTitle('Settings — Prog Point Roles')
+      .setDescription(
+        'Select an encounter below to view its prog point role mappings.',
+      );
+  }
+
+  const lines = Object.entries(settings.progPointRoles?.[encounter] ?? {}).map(
+    ([progPoint, roleId]) => `**${progPoint}:** ${roleMention(roleId)}`,
+  );
+
+  return new EmbedBuilder()
+    .setTitle(`Settings — Prog Point Roles — ${encounter}`)
+    .setDescription(
+      lines.length
+        ? buildTruncatedList(lines, EMBED_DESCRIPTION_LIMIT)
+        : 'No prog point roles set for this encounter.',
+    );
+}


### PR DESCRIPTION
## Summary
Refactored the `/settings view` command to use interactive button and select menu components, allowing users to navigate between different settings sections without re-running the command. The response now displays an overview by default with buttons to view encounter roles and prog point role mappings.

## Key Changes
- **New component builder module** (`view-settings.components.ts`): Extracted embed and component building logic into reusable functions with clear separation of concerns
  - `buildOverviewEmbed()`: Creates the main settings overview with role configuration summaries
  - `buildEncounterRolesEmbed()`: Displays prog and clear role mappings per encounter
  - `buildProgPointRolesEmbed()`: Shows prog point role mappings with optional encounter selection
  - Navigation helpers: `createNavRow()` and `createEncounterSelectRow()` for interactive components
  - Utility functions: `buildTruncatedList()`, `getConfiguredProgPointEncounters()`, `formatRole()`, `formatChannel()`

- **Enhanced command handler** (`view-settings.command-handler.ts`): Implemented message component collector for interactive navigation
  - Fetches spreadsheet metadata once and caches it across navigation to avoid redundant API calls
  - Creates a 5-minute timeout collector scoped to the invoking user
  - Handles button clicks to switch between overview, encounter roles, and prog point roles views
  - Handles select menu interactions to choose specific encounters for prog point role details
  - Gracefully removes components when the collector expires

- **Comprehensive test coverage** (`view-settings.command-handler.spec.ts`): Rewrote tests to verify interactive behavior
  - Tests for each navigation section and their content
  - Verification that spreadsheet metadata is fetched once and reused
  - Tests for edge cases (no prog point roles configured, no settings found)
  - Collector lifecycle testing (creation with proper filters/timeout, expiration handling)

## Notable Implementation Details
- The overview now shows role configuration counts instead of full mappings, reducing clutter
- Prog point role mappings are only shown when explicitly selected via the encounter select menu
- Empty prog point role mappings are filtered out from the select menu to prevent invalid Discord API calls
- The collector uses `isSameUserFilter` to ensure only the command invoker can interact with the components
- Spreadsheet field fetching is cached to avoid re-querying the Sheets API when navigating back to the overview

https://claude.ai/code/session_01DY5jdM75nks6pCXTFNCss4