### PR TITLE
feat(settings, blacklist): add configurable blacklist notification channels

### DIFF
--- a/src/firebase/models/settings.model.spec.ts
+++ b/src/firebase/models/settings.model.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getBlacklistChannelIds } from './settings.model.js';
+
+describe('getBlacklistChannelIds', () => {
+  it('returns the configured channel list when set', () => {
+    expect(
+      getBlacklistChannelIds({
+        blacklistChannelIds: ['chan-1', 'chan-2'],
+        autoModChannelId: 'automod-chan',
+      }),
+    ).toEqual(['chan-1', 'chan-2']);
+  });
+
+  it('respects an explicitly saved empty list without falling back', () => {
+    expect(
+      getBlacklistChannelIds({
+        blacklistChannelIds: [],
+        autoModChannelId: 'automod-chan',
+      }),
+    ).toEqual([]);
+  });
+
+  it('falls back to the auto-mod channel when the list is unset', () => {
+    expect(
+      getBlacklistChannelIds({ autoModChannelId: 'automod-chan' }),
+    ).toEqual(['automod-chan']);
+  });
+
+  it('returns an empty list when neither setting exists', () => {
+    expect(getBlacklistChannelIds({})).toEqual([]);
+    expect(getBlacklistChannelIds(undefined)).toEqual([]);
+  });
+});

--- a/src/firebase/models/settings.model.ts
+++ b/src/firebase/models/settings.model.ts
@@ -5,6 +5,7 @@ export interface SettingsDocument extends DocumentData {
   reviewChannel?: string;
   reviewerRole?: string;
   autoModChannelId?: string;
+  blacklistChannelIds?: string[];
   signupChannel?: string;
   spreadsheetId?: string;
   turboProgActive?: boolean;
@@ -21,4 +22,19 @@ export interface SettingsDocument extends DocumentData {
   progPointRoles?: {
     [key in keyof typeof Encounter]?: Record<string, string>;
   };
+}
+
+/**
+ * Resolves the channels that should receive blacklist notifications.
+ * Guilds that predate `blacklistChannelIds` fall back to `autoModChannelId`;
+ * an explicitly saved empty list means notifications are intentionally off.
+ */
+export function getBlacklistChannelIds(
+  settings: SettingsDocument | undefined,
+): string[] {
+  if (settings?.blacklistChannelIds) {
+    return settings.blacklistChannelIds;
+  }
+
+  return settings?.autoModChannelId ? [settings.autoModChannelId] : [];
 }

--- a/src/slash-commands/blacklist/blacklist.utils.ts
+++ b/src/slash-commands/blacklist/blacklist.utils.ts
@@ -1,12 +1,45 @@
+import type { Logger } from '@nestjs/common';
 import {
   type APIEmbedField,
   type CacheType,
   type ChatInputCommandInteraction,
+  type EmbedBuilder,
   userMention,
 } from 'discord.js';
 import { titleCase } from 'title-case';
 import type { DiscordService } from '../../discord/discord.service.js';
 import type { BlacklistDocument } from '../../firebase/models/blacklist.model.js';
+
+/**
+ * Sends the embed to every configured blacklist notification channel.
+ * A channel that fails to resolve or send must not block the others.
+ */
+export async function sendToBlacklistChannels(
+  discordService: DiscordService,
+  logger: Logger,
+  {
+    guildId,
+    channelIds,
+    embed,
+  }: { guildId: string; channelIds: string[]; embed: EmbedBuilder },
+): Promise<void> {
+  await Promise.all(
+    channelIds.map(async (channelId) => {
+      try {
+        const channel = await discordService.getTextChannel({
+          guildId,
+          channelId,
+        });
+        await channel?.send({ embeds: [embed] });
+      } catch (error) {
+        logger.error(
+          `failed to send blacklist message to channel ${channelId} in guild ${guildId}`,
+          error,
+        );
+      }
+    }),
+  );
+}
 
 export function getDiscordId(
   interaction: ChatInputCommandInteraction<CacheType>,

--- a/src/slash-commands/blacklist/handlers/blacklist-search.command-handler.spec.ts
+++ b/src/slash-commands/blacklist/handlers/blacklist-search.command-handler.spec.ts
@@ -1,0 +1,143 @@
+import { Test } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+import { DiscordService } from '../../../discord/discord.service.js';
+import { BlacklistCollection } from '../../../firebase/collections/blacklist-collection.js';
+import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
+import type { BlacklistDocument } from '../../../firebase/models/blacklist.model.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
+import { BlacklistSearchCommand } from '../blacklist.commands.js';
+import { BlacklistSearchCommandHandler } from './blacklist-search.command-handler.js';
+
+describe('BlacklistSearchCommandHandler', () => {
+  let handler: BlacklistSearchCommandHandler;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let blacklistCollection: Mocked<BlacklistCollection>;
+  let discordService: Mocked<DiscordService>;
+
+  const guildId = 'guild-1';
+  const command = new BlacklistSearchCommand(
+    {
+      discordId: 'user-1',
+      character: 'Test Character',
+      reviewMessageId: 'msg-1',
+    },
+    guildId,
+  );
+
+  const match: BlacklistDocument = {
+    discordId: 'user-1',
+    characterName: 'test character',
+    reason: 'botting',
+    lodestoneId: null,
+  };
+
+  function mockChannel() {
+    return { send: vi.fn().mockResolvedValue(undefined) };
+  }
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [BlacklistSearchCommandHandler],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    handler = fixture.get(BlacklistSearchCommandHandler);
+    settingsCollection = fixture.get(SettingsCollection);
+    blacklistCollection = fixture.get(BlacklistCollection);
+    discordService = fixture.get(DiscordService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('does not search when no blacklist channels are configured', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(command);
+
+    expect(blacklistCollection.search).not.toHaveBeenCalled();
+  });
+
+  it('does not search when the channel list was explicitly emptied', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: [],
+      autoModChannelId: 'automod-chan',
+    });
+
+    await handler.execute(command);
+
+    expect(blacklistCollection.search).not.toHaveBeenCalled();
+  });
+
+  it('sends the detection embed to every configured channel', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['chan-1', 'chan-2'],
+    });
+    blacklistCollection.search.mockResolvedValueOnce(match);
+
+    const channel1 = mockChannel();
+    const channel2 = mockChannel();
+    discordService.getTextChannel
+      .mockResolvedValueOnce(channel1 as never)
+      .mockResolvedValueOnce(channel2 as never);
+
+    await handler.execute(command);
+
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'chan-1',
+    });
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'chan-2',
+    });
+    expect(channel1.send).toHaveBeenCalledTimes(1);
+    expect(channel2.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the auto-mod channel when no list is configured', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      autoModChannelId: 'automod-chan',
+    });
+    blacklistCollection.search.mockResolvedValueOnce(match);
+
+    const channel = mockChannel();
+    discordService.getTextChannel.mockResolvedValueOnce(channel as never);
+
+    await handler.execute(command);
+
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'automod-chan',
+    });
+    expect(channel.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send anything when the signup is not blacklisted', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['chan-1'],
+    });
+    blacklistCollection.search.mockResolvedValueOnce(undefined);
+
+    await handler.execute(command);
+
+    expect(discordService.getTextChannel).not.toHaveBeenCalled();
+  });
+
+  it('still notifies the remaining channels when one channel fails', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['broken-chan', 'chan-2'],
+    });
+    blacklistCollection.search.mockResolvedValueOnce(match);
+
+    const channel2 = mockChannel();
+    discordService.getTextChannel
+      .mockRejectedValueOnce(new Error('Missing Access'))
+      .mockResolvedValueOnce(channel2 as never);
+
+    await expect(handler.execute(command)).resolves.toBeUndefined();
+    expect(channel2.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slash-commands/blacklist/handlers/blacklist-search.command-handler.ts
+++ b/src/slash-commands/blacklist/handlers/blacklist-search.command-handler.ts
@@ -6,9 +6,13 @@ import { DiscordService } from '../../../discord/discord.service.js';
 import { BlacklistCollection } from '../../../firebase/collections/blacklist-collection.js';
 import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
 import type { BlacklistDocument } from '../../../firebase/models/blacklist.model.js';
+import { getBlacklistChannelIds } from '../../../firebase/models/settings.model.js';
 import type { SignupDocument } from '../../../firebase/models/signup.model.js';
 import { BlacklistSearchCommand } from '../blacklist.commands.js';
-import { createBlacklistEmbedFields } from '../blacklist.utils.js';
+import {
+  createBlacklistEmbedFields,
+  sendToBlacklistChannels,
+} from '../blacklist.utils.js';
 
 @CommandHandler(BlacklistSearchCommand)
 class BlacklistSearchCommandHandler
@@ -23,12 +27,12 @@ class BlacklistSearchCommandHandler
 
   async execute({ signup, guildId }: BlacklistSearchCommand) {
     const settings = await this.settingsCollection.getSettings(guildId);
-    if (!settings?.autoModChannelId) {
-      this.logger.warn(`No auto-mod channel set for guild ${guildId}`);
+    const channelIds = getBlacklistChannelIds(settings);
+
+    if (channelIds.length === 0) {
+      this.logger.warn(`No blacklist channels set for guild ${guildId}`);
       return;
     }
-
-    const { autoModChannelId, reviewChannel } = settings;
 
     // search to see if the signup is in the blacklist
     const match = await this.blacklistCollection.search({
@@ -39,17 +43,16 @@ class BlacklistSearchCommandHandler
 
     if (!match) return;
 
-    const channel = await this.discordService.getTextChannel({
-      guildId,
-      channelId: autoModChannelId,
-    });
-
     const embed = await this.createBlacklistEmbed(match, signup, {
       guildId,
-      reviewChannelId: reviewChannel,
+      reviewChannelId: settings?.reviewChannel,
     });
 
-    return await channel?.send({ embeds: [embed] });
+    await sendToBlacklistChannels(this.discordService, this.logger, {
+      guildId,
+      channelIds,
+      embed,
+    });
   }
 
   private async createBlacklistEmbed(

--- a/src/slash-commands/blacklist/handlers/blacklist-updated.event-handler.spec.ts
+++ b/src/slash-commands/blacklist/handlers/blacklist-updated.event-handler.spec.ts
@@ -1,0 +1,130 @@
+import { Test } from '@nestjs/testing';
+import type { User } from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+import { DiscordService } from '../../../discord/discord.service.js';
+import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../test-utils/mock-factory.js';
+import { BlacklistUpdatedEvent } from '../events/blacklist.events.js';
+import { BlacklistUpdatedEventHandler } from './blacklist-updated.event-handler.js';
+
+describe('BlacklistUpdatedEventHandler', () => {
+  let handler: BlacklistUpdatedEventHandler;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let discordService: Mocked<DiscordService>;
+
+  const guildId = 'guild-1';
+  const triggeredBy = {
+    id: 'mod-1',
+    displayAvatarURL: () => 'https://cdn.example/avatar.png',
+  } as unknown as User;
+
+  const event = new BlacklistUpdatedEvent({
+    guildId,
+    type: 'added',
+    triggeredBy,
+    entry: {
+      discordId: 'user-1',
+      characterName: 'test character',
+      reason: 'botting',
+      lodestoneId: 12345,
+    },
+  });
+
+  function mockChannel() {
+    return { send: vi.fn().mockResolvedValue(undefined) };
+  }
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [BlacklistUpdatedEventHandler],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    handler = fixture.get(BlacklistUpdatedEventHandler);
+    settingsCollection = fixture.get(SettingsCollection);
+    discordService = fixture.get(DiscordService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('does nothing when no blacklist channels are configured', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.handle(event);
+
+    expect(discordService.getTextChannel).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the channel list was explicitly emptied', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: [],
+      autoModChannelId: 'automod-chan',
+    });
+
+    await handler.handle(event);
+
+    expect(discordService.getTextChannel).not.toHaveBeenCalled();
+  });
+
+  it('sends the update embed to every configured channel', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['chan-1', 'chan-2'],
+    });
+
+    const channel1 = mockChannel();
+    const channel2 = mockChannel();
+    discordService.getTextChannel
+      .mockResolvedValueOnce(channel1 as never)
+      .mockResolvedValueOnce(channel2 as never);
+
+    await handler.handle(event);
+
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'chan-1',
+    });
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'chan-2',
+    });
+    expect(channel1.send).toHaveBeenCalledTimes(1);
+    expect(channel2.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the auto-mod channel when no list is configured', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      autoModChannelId: 'automod-chan',
+    });
+
+    const channel = mockChannel();
+    discordService.getTextChannel.mockResolvedValueOnce(channel as never);
+
+    await handler.handle(event);
+
+    expect(discordService.getTextChannel).toHaveBeenCalledWith({
+      guildId,
+      channelId: 'automod-chan',
+    });
+    expect(channel.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('still notifies the remaining channels when one send fails', async () => {
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['broken-chan', 'chan-2'],
+    });
+
+    const brokenChannel = {
+      send: vi.fn().mockRejectedValue(new Error('Missing Permissions')),
+    };
+    const channel2 = mockChannel();
+    discordService.getTextChannel
+      .mockResolvedValueOnce(brokenChannel as never)
+      .mockResolvedValueOnce(channel2 as never);
+
+    await expect(handler.handle(event)).resolves.toBeUndefined();
+    expect(channel2.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slash-commands/blacklist/handlers/blacklist-updated.event-handler.ts
+++ b/src/slash-commands/blacklist/handlers/blacklist-updated.event-handler.ts
@@ -1,15 +1,19 @@
+import { Logger } from '@nestjs/common';
 import { EventsHandler, type IEventHandler } from '@nestjs/cqrs';
 import { EmbedBuilder } from 'discord.js';
 import { createFields } from '../../../common/embed-helpers.js';
 import { DiscordService } from '../../../discord/discord.service.js';
 import { SettingsCollection } from '../../../firebase/collections/settings-collection.js';
-import { getDisplayName } from '../blacklist.utils.js';
+import { getBlacklistChannelIds } from '../../../firebase/models/settings.model.js';
+import { getDisplayName, sendToBlacklistChannels } from '../blacklist.utils.js';
 import { BlacklistUpdatedEvent } from '../events/blacklist.events.js';
 
 @EventsHandler(BlacklistUpdatedEvent)
 class BlacklistUpdatedEventHandler
   implements IEventHandler<BlacklistUpdatedEvent>
 {
+  private readonly logger = new Logger(BlacklistUpdatedEventHandler.name);
+
   constructor(
     private readonly settingsCollection: SettingsCollection,
     private readonly discordService: DiscordService,
@@ -19,12 +23,11 @@ class BlacklistUpdatedEventHandler
     data: { entry, type, guildId, triggeredBy },
   }: BlacklistUpdatedEvent) {
     const settings = await this.settingsCollection.getSettings(guildId);
+    const channelIds = getBlacklistChannelIds(settings);
 
-    if (!settings?.autoModChannelId) {
+    if (channelIds.length === 0) {
       return;
     }
-
-    const { autoModChannelId } = settings;
 
     const toFrom = type === 'added' ? 'to' : 'from';
     const displayName = await getDisplayName(this.discordService, {
@@ -65,12 +68,11 @@ class BlacklistUpdatedEventHandler
       })
       .addFields(fields);
 
-    const channel = await this.discordService.getTextChannel({
-      channelId: autoModChannelId,
+    await sendToBlacklistChannels(this.discordService, this.logger, {
       guildId,
+      channelIds,
+      embed,
     });
-
-    await channel?.send({ embeds: [embed] });
   }
 }
 

--- a/src/slash-commands/settings/settings.module.ts
+++ b/src/slash-commands/settings/settings.module.ts
@@ -3,6 +3,7 @@ import { EncountersModule } from '../../encounters/encounters.module.js';
 import { ErrorModule } from '../../error/error.module.js';
 import { FirebaseModule } from '../../firebase/firebase.module.js';
 import { SheetsModule } from '../../sheets/sheets.module.js';
+import { EditBlacklistChannelsCommandHandler } from './subcommands/blacklist-channels/edit-blacklist-channels.command-handler.js';
 import { EditChannelsCommandHandler } from './subcommands/channels/edit-channels.command-handler.js';
 import { EditProgPointRolesCommandHandler } from './subcommands/prog-point-roles/edit-prog-point-roles.command-handler.js';
 import { EditReviewerCommandHandler } from './subcommands/reviewer/edit-reviewer.command-handler.js';
@@ -14,6 +15,7 @@ import { ViewSettingsCommandHandler } from './subcommands/view/view-settings.com
 @Module({
   imports: [ErrorModule, FirebaseModule, SheetsModule, EncountersModule],
   providers: [
+    EditBlacklistChannelsCommandHandler,
     EditChannelsCommandHandler,
     EditEncounterRolesCommandHandler,
     EditProgPointRolesCommandHandler,

--- a/src/slash-commands/settings/settings.slash-command.ts
+++ b/src/slash-commands/settings/settings.slash-command.ts
@@ -32,10 +32,17 @@ export const EditChannelsSubcommand = new SlashCommandSubcommandBuilder()
   .addChannelOption((option) =>
     option
       .setName('moderation-channel')
-      .setDescription('The channel to send automatic moderation messages to')
+      .setDescription(
+        'The channel for automatic moderation messages. Blacklist alerts use /settings blacklist-channels',
+      )
       .addChannelTypes(ChannelType.GuildText)
       .setRequired(false),
   );
+
+export const EditBlacklistChannelsSubcommand =
+  new SlashCommandSubcommandBuilder()
+    .setName('blacklist-channels')
+    .setDescription('Choose the channels that receive blacklist notifications');
 
 export const EditReviewerRoleSubcommand = new SlashCommandSubcommandBuilder()
   .setName('reviewer')
@@ -134,6 +141,7 @@ export const SettingsSlashCommand = new SlashCommandBuilder()
   .setName('settings')
   .setDescription('Configure/Review the bots roles and channel settings')
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+  .addSubcommand(EditBlacklistChannelsSubcommand)
   .addSubcommand(EditChannelsSubcommand)
   .addSubcommand(EditReviewerRoleSubcommand)
   .addSubcommand(EditEncounterRolesSubcommand)

--- a/src/slash-commands/settings/subcommands/blacklist-channels/blacklist-channels.components.spec.ts
+++ b/src/slash-commands/settings/subcommands/blacklist-channels/blacklist-channels.components.spec.ts
@@ -1,0 +1,39 @@
+import { ChannelType, ComponentType } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+import {
+  BLACKLIST_CHANNELS_SELECT_ID,
+  createBlacklistChannelsSelectRow,
+} from './blacklist-channels.components.js';
+
+describe('createBlacklistChannelsSelectRow', () => {
+  it('builds a multi-select channel menu restricted to text channels', () => {
+    const row = createBlacklistChannelsSelectRow([]).toJSON();
+
+    const [menu] = row.components as {
+      type: ComponentType;
+      custom_id: string;
+      channel_types?: ChannelType[];
+      min_values?: number;
+      max_values?: number;
+    }[];
+
+    expect(menu.type).toBe(ComponentType.ChannelSelect);
+    expect(menu.custom_id).toBe(BLACKLIST_CHANNELS_SELECT_ID);
+    expect(menu.channel_types).toEqual([ChannelType.GuildText]);
+    expect(menu.min_values).toBe(0);
+    expect(menu.max_values).toBe(25);
+  });
+
+  it('pre-selects the current channels as default values', () => {
+    const row = createBlacklistChannelsSelectRow(['chan-1', 'chan-2']).toJSON();
+
+    const [menu] = row.components as {
+      default_values?: { id: string; type: string }[];
+    }[];
+
+    expect(menu.default_values).toEqual([
+      { id: 'chan-1', type: 'channel' },
+      { id: 'chan-2', type: 'channel' },
+    ]);
+  });
+});

--- a/src/slash-commands/settings/subcommands/blacklist-channels/blacklist-channels.components.ts
+++ b/src/slash-commands/settings/subcommands/blacklist-channels/blacklist-channels.components.ts
@@ -1,0 +1,19 @@
+import {
+  ActionRowBuilder,
+  ChannelSelectMenuBuilder,
+  ChannelType,
+} from 'discord.js';
+
+export const BLACKLIST_CHANNELS_SELECT_ID = 'settingsBlacklistChannelsSelect';
+
+export function createBlacklistChannelsSelectRow(currentIds: string[]) {
+  const menu = new ChannelSelectMenuBuilder()
+    .setCustomId(BLACKLIST_CHANNELS_SELECT_ID)
+    .setPlaceholder('Select blacklist notification channels')
+    .addChannelTypes(ChannelType.GuildText)
+    .setMinValues(0)
+    .setMaxValues(25)
+    .setDefaultChannels(currentIds);
+
+  return new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(menu);
+}

--- a/src/slash-commands/settings/subcommands/blacklist-channels/edit-blacklist-channels.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/blacklist-channels/edit-blacklist-channels.command-handler.spec.ts
@@ -1,0 +1,219 @@
+import { Test } from '@nestjs/testing';
+import type {
+  ChannelSelectMenuInteraction,
+  ChatInputCommandInteraction,
+} from 'discord.js';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+import { ErrorService } from '../../../../error/error.service.js';
+import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { createAutoMock } from '../../../../test-utils/mock-factory.js';
+import { BLACKLIST_CHANNELS_SELECT_ID } from './blacklist-channels.components.js';
+import { EditBlacklistChannelsCommandHandler } from './edit-blacklist-channels.command-handler.js';
+
+type ReplyPayload = {
+  content?: string;
+  components: {
+    toJSON: () => { components: { default_values?: unknown[] }[] };
+  }[];
+};
+
+describe('EditBlacklistChannelsCommandHandler', () => {
+  let handler: EditBlacklistChannelsCommandHandler;
+  let settingsCollection: Mocked<SettingsCollection>;
+  let errorService: Mocked<ErrorService>;
+
+  function createInteraction() {
+    const interaction = createAutoMock() as unknown as Mocked<
+      ChatInputCommandInteraction<'cached'>
+    >;
+    const collector = createAutoMock();
+    const callbacks: {
+      collect?: (i: unknown) => Promise<void>;
+      end?: () => Promise<void>;
+    } = {};
+
+    collector.on.mockImplementation((event: string, cb: never) => {
+      if (event === 'collect') callbacks.collect = cb;
+      if (event === 'end') callbacks.end = cb;
+      return collector;
+    });
+
+    const replyMessage = createAutoMock();
+    replyMessage.createMessageComponentCollector.mockReturnValue(collector);
+
+    vi.mocked(interaction.editReply).mockResolvedValue(replyMessage as never);
+    Object.assign(interaction, {
+      guildId: 'guild-1',
+      user: { id: 'user123' },
+    });
+
+    return { interaction, replyMessage, callbacks };
+  }
+
+  function createSelectInteraction(customId: string, values: string[]) {
+    const select =
+      createAutoMock() as unknown as Mocked<ChannelSelectMenuInteraction>;
+    select.customId = customId;
+    select.values = values;
+    select.isChannelSelectMenu.mockReturnValue(true);
+    return select;
+  }
+
+  function lastReplyPayload(mock: { mock: { calls: unknown[][] } }) {
+    return mock.mock.calls.at(-1)?.[0] as ReplyPayload;
+  }
+
+  beforeEach(async () => {
+    const fixture = await Test.createTestingModule({
+      providers: [EditBlacklistChannelsCommandHandler],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    handler = fixture.get(EditBlacklistChannelsCommandHandler);
+    settingsCollection = fixture.get(SettingsCollection);
+    errorService = fixture.get(ErrorService);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('renders the select menu pre-filled with the configured channel list', async () => {
+    const { interaction } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['chan-1', 'chan-2'],
+    });
+
+    await handler.execute(interaction);
+
+    const { components } = lastReplyPayload(vi.mocked(interaction.editReply));
+    expect(components[0].toJSON().components[0].default_values).toHaveLength(2);
+  });
+
+  it('falls back to the auto-mod channel for the initial selection', async () => {
+    const { interaction } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      autoModChannelId: 'automod-chan',
+    });
+
+    await handler.execute(interaction);
+
+    const { components } = lastReplyPayload(vi.mocked(interaction.editReply));
+    expect(components[0].toJSON().components[0].default_values).toEqual([
+      { id: 'automod-chan', type: 'channel' },
+    ]);
+  });
+
+  it('replaces the stored list with the submitted selection', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(interaction);
+
+    const select = createSelectInteraction(BLACKLIST_CHANNELS_SELECT_ID, [
+      'chan-1',
+      'chan-2',
+    ]);
+    await callbacks.collect?.(select);
+
+    expect(select.deferUpdate).toHaveBeenCalled();
+    expect(settingsCollection.upsert).toHaveBeenCalledWith('guild-1', {
+      blacklistChannelIds: ['chan-1', 'chan-2'],
+    });
+
+    const { content } = lastReplyPayload(vi.mocked(select.editReply));
+    expect(content).toContain('<#chan-1>');
+    expect(content).toContain('<#chan-2>');
+  });
+
+  it('saves an empty selection to disable notifications', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce({
+      blacklistChannelIds: ['chan-1'],
+    });
+
+    await handler.execute(interaction);
+
+    const select = createSelectInteraction(BLACKLIST_CHANNELS_SELECT_ID, []);
+    await callbacks.collect?.(select);
+
+    expect(settingsCollection.upsert).toHaveBeenCalledWith('guild-1', {
+      blacklistChannelIds: [],
+    });
+
+    const { content } = lastReplyPayload(vi.mocked(select.editReply));
+    expect(content).toContain('disabled');
+  });
+
+  it('ignores interactions from other components', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(interaction);
+
+    const select = createSelectInteraction('someOtherComponent', ['chan-1']);
+    await callbacks.collect?.(select);
+
+    expect(settingsCollection.upsert).not.toHaveBeenCalled();
+    expect(select.editReply).not.toHaveBeenCalled();
+  });
+
+  it('removes the components when the collector ends', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(interaction);
+    await callbacks.end?.();
+
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        'This menu has expired. Run /settings blacklist-channels again if needed.',
+      components: [],
+    });
+  });
+
+  it('captures component interaction errors instead of rejecting', async () => {
+    const { interaction, callbacks } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(interaction);
+
+    const select = createSelectInteraction(BLACKLIST_CHANNELS_SELECT_ID, [
+      'chan-1',
+    ]);
+    vi.mocked(select.deferUpdate).mockRejectedValueOnce(
+      new Error('Unknown interaction'),
+    );
+
+    // an unhandled rejection here would crash the bot via the
+    // process-level unhandledRejection handler in main.ts
+    await expect(callbacks.collect?.(select)).resolves.toBeUndefined();
+    expect(errorService.captureError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('routes command errors through the error service', async () => {
+    const { interaction } = createInteraction();
+    const error = new Error('firestore down');
+    settingsCollection.getSettings.mockRejectedValueOnce(error);
+
+    await handler.execute(interaction);
+
+    expect(errorService.handleCommandError).toHaveBeenCalledWith(
+      error,
+      interaction,
+    );
+  });
+
+  it('creates the collector scoped to the invoking user with a timeout', async () => {
+    const { interaction, replyMessage } = createInteraction();
+    settingsCollection.getSettings.mockResolvedValueOnce(undefined);
+
+    await handler.execute(interaction);
+
+    expect(replyMessage.createMessageComponentCollector).toHaveBeenCalledWith({
+      filter: expect.any(Function),
+      time: 300000,
+    });
+  });
+});

--- a/src/slash-commands/settings/subcommands/blacklist-channels/edit-blacklist-channels.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/blacklist-channels/edit-blacklist-channels.command-handler.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SentryTraced } from '@sentry/nestjs';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { channelMention, MessageFlags } from 'discord.js';
+import { isSameUserFilter } from '../../../../common/collection-filters.js';
+import { ErrorService } from '../../../../error/error.service.js';
+import { SettingsCollection } from '../../../../firebase/collections/settings-collection.js';
+import { getBlacklistChannelIds } from '../../../../firebase/models/settings.model.js';
+import { SlashCommand } from '../../../slash-command.decorator.js';
+import type { ISlashCommand } from '../../../slash-command.interface.js';
+import { SettingsSlashCommand } from '../../settings.slash-command.js';
+import {
+  BLACKLIST_CHANNELS_SELECT_ID,
+  createBlacklistChannelsSelectRow,
+} from './blacklist-channels.components.js';
+
+const INSTRUCTIONS =
+  'Select the channels that should receive blacklist notifications. Your selection replaces the current list; submit an empty selection to disable notifications.';
+
+@Injectable()
+@SlashCommand({
+  builder: SettingsSlashCommand,
+  subcommand: 'blacklist-channels',
+})
+class EditBlacklistChannelsCommandHandler implements ISlashCommand {
+  private readonly logger = new Logger(
+    EditBlacklistChannelsCommandHandler.name,
+  );
+
+  constructor(
+    private readonly settingsCollection: SettingsCollection,
+    private readonly errorService: ErrorService,
+  ) {}
+
+  @SentryTraced()
+  async execute(
+    interaction: ChatInputCommandInteraction<'cached'>,
+  ): Promise<void> {
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const settings = await this.settingsCollection.getSettings(
+        interaction.guildId,
+      );
+
+      const replyMessage = await interaction.editReply({
+        content: INSTRUCTIONS,
+        components: [
+          createBlacklistChannelsSelectRow(getBlacklistChannelIds(settings)),
+        ],
+      });
+
+      const collector = replyMessage.createMessageComponentCollector({
+        filter: isSameUserFilter(interaction.user),
+        time: 300000, // 5 minutes timeout
+      });
+
+      // a rejection escaping this listener would hit the process-level
+      // unhandledRejection handler in main.ts and take the bot down
+      collector.on('collect', async (i) => {
+        try {
+          if (
+            i.customId !== BLACKLIST_CHANNELS_SELECT_ID ||
+            !i.isChannelSelectMenu()
+          ) {
+            return;
+          }
+
+          await i.deferUpdate();
+
+          const blacklistChannelIds = i.values;
+
+          await this.settingsCollection.upsert(interaction.guildId, {
+            blacklistChannelIds,
+          });
+
+          const confirmation =
+            blacklistChannelIds.length > 0
+              ? `Saved! Blacklist notifications will be sent to: ${blacklistChannelIds
+                  .map(channelMention)
+                  .join(', ')}`
+              : 'Saved! Blacklist notifications are now disabled.';
+
+          await i.editReply({
+            content: `${INSTRUCTIONS}\n\n${confirmation}`,
+            components: [createBlacklistChannelsSelectRow(blacklistChannelIds)],
+          });
+        } catch (error) {
+          this.logger.error('Failed to update blacklist channels', error);
+          this.errorService.captureError(error);
+        }
+      });
+
+      collector.on('end', async () => {
+        try {
+          await interaction.editReply({
+            content:
+              'This menu has expired. Run /settings blacklist-channels again if needed.',
+            components: [],
+          });
+        } catch (error) {
+          this.logger.error(
+            'Failed to update expired blacklist channels menu',
+            error,
+          );
+        }
+      });
+    } catch (error) {
+      const errorEmbed = this.errorService.handleCommandError(
+        error,
+        interaction,
+      );
+      await interaction.editReply({ embeds: [errorEmbed] });
+    }
+  }
+}
+
+export { EditBlacklistChannelsCommandHandler };

--- a/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.command-handler.spec.ts
@@ -126,6 +126,13 @@ describe('ViewSettingsCommandHandler', () => {
         value: '<#review-chan>',
       }),
     );
+    // falls back to the auto-mod channel while no blacklist list is configured
+    expect(fields).toContainEqual(
+      expect.objectContaining({
+        name: 'Blacklist Channels',
+        value: '<#automod-chan>',
+      }),
+    );
     expect(fields).toContainEqual(
       expect.objectContaining({
         name: 'Reviewer Role',

--- a/src/slash-commands/settings/subcommands/view/view-settings.components.ts
+++ b/src/slash-commands/settings/subcommands/view/view-settings.components.ts
@@ -12,7 +12,10 @@ import {
   type Encounter,
   EncounterFriendlyDescription,
 } from '../../../../encounters/encounters.consts.js';
-import type { SettingsDocument } from '../../../../firebase/models/settings.model.js';
+import {
+  getBlacklistChannelIds,
+  type SettingsDocument,
+} from '../../../../firebase/models/settings.model.js';
 
 export const SETTINGS_VIEW_OVERVIEW_BUTTON_ID = 'settingsViewOverview';
 export const SETTINGS_VIEW_ENCOUNTER_ROLES_BUTTON_ID =
@@ -186,10 +189,22 @@ export function buildOverviewEmbed(
     0,
   );
 
+  const blacklistChannelIds = getBlacklistChannelIds(settings);
+
   const fields: APIEmbedField[] = [
     {
       name: 'Auto-Moderation Channel',
       value: formatChannel(autoModChannelId),
+      inline: true,
+    },
+    {
+      name: 'Blacklist Channels',
+      value: blacklistChannelIds.length
+        ? buildTruncatedList(
+            blacklistChannelIds.map(channelMention),
+            EMBED_FIELD_VALUE_LIMIT,
+          )
+        : 'No Channels Set',
       inline: true,
     },
     {


### PR DESCRIPTION
## Summary

Introduces a new `/settings blacklist-channels` command that allows guild admins to configure which channels receive blacklist notifications, replacing the previous hardcoded reliance on the auto-mod channel. Guilds that haven't configured the new setting gracefully fall back to the auto-mod channel for backward compatibility.

## Key Changes

- **New command handler**: `EditBlacklistChannelsCommandHandler` provides an interactive channel selection menu with a 5-minute timeout. Users can select multiple text channels or explicitly disable notifications by submitting an empty selection.

- **Settings model enhancement**: Added `blacklistChannelIds` field to `SettingsDocument` and created `getBlacklistChannelIds()` helper that implements the fallback logic: uses the configured list if set, falls back to auto-mod channel if unset, or returns empty list if neither exists.

- **Shared notification utility**: Extracted `sendToBlacklistChannels()` helper in `blacklist.utils.ts` to handle sending embeds to multiple channels with graceful error handling—a single channel failure doesn't block others.

- **Updated blacklist handlers**: Modified `BlacklistSearchCommandHandler` and `BlacklistUpdatedEventHandler` to use the new channel resolution logic instead of directly accessing `autoModChannelId`.

- **UI updates**: Updated the settings overview embed to display configured blacklist channels and clarified the auto-mod channel description to reference the new dedicated command.

- **Comprehensive test coverage**: Added unit tests for all new components including the command handler, event handler, search handler, UI components, and the settings model helper function.

## Notable Implementation Details

- The channel selection menu is scoped to the invoking user and respects the 5-minute timeout before expiring.
- Component interaction errors are captured via the error service rather than propagating, preventing unhandled rejections from crashing the bot.
- The fallback behavior ensures existing guilds continue to receive notifications without manual reconfiguration.

https://claude.ai/code/session_01WChbyWM7KRSzs4k6nGJtZQ