### PR TITLE
chore: exclude CLI directory from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,4 @@ codecov:
   require_ci_to_pass: false
 ignore:
   - src/slash-commands/**/*-command.ts # Ignore call slash command builder commands from coverage
+  - src/cli/**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       exclude: [
         'src/slash-commands/**/*{-command.ts,.command.ts}',
         '**/*.module.ts',
+        'src/cli/**',
       ],
       provider: 'v8',
     },


### PR DESCRIPTION
Add src/cli/** to both vitest's coverage.exclude and codecov.yml's
ignore list, since the CLI is a separately built entrypoint
(tsconfig.cli.json) and Codecov applies its own exclusion patterns
independent of the local coverage report.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014FYNr2m4ZiDauKCacNk1x8