### PR TITLE
fix(sheets): raise Google Sheets timeout to 30s

### DIFF
--- a/src/sheets/sheets.utils.ts
+++ b/src/sheets/sheets.utils.ts
@@ -40,7 +40,7 @@ export async function getSheetValues(
       spreadsheetId,
       range,
     },
-    { timeout: 15_000 },
+    { timeout: 30_000 },
   );
 
   return response.data.values;


### PR DESCRIPTION
Bumps the per-call timeout on `getSheetValues` from 15s to 30s, matching the existing `batchUpdate` default.

## Why

Sentry `ULTI-PROJECT-BOT-6V` — `AbortError: The operation was aborted.` on `remove-signup`. The abort is client-side, not user cancellation and not a Google error response: gaxios implements `timeout` as `AbortSignal.timeout()` (`gaxios.js:432`), and the stack trace bottoms out in `internal/timers` → `internal/abort_controller` → node-fetch's `abortAndFinalize`. The 15s deadline expired before Sheets responded.

`createRemoveSignup` fans out one `getSheetValues` per party-type range under `Promise.all`, so a single stalled read fails the whole command.

## Caveat

This lowers the failure rate; it is not a guaranteed fix, so no `Fixes` trailer.

Notably `retry: true` on the client does not cover this case. gaxios refuses to retry aborts unless `err.code === 'TimeoutError'` (`retry.js:95`), but node-fetch replaces the DOMException with its own `AbortError`, which carries no `code` — so the guard matches and the request fails on the first stall with zero retries. A 30s stall still hard-fails. Worth a follow-up if the issue recurs.

## Test plan

- `pnpm build:check` clean
- `biome check` clean
- 394 tests pass (via lefthook pre-commit)

No test added — the change is a single constant with no branching behavior to assert.