### PR TITLE
fix(search): paginate search results to avoid Discord embed limit

### DIFF
--- a/src/slash-commands/search/handlers/search.command-handler.spec.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.spec.ts
@@ -13,6 +13,8 @@ import { PartyStatus } from '../../../firebase/models/signup.model.js';
 import { createAutoMock } from '../../../test-utils/mock-factory.js';
 import {
   SEARCH_ENCOUNTER_SELECTOR_ID,
+  SEARCH_NEXT_PAGE_BUTTON_ID,
+  SEARCH_PREV_PAGE_BUTTON_ID,
   SEARCH_PROG_POINT_SELECT_ID,
   SEARCH_RESET_BUTTON_ID,
 } from '../search.components.js';
@@ -404,25 +406,120 @@ describe('SearchCommandHandler', () => {
     });
     expect(mockSignupsCollection.findAll).toHaveBeenCalledTimes(2);
 
-    // Verify the response contains multiple embeds
+    // Verify the response contains a single embed for the current page,
+    // plus a pagination row, rather than every page crammed into one message
     expect(mockProgPointSelect.editReply).toHaveBeenCalled();
     const editReplyCall = mockProgPointSelect.editReply.mock.calls[0][0] as any;
     expect(editReplyCall).toHaveProperty('embeds');
-    expect(editReplyCall.embeds).toHaveLength(2); // Should have 2 pages
+    expect(editReplyCall.embeds).toHaveLength(1);
 
-    // Verify first page
     const firstEmbed = editReplyCall.embeds[0];
     expect(firstEmbed.data).toHaveProperty('description');
     expect(firstEmbed.data.description).toContain('Found 10 player(s)');
     expect(firstEmbed.data.description).toContain('Page 1/2');
     expect(firstEmbed.data.fields).toHaveLength(24); // 8 players * 3 fields each
 
-    // Verify second page
-    const secondEmbed = editReplyCall.embeds[1];
-    expect(secondEmbed.data).toHaveProperty('description');
+    // reset row + pagination row
+    expect(editReplyCall.components).toHaveLength(2);
+    const paginationRow = editReplyCall.components[1];
+    const [prevButton, nextButton] = paginationRow.components;
+    expect(prevButton.data.custom_id).toBe(SEARCH_PREV_PAGE_BUTTON_ID);
+    expect(prevButton.data.disabled).toBe(true);
+    expect(nextButton.data.custom_id).toBe(SEARCH_NEXT_PAGE_BUTTON_ID);
+    expect(nextButton.data.disabled).toBe(false);
+
+    // Clicking Next should render page 2 with the remaining 2 players
+    const mockNextPage =
+      createAutoMock() as unknown as Mocked<ButtonInteraction>;
+    mockNextPage.customId = SEARCH_NEXT_PAGE_BUTTON_ID;
+
+    await collectorCallback!(mockNextPage);
+
+    expect(mockNextPage.editReply).toHaveBeenCalled();
+    const nextPageCall = mockNextPage.editReply.mock.calls[0][0] as any;
+    expect(nextPageCall.embeds).toHaveLength(1);
+    const secondEmbed = nextPageCall.embeds[0];
     expect(secondEmbed.data.description).toContain('Found 10 player(s)');
     expect(secondEmbed.data.description).toContain('Page 2/2');
     expect(secondEmbed.data.fields).toHaveLength(6); // 2 players * 3 fields each
+
+    const secondPaginationRow = nextPageCall.components[1];
+    const [prevButton2, nextButton2] = secondPaginationRow.components;
+    expect(prevButton2.data.disabled).toBe(false);
+    expect(nextButton2.data.disabled).toBe(true);
+  });
+
+  it('should not exceed the 10-embed Discord limit when results span more than 10 pages', async () => {
+    // Setup the collector
+    let collectorCallback: (i: any) => Promise<void>;
+    mockCollector.on.mockImplementation((event: string, callback: any) => {
+      if (event === 'collect') {
+        collectorCallback = callback;
+      }
+      return mockCollector;
+    });
+
+    // 90 signups -> 12 pages of 8 players, which used to overflow the
+    // 10-embed-per-message Discord limit when all pages were sent at once
+    const manySignups = Array.from({ length: 90 }, (_, i) => ({
+      character: `Char${i + 1}`,
+      world: 'TestWorld',
+      role: 'DPS',
+      discordId: `user${i + 1}`,
+      notes: '',
+      username: `user${i + 1}`,
+      progPoint: 'Clear',
+    }));
+
+    mockSignupsCollection.findAll.mockImplementation(
+      ({ progPoint }: { progPoint?: string }) =>
+        progPoint === 'Clear'
+          ? Promise.resolve(manySignups as any)
+          : Promise.resolve([]),
+    );
+
+    // Execute the command
+    await handler.execute(
+      mockInteraction as unknown as ChatInputCommandInteraction<'cached'>,
+    );
+
+    // Simulate encounter + prog point selection (Clear has no eligible
+    // higher prog points, so only one findAll call is made)
+    const mockEncounterSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
+    mockEncounterSelect.customId = SEARCH_ENCOUNTER_SELECTOR_ID;
+    mockEncounterSelect.values = [Encounter.TOP];
+    mockEncounterSelect.isStringSelectMenu.mockReturnValue(true);
+    await collectorCallback!(mockEncounterSelect);
+
+    const mockProgPointSelect =
+      createAutoMock() as unknown as Mocked<StringSelectMenuInteraction>;
+    mockProgPointSelect.customId = SEARCH_PROG_POINT_SELECT_ID;
+    mockProgPointSelect.values = ['Clear'];
+    mockProgPointSelect.isStringSelectMenu.mockReturnValue(true);
+
+    await collectorCallback!(mockProgPointSelect);
+
+    const editReplyCall = mockProgPointSelect.editReply.mock.calls[0][0] as any;
+    expect(editReplyCall.embeds.length).toBeLessThanOrEqual(10);
+    expect(editReplyCall.embeds).toHaveLength(1);
+    expect(editReplyCall.embeds[0].data.description).toContain('Page 1/12');
+
+    // Paging all the way to the last page should never exceed 1 embed either
+    let lastInteraction = mockProgPointSelect;
+    for (let i = 0; i < 11; i++) {
+      const mockNext = createAutoMock() as unknown as Mocked<ButtonInteraction>;
+      mockNext.customId = SEARCH_NEXT_PAGE_BUTTON_ID;
+      await collectorCallback!(mockNext);
+      lastInteraction = mockNext as any;
+    }
+
+    const lastCall = lastInteraction.editReply.mock.calls[0][0] as any;
+    expect(lastCall.embeds).toHaveLength(1);
+    expect(lastCall.embeds[0].data.description).toContain('Page 12/12');
+    const lastPaginationRow = lastCall.components[1];
+    const [, lastNextButton] = lastPaginationRow.components;
+    expect(lastNextButton.data.disabled).toBe(true);
   });
 
   it('should handle reset button and return to initial state', async () => {

--- a/src/slash-commands/search/handlers/search.command-handler.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.ts
@@ -20,9 +20,12 @@ import { SlashCommand } from '../../slash-command.decorator.js';
 import type { ISlashCommand } from '../../slash-command.interface.js';
 import {
   createEncounterSelectMenu,
+  createPaginationRow,
   createProgPointSelectMenu,
   createResetButton,
   SEARCH_ENCOUNTER_SELECTOR_ID,
+  SEARCH_NEXT_PAGE_BUTTON_ID,
+  SEARCH_PREV_PAGE_BUTTON_ID,
   SEARCH_PROG_POINT_SELECT_ID,
   SEARCH_RESET_BUTTON_ID,
 } from '../search.components.js';
@@ -72,6 +75,9 @@ class SearchCommandHandler implements ISlashCommand {
     // Keep track of the current state
     let selectedEncounter: Encounter | null = null;
     let selectedProgPoint: string | null = null;
+    let resultPages: SignupDocument[][] = [];
+    let totalResults = 0;
+    let currentPage = 0;
 
     collector.on('collect', async (i) => {
       await i.deferUpdate();
@@ -126,26 +132,45 @@ class SearchCommandHandler implements ISlashCommand {
           selectedProgPoint,
         );
 
-        // Format the results
-        const embeds = this.createResultsEmbed(
-          selectedEncounter as Encounter,
-          selectedProgPoint,
-          searchResults,
-        );
+        resultPages = this.paginateSignups(searchResults);
+        totalResults = searchResults.length;
+        currentPage = 0;
 
-        // Create a row with the reset button
-        const resetRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-          createResetButton(),
+        await i.editReply(
+          this.buildResultsPage(
+            selectedEncounter as Encounter,
+            selectedProgPoint,
+            totalResults,
+            resultPages,
+            currentPage,
+          ),
         );
+      } else if (
+        i.customId === SEARCH_PREV_PAGE_BUTTON_ID ||
+        i.customId === SEARCH_NEXT_PAGE_BUTTON_ID
+      ) {
+        // Navigate between result pages
+        currentPage =
+          i.customId === SEARCH_PREV_PAGE_BUTTON_ID
+            ? Math.max(currentPage - 1, 0)
+            : Math.min(currentPage + 1, resultPages.length - 1);
 
-        await i.editReply({
-          embeds: embeds,
-          components: [resetRow],
-        });
+        await i.editReply(
+          this.buildResultsPage(
+            selectedEncounter as Encounter,
+            selectedProgPoint as string,
+            totalResults,
+            resultPages,
+            currentPage,
+          ),
+        );
       } else if (i.customId === SEARCH_RESET_BUTTON_ID) {
         // Reset the selections
         selectedEncounter = null;
         selectedProgPoint = null;
+        resultPages = [];
+        totalResults = 0;
+        currentPage = 0;
 
         // Return to initial state
         await i.editReply({
@@ -212,55 +237,93 @@ class SearchCommandHandler implements ISlashCommand {
   }
 
   /**
-   * Create an embed with the search results
+   * Split the search results into pages of PLAYERS_PER_PAGE signups each.
+   * Each player takes 3 fields (character, discord, spacer), and embeds have
+   * a 25 field limit, so we can show 8 players per page.
    */
-  private createResultsEmbed(
-    encounter: Encounter,
-    progPoint: string,
-    signups: SignupDocument[],
-  ): EmbedBuilder[] {
-    // If no results found
-    if (signups.length === 0) {
-      return [
-        new EmbedBuilder()
-          .setTitle('Search Results')
-          .setDescription(
-            `No signups found for ${encounter} at least at prog point: ${progPoint}`,
-          )
-          .setColor(Colors.Red),
-      ];
-    }
-
-    // Since each player takes 3 fields (character, discord, spacer),
-    // and embeds have a 25 field limit, we can show 8 players per embed
+  private paginateSignups(signups: SignupDocument[]): SignupDocument[][] {
     const PLAYERS_PER_PAGE = 8;
     const totalPages = Math.ceil(signups.length / PLAYERS_PER_PAGE);
 
-    // Create embeds for each page of results
     return Array.from({ length: totalPages }, (_, pageIndex) => {
       const startIdx = pageIndex * PLAYERS_PER_PAGE;
       const endIdx = Math.min(startIdx + PLAYERS_PER_PAGE, signups.length);
-      const pageSignups = signups.slice(startIdx, endIdx);
+      return signups.slice(startIdx, endIdx);
+    });
+  }
 
+  /**
+   * Build the embed + components payload for a single page of search results
+   */
+  private buildResultsPage(
+    encounter: Encounter,
+    progPoint: string,
+    totalResults: number,
+    resultPages: SignupDocument[][],
+    currentPage: number,
+  ) {
+    const resetRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      createResetButton(),
+    );
+
+    if (totalResults === 0) {
       const embed = new EmbedBuilder()
         .setTitle('Search Results')
         .setDescription(
-          `Found ${signups.length} player(s) for **${encounter}** at prog point: **${progPoint} or beyond**${
-            totalPages > 1 ? `\nPage ${pageIndex + 1}/${totalPages}` : ''
-          }`,
+          `No signups found for ${encounter} at least at prog point: ${progPoint}`,
         )
-        .setColor(Colors.Green);
+        .setColor(Colors.Red);
 
-      // Create fields for each player on this page using flatMap
-      const fields = pageSignups.flatMap((signup) => [
-        characterField(signup.character, { memberId: signup.discordId }),
-        { name: 'Role', value: signup.role, inline: true },
-        // biome-ignore lint/style/noNonNullAssertion: prog point won't be undefined here but we should improve types of Signups to fix this kind of issue
-        { name: 'Prog Point', value: signup.progPoint!, inline: true },
-      ]);
+      return { embeds: [embed], components: [resetRow] };
+    }
 
-      return embed.addFields(fields);
-    });
+    const totalPages = resultPages.length;
+    const embed = this.createResultsPageEmbed(
+      encounter,
+      progPoint,
+      totalResults,
+      resultPages[currentPage],
+      currentPage,
+      totalPages,
+    );
+
+    const components =
+      totalPages > 1
+        ? [resetRow, createPaginationRow(currentPage, totalPages)]
+        : [resetRow];
+
+    return { embeds: [embed], components };
+  }
+
+  /**
+   * Create the embed for a single page of search results
+   */
+  private createResultsPageEmbed(
+    encounter: Encounter,
+    progPoint: string,
+    totalResults: number,
+    pageSignups: SignupDocument[],
+    pageIndex: number,
+    totalPages: number,
+  ): EmbedBuilder {
+    const embed = new EmbedBuilder()
+      .setTitle('Search Results')
+      .setDescription(
+        `Found ${totalResults} player(s) for **${encounter}** at prog point: **${progPoint} or beyond**${
+          totalPages > 1 ? `\nPage ${pageIndex + 1}/${totalPages}` : ''
+        }`,
+      )
+      .setColor(Colors.Green);
+
+    // Create fields for each player on this page using flatMap
+    const fields = pageSignups.flatMap((signup) => [
+      characterField(signup.character, { memberId: signup.discordId }),
+      { name: 'Role', value: signup.role, inline: true },
+      // biome-ignore lint/style/noNonNullAssertion: prog point won't be undefined here but we should improve types of Signups to fix this kind of issue
+      { name: 'Prog Point', value: signup.progPoint!, inline: true },
+    ]);
+
+    return embed.addFields(fields);
   }
 }
 

--- a/src/slash-commands/search/search.components.ts
+++ b/src/slash-commands/search/search.components.ts
@@ -1,4 +1,5 @@
 import {
+  ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
   type SelectMenuComponentOptionData,
@@ -13,6 +14,8 @@ import {
 export const SEARCH_ENCOUNTER_SELECTOR_ID = 'searchEncounterSelect';
 export const SEARCH_PROG_POINT_SELECT_ID = 'searchProgPointSelect';
 export const SEARCH_RESET_BUTTON_ID = 'searchResetButton';
+export const SEARCH_PREV_PAGE_BUTTON_ID = 'searchPrevPageButton';
+export const SEARCH_NEXT_PAGE_BUTTON_ID = 'searchNextPageButton';
 
 // Create select menu options for encounters based on application mode
 export const getEncounterOptions = (
@@ -56,3 +59,18 @@ export const createResetButton = () =>
     .setCustomId(SEARCH_RESET_BUTTON_ID)
     .setLabel('Reset Search')
     .setStyle(ButtonStyle.Secondary);
+
+// Create the prev/next pagination row for paged results
+export const createPaginationRow = (currentPage: number, totalPages: number) =>
+  new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(SEARCH_PREV_PAGE_BUTTON_ID)
+      .setLabel('Previous')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(currentPage === 0),
+    new ButtonBuilder()
+      .setCustomId(SEARCH_NEXT_PAGE_BUTTON_ID)
+      .setLabel('Next')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(currentPage === totalPages - 1),
+  );


### PR DESCRIPTION
## Summary
Refactored the search results display to paginate results instead of cramming all pages into a single message. This prevents exceeding Discord's 10-embed-per-message limit when search results span many pages.

## Key Changes
- **Pagination logic**: Added `paginateSignups()` method to split results into pages of 8 players each (respecting the 25-field embed limit)
- **State management**: Track `resultPages`, `totalResults`, and `currentPage` in the collector to maintain pagination state across interactions
- **Navigation buttons**: Added prev/next pagination buttons via new `createPaginationRow()` component, with proper disabled states
- **Single embed per page**: Replaced multi-embed approach with `buildResultsPage()` that returns only the current page's embed plus pagination controls
- **Page rendering**: New `createResultsPageEmbed()` method generates the embed for a single page with correct page indicator
- **Reset handling**: Clear pagination state when user resets the search

## Implementation Details
- Each player occupies 3 fields (character, role, prog point), allowing 8 players per page within Discord's 25-field limit
- Pagination buttons are only shown when results span multiple pages
- Previous button is disabled on page 1; next button is disabled on the last page
- Tests verify the solution handles edge cases like 90 results (12 pages) without exceeding the 10-embed limit

https://claude.ai/code/session_01XAhrtjeCJoXB8DMrGQbS9X