### PR TITLE
refactor(cli): prog points to use atomic replace operation

### DIFF
--- a/data/encounters/DMU.yaml
+++ b/data/encounters/DMU.yaml
@@ -48,12 +48,12 @@ progPoints:
     label: "Phase 5: Celestriad"
     partyStatus: "Clear Party"
     active: true
-  - id: "P5 Maddening 2"
-    label: "Phase 5: Maddening Orchestra 2"
-    partyStatus: "Clear Party"
-    active: true
   - id: "P5 Exas"
     label: "Phase 5: Stray Apocalypse (Exas)"
+    partyStatus: "Clear Party"
+    active: true
+  - id: "P5 Maddening 2"
+    label: "Phase 5: Maddening Orchestra 2"
     partyStatus: "Clear Party"
     active: true
   - id: "P5 Forsaken"

--- a/src/cli/commands/encounters/push/index.ts
+++ b/src/cli/commands/encounters/push/index.ts
@@ -11,8 +11,7 @@ import {
   readEncounterYaml,
 } from '../../../utils/encounter-yaml.js';
 import {
-  addProgPoint,
-  clearProgPoints,
+  replaceProgPoints,
   upsertEncounter,
 } from '../../../utils/firestore.js';
 
@@ -53,12 +52,12 @@ async function pushEncounter(
   };
 
   await upsertEncounter(db, config.id, encounterData);
-  await clearProgPoints(db, config.id);
 
-  const progPoints = config.progPoints ?? [];
-  for (const [i, pp] of progPoints.entries()) {
-    await addProgPoint(db, config.id, { ...pp, order: i });
-  }
+  const progPoints = (config.progPoints ?? []).map((pp, i) => ({
+    ...pp,
+    order: i,
+  }));
+  await replaceProgPoints(db, config.id, progPoints);
 }
 
 async function pushWithConfirmation(

--- a/src/cli/utils/firestore.ts
+++ b/src/cli/utils/firestore.ts
@@ -49,15 +49,20 @@ export async function getAllProgPoints(
   return snapshot.docs.map((doc) => doc.data());
 }
 
-export async function clearProgPoints(
+export async function replaceProgPoints(
   db: Firestore,
   encounterId: string,
+  progPoints: ProgPointDocument[],
 ): Promise<void> {
-  const snapshot = await progPointsRef(db, encounterId).get();
-  if (snapshot.empty) return;
+  const ref = progPointsRef(db, encounterId);
+  const existing = await ref.get();
+
   const batch = db.batch();
-  for (const doc of snapshot.docs) {
+  for (const doc of existing.docs) {
     batch.delete(doc.ref);
+  }
+  for (const progPoint of progPoints) {
+    batch.set(ref.doc(progPoint.id), progPoint);
   }
   await batch.commit();
 }


### PR DESCRIPTION
## Summary
Refactored the prog points update logic to use a single atomic batch operation instead of separate clear and add operations. This improves data consistency and reduces the number of database operations.

## Key Changes
- Replaced separate `clearProgPoints()` and `addProgPoint()` calls with a single `replaceProgPoints()` function that atomically deletes old prog points and writes new ones in a single batch
- Updated `pushEncounter()` to map prog points with their order index before passing to the new function, eliminating the loop
- Renamed `clearProgPoints()` to `replaceProgPoints()` and extended it to accept and write the new prog points array
- Reordered prog points in `data/encounters/DMU.yaml` (moved "P5 Maddening 2" after "P5 Exas")

## Implementation Details
The new `replaceProgPoints()` function:
- Fetches all existing prog point documents
- Creates a single batch operation that deletes all existing docs and sets all new ones
- Commits the batch atomically, ensuring consistency even if the operation is interrupted

https://claude.ai/code/session_01JFj8cpzwgYWArfqX5UvCF8