### PR TITLE
ci: make knip check blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - run: pnpm build:check
           - run: pnpm lint:ci
           - run: pnpm test:ci
-          - run: pnpm knip:ci
+          - run: pnpm knip
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "g:slash-command": "hygen slash-command new",
     "graphql:codegen": "graphql-codegen --config codegen.ts",
     "knip": "knip",
-    "knip:ci": "knip --no-exit-code",
     "lint": "biome lint --diagnostic-level=error",
     "lint:ci": "biome ci --diagnostic-level=error",
     "prepare": "node scripts/install-hooks.js",


### PR DESCRIPTION
## Summary
- Flips `pnpm knip` in CI from non-blocking (`--no-exit-code`) to blocking, now that the initial knip integration (#1394) has merged and the baseline is clean.
- Drops the now-redundant `knip:ci` script from `package.json`.

## Test plan
- [x] `pnpm knip` passes (exit 0, no findings)
- [x] `pnpm build:check` passes
- [x] `pnpm lint:ci` passes
- [x] `pnpm test:ci` passes (394/394)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaMNaS7XwuhJeT2C1nfBgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaMNaS7XwuhJeT2C1nfBgD)_