### PR TITLE
feat(firebase): scope all collections under guilds/{guildId}

### DIFF
--- a/.claude/skills/edit-encounter-prog-points/SKILL.md
+++ b/.claude/skills/edit-encounter-prog-points/SKILL.md
@@ -92,17 +92,20 @@ clearPartyThreshold: "P5: Fulgent 1"      # Minimum prog point for a "clear part
 
 ```bash
 # Sync a specific encounter (recommended)
-pnpm cli encounters push FRU
+pnpm cli --guild <guildId> encounters push FRU
 
 # Sync all encounters (use cautiously)
-pnpm cli encounters push
+pnpm cli --guild <guildId> encounters push
 
 # Preview changes without syncing (dry-run)
-pnpm cli encounters push --dry-run
+pnpm cli --guild <guildId> encounters push --dry-run
 
 # Skip confirmation prompts (useful for automation)
-pnpm cli encounters push FRU --yes
+pnpm cli --guild <guildId> encounters push FRU --yes
 ```
+
+Encounters live at `guilds/{guildId}/encounters`, so a push always targets one
+guild. `--guild` can be omitted if `GUILD_ID` is set in the env file.
 
 **What the sync does:**
 1. Validates YAML against schema
@@ -135,7 +138,7 @@ Invalid encounter YAML:
 
 | Mistake | Why It Breaks | Fix |
 |---------|---------------|-----|
-| Edit YAML, don't run sync | Changes never reach Firestore; bot shows old data | Always run `pnpm cli encounters push ENCOUNTER_ID` |
+| Edit YAML, don't run sync | Changes never reach Firestore; bot shows old data | Always run `pnpm cli --guild <guildId> encounters push ENCOUNTER_ID` |
 | Use `Prog Party` in code but `progParty` in YAML | Schema validation fails, sync rejects file | Use exact enum: `Prog Party` with space and capitals |
 | Rename prog point id but forget threshold update | Thresholds reference broken id | If `progPartyThreshold: "P3: Old Name"` and you rename it, update the threshold field too |
 | Delete prog point without checking thresholds | Thresholds may reference deleted id; bot breaks silently | Before deleting, check if `progPartyThreshold` or `clearPartyThreshold` reference it; update thresholds first |
@@ -166,7 +169,7 @@ progPoints:
 
 Then sync:
 ```bash
-pnpm cli encounters push FRU
+pnpm cli --guild <guildId> encounters push FRU
 ```
 
 Output: `Pushed FRU (N prog points)` where N includes your new point.
@@ -189,7 +192,7 @@ progPartyThreshold: "P3: Curtain Call"  # Updated to match new id
 
 Then sync:
 ```bash
-pnpm cli encounters push FRU
+pnpm cli --guild <guildId> encounters push FRU
 ```
 
 ## Red Flags - Stop and Validate
@@ -223,7 +226,7 @@ Have I made the YAML changes?
 ├─ NO: Make them now
 └─ YES: Continue
 
-Am I about to run pnpm cli encounters push?
+Am I about to run pnpm cli --guild <guildId> encounters push?
 ├─ NO: Stop. This step is mandatory.
 └─ YES: Do it now, observe the output
 ```

--- a/data/README.md
+++ b/data/README.md
@@ -27,17 +27,21 @@ Run the CLI command to push your changes to Firestore:
 
 ```bash
 # Sync all encounters
-pnpm cli encounters push
+pnpm cli --guild <guildId> encounters push
 
 # Sync a specific encounter
-pnpm cli encounters push FRU
+pnpm cli --guild <guildId> encounters push FRU
 
 # Dry-run to preview changes
-pnpm cli encounters push --dry-run
+pnpm cli --guild <guildId> encounters push --dry-run
 
 # Skip confirmation prompts
-pnpm cli encounters push --yes
+pnpm cli --guild <guildId> encounters push --yes
 ```
+
+Encounters are stored per-guild at `guilds/{guildId}/encounters`, so every CLI
+command needs to know which guild to write to. Set `GUILD_ID` in your env file to
+drop the `--guild` flag from these commands.
 
 The CLI will:
 - Load and validate all YAML files against `encounter.schema.yaml`
@@ -58,5 +62,6 @@ This is automatically added when using the CLI to create new encounters.
 ## Notes
 
 - Always sync changes via the CLI after editing YAML files—the database will not automatically reflect file changes
+- A push writes to one guild. Repeat it per `--guild` to roll the same encounter out to several guilds
 - The `progPoints` order in the YAML determines their display order in the application
 - Removing a progression point from the YAML and syncing will delete it from Firestore

--- a/src/cli/commands/encounters/add/index.ts
+++ b/src/cli/commands/encounters/add/index.ts
@@ -20,6 +20,7 @@ export interface AddCommandOptions {
 
 async function runAdd(
   db: Firestore,
+  guildId: string,
   fflogsToken: string | undefined,
   opts: AddCommandOptions,
 ): Promise<void> {
@@ -45,7 +46,7 @@ async function runAdd(
   }
 
   await applySourceEditsStep(sourceEdits, opts);
-  await seedFirestoreStep(db, config, opts);
+  await seedFirestoreStep(db, guildId, config, opts);
 
   clack.outro(`Encounter '${config.id}' added successfully.`);
 }
@@ -62,6 +63,6 @@ export function registerAddCommand(encountersCmd: Command): void {
       'Comma-separated FF Logs encounter IDs',
     )
     .action(async (opts: AddCommandOptions) => {
-      await runAdd(ctx.db, ctx.fflogsToken, opts);
+      await runAdd(ctx.db, ctx.guildId, ctx.fflogsToken, opts);
     });
 }

--- a/src/cli/commands/encounters/add/steps.ts
+++ b/src/cli/commands/encounters/add/steps.ts
@@ -109,6 +109,7 @@ export async function applySourceEditsStep(
 
 async function seedProgPoints(
   db: Firestore,
+  guildId: string,
   config: EncounterConfig,
 ): Promise<void> {
   if (!config.progPoints || config.progPoints.length === 0) return;
@@ -126,7 +127,7 @@ async function seedProgPoints(
         order: i,
         active: true,
       };
-      await addProgPoint(db, config.id, progPoint);
+      await addProgPoint(db, guildId, config.id, progPoint);
       addedCount++;
     }
     ppSpinner.stop(`Added ${addedCount} prog points`);
@@ -144,6 +145,7 @@ async function seedProgPoints(
 
 export async function seedFirestoreStep(
   db: Firestore,
+  guildId: string,
   config: EncounterConfig,
   opts: AddCommandOptions,
 ): Promise<void> {
@@ -152,7 +154,7 @@ export async function seedFirestoreStep(
     : cancelIfCancel(await clack.confirm({ message: 'Seed Firestore?' }));
   if (!seed) return;
 
-  const existing = await getEncounter(db, config.id);
+  const existing = await getEncounter(db, guildId, config.id);
   if (existing) {
     const overwrite = opts.yes
       ? true
@@ -170,7 +172,7 @@ export async function seedFirestoreStep(
   const encSpinner = clack.spinner();
   encSpinner.start('Creating encounter document...');
   try {
-    await upsertEncounter(db, config.id, {
+    await upsertEncounter(db, guildId, config.id, {
       name: config.name,
       description: config.description,
       active: true,
@@ -187,7 +189,7 @@ export async function seedFirestoreStep(
     process.exit(1);
   }
 
-  await seedProgPoints(db, config);
+  await seedProgPoints(db, guildId, config);
 }
 
 export { planSourceEdits };

--- a/src/cli/commands/encounters/pull/index.ts
+++ b/src/cli/commands/encounters/pull/index.ts
@@ -12,7 +12,7 @@ import {
   getAllProgPoints,
 } from '../../../utils/firestore.js';
 
-async function runPull(db: Firestore): Promise<void> {
+async function runPull(db: Firestore, guildId: string): Promise<void> {
   clack.intro('Pull Encounters');
 
   const dirPath = join(process.cwd(), 'data', 'encounters');
@@ -22,7 +22,7 @@ async function runPull(db: Firestore): Promise<void> {
 
   let encounters: Awaited<ReturnType<typeof getAllActiveEncounters>>;
   try {
-    encounters = await getAllActiveEncounters(db);
+    encounters = await getAllActiveEncounters(db, guildId);
     fetchSpinner.stop(`Found ${encounters.length} active encounter(s)`);
   } catch (error) {
     fetchSpinner.stop('Failed');
@@ -40,7 +40,7 @@ async function runPull(db: Firestore): Promise<void> {
     spinner.start(`Pulling ${enc.id}...`);
 
     try {
-      const progPoints = await getAllProgPoints(db, enc.id);
+      const progPoints = await getAllProgPoints(db, guildId, enc.id);
 
       const yamlConfig: EncounterYamlConfig = {
         id: enc.id,
@@ -83,7 +83,7 @@ export function registerPullCommand(encountersCmd: Command): void {
     .command('pull')
     .description('Pull all active encounters from Firestore to YAML files')
     .action(async () => {
-      const { db } = ctx;
-      await runPull(db);
+      const { db, guildId } = ctx;
+      await runPull(db, guildId);
     });
 }

--- a/src/cli/commands/encounters/push/index.ts
+++ b/src/cli/commands/encounters/push/index.ts
@@ -32,6 +32,7 @@ function getEncounterYamlPaths(encounterId?: string): string[] {
 
 async function pushEncounter(
   db: Firestore,
+  guildId: string,
   config: EncounterYamlConfig,
 ): Promise<void> {
   const encounterData: Partial<EncounterDocument> = {
@@ -51,17 +52,18 @@ async function pushEncounter(
     }),
   };
 
-  await upsertEncounter(db, config.id, encounterData);
+  await upsertEncounter(db, guildId, config.id, encounterData);
 
   const progPoints = (config.progPoints ?? []).map((pp, i) => ({
     ...pp,
     order: i,
   }));
-  await replaceProgPoints(db, config.id, progPoints);
+  await replaceProgPoints(db, guildId, config.id, progPoints);
 }
 
 async function pushWithConfirmation(
   db: Firestore,
+  guildId: string,
   config: EncounterYamlConfig,
   yes: boolean | undefined,
 ): Promise<boolean> {
@@ -79,7 +81,7 @@ async function pushWithConfirmation(
   spinner.start(`Pushing ${config.id}...`);
 
   try {
-    await pushEncounter(db, config);
+    await pushEncounter(db, guildId, config);
     const count = config.progPoints?.length ?? 0;
     spinner.stop(`Pushed ${config.id} (${count} prog points)`);
     return true;
@@ -92,6 +94,7 @@ async function pushWithConfirmation(
 
 async function runPush(
   db: Firestore,
+  guildId: string,
   encounterId: string | undefined,
   opts: PushCommandOptions,
 ): Promise<void> {
@@ -124,7 +127,7 @@ async function runPush(
   let pushed = 0;
 
   for (const config of configs) {
-    const didPush = await pushWithConfirmation(db, config, opts.yes);
+    const didPush = await pushWithConfirmation(db, guildId, config, opts.yes);
     if (didPush) pushed++;
   }
 
@@ -139,7 +142,7 @@ export function registerPushCommand(encountersCmd: Command): void {
     .option('--yes', 'Skip confirmation prompts')
     .action(
       async (encounterId: string | undefined, opts: PushCommandOptions) => {
-        await runPush(ctx.db, encounterId, opts);
+        await runPush(ctx.db, ctx.guildId, encounterId, opts);
       },
     );
 }

--- a/src/cli/commands/encounters/view/index.ts
+++ b/src/cli/commands/encounters/view/index.ts
@@ -37,11 +37,12 @@ function formatProgPointRow(
 
 async function viewSingleEncounter(
   db: Firestore,
+  guildId: string,
   encounterId: string,
 ): Promise<void> {
   const [encounter, progPoints] = await Promise.all([
-    getEncounter(db, encounterId),
-    getAllProgPoints(db, encounterId),
+    getEncounter(db, guildId, encounterId),
+    getAllProgPoints(db, guildId, encounterId),
   ]);
 
   if (!encounter) {
@@ -70,8 +71,11 @@ async function viewSingleEncounter(
   );
 }
 
-async function viewAllEncounters(db: Firestore): Promise<void> {
-  const active = await getAllActiveEncounters(db);
+async function viewAllEncounters(
+  db: Firestore,
+  guildId: string,
+): Promise<void> {
+  const active = await getAllActiveEncounters(db, guildId);
 
   if (active.length === 0) {
     clack.log.warn('No active encounters found in Firestore.');
@@ -84,7 +88,7 @@ async function viewAllEncounters(db: Firestore): Promise<void> {
   ];
 
   for (const enc of active) {
-    const progPoints = await getAllProgPoints(db, enc.id);
+    const progPoints = await getAllProgPoints(db, guildId, enc.id);
     const hasProg = enc.progPartyThreshold ? '✅' : '❌';
     const hasClear = enc.clearPartyThreshold ? '✅' : '❌';
     const name =
@@ -97,7 +101,11 @@ async function viewAllEncounters(db: Firestore): Promise<void> {
   clack.log.info(lines.join('\n'));
 }
 
-async function runView(db: Firestore, encounterId?: string): Promise<void> {
+async function runView(
+  db: Firestore,
+  guildId: string,
+  encounterId?: string,
+): Promise<void> {
   clack.intro('View Encounter');
 
   const spinner = clack.spinner();
@@ -106,9 +114,9 @@ async function runView(db: Firestore, encounterId?: string): Promise<void> {
   try {
     spinner.stop('');
     if (encounterId) {
-      await viewSingleEncounter(db, encounterId);
+      await viewSingleEncounter(db, guildId, encounterId);
     } else {
-      await viewAllEncounters(db);
+      await viewAllEncounters(db, guildId);
     }
   } catch (error) {
     spinner.stop('Failed');
@@ -124,7 +132,7 @@ export function registerViewCommand(encountersCmd: Command): void {
     .command('view [encounter-id]')
     .description('View encounter configuration from Firestore')
     .action(async (encounterId?: string) => {
-      const { db } = ctx;
-      await runView(db, encounterId);
+      const { db, guildId } = ctx;
+      await runView(db, guildId, encounterId);
     });
 }

--- a/src/cli/commands/migrate/index.ts
+++ b/src/cli/commands/migrate/index.ts
@@ -1,0 +1,265 @@
+import * as clack from '@clack/prompts';
+import type { Command } from 'commander';
+import type {
+  DocumentReference,
+  Firestore,
+  QueryDocumentSnapshot,
+  WriteBatch,
+} from 'firebase-admin/firestore';
+import { guildDoc } from '../../../firebase/firebase.paths.js';
+import { ctx } from '../../config.js';
+import { cancelIfCancel } from '../../utils/clack.js';
+
+// Firestore caps a batch at 500 writes; --delete-source doubles the writes per
+// document, so commit well below the limit.
+const BATCH_LIMIT = 200;
+
+interface MigrateCommandOptions {
+  dryRun?: boolean;
+  deleteSource?: boolean;
+  yes?: boolean;
+}
+
+interface CopyPlan {
+  source: QueryDocumentSnapshot[];
+  /** Resolves the destination for a given source document. */
+  destination: (doc: QueryDocumentSnapshot) => DocumentReference;
+}
+
+/**
+ * Commits `writes` in chunks so a large collection can't exceed the batch limit.
+ */
+async function commitInChunks(
+  db: Firestore,
+  writes: ((batch: WriteBatch) => void)[],
+): Promise<void> {
+  for (let i = 0; i < writes.length; i += BATCH_LIMIT) {
+    const batch = db.batch();
+    for (const write of writes.slice(i, i + BATCH_LIMIT)) {
+      write(batch);
+    }
+    await batch.commit();
+  }
+}
+
+async function applyPlan(
+  db: Firestore,
+  plan: CopyPlan,
+  deleteSource: boolean,
+): Promise<number> {
+  const writes = plan.source.flatMap((doc) => {
+    const target = plan.destination(doc);
+    const ops = [(batch: WriteBatch) => batch.set(target, doc.data())];
+    if (deleteSource) {
+      ops.push((batch: WriteBatch) => batch.delete(doc.ref));
+    }
+    return ops;
+  });
+
+  await commitInChunks(db, writes);
+  return plan.source.length;
+}
+
+/**
+ * Settings used to be a single document at `settings/{guildId}`; it now lives on
+ * the guild document itself, so this is a merge rather than a collection copy.
+ */
+async function migrateSettings(
+  db: Firestore,
+  guildId: string,
+  { dryRun, deleteSource }: MigrateCommandOptions,
+): Promise<number> {
+  const legacy = db.collection('settings').doc(guildId);
+  const snapshot = await legacy.get();
+
+  if (!snapshot.exists) return 0;
+  if (dryRun) return 1;
+
+  await guildDoc(db, guildId).set(snapshot.data() ?? {}, { merge: true });
+  if (deleteSource) {
+    await legacy.delete();
+  }
+
+  return 1;
+}
+
+async function migrateSignups(
+  db: Firestore,
+  guildId: string,
+  { dryRun, deleteSource }: MigrateCommandOptions,
+): Promise<number> {
+  const source = await db.collection('signups').get();
+  if (dryRun) return source.size;
+
+  const target = guildDoc(db, guildId).collection('signups');
+  return applyPlan(
+    db,
+    {
+      source: source.docs,
+      destination: (doc) => target.doc(doc.id),
+    },
+    !!deleteSource,
+  );
+}
+
+async function migrateBlacklist(
+  db: Firestore,
+  guildId: string,
+  { dryRun, deleteSource }: MigrateCommandOptions,
+): Promise<number> {
+  const source = await db
+    .collection('blacklist')
+    .doc(guildId)
+    .collection('documents')
+    .get();
+  if (dryRun) return source.size;
+
+  const target = guildDoc(db, guildId).collection('blacklist');
+  return applyPlan(
+    db,
+    {
+      source: source.docs,
+      destination: (doc) => target.doc(doc.id),
+    },
+    !!deleteSource,
+  );
+}
+
+/**
+ * Encounters carry a `prog-points` subcollection, which a document copy does not
+ * follow — each one has to be walked explicitly.
+ */
+async function migrateEncounters(
+  db: Firestore,
+  guildId: string,
+  { dryRun, deleteSource }: MigrateCommandOptions,
+): Promise<{ encounters: number; progPoints: number }> {
+  const source = await db.collection('encounters').get();
+  const target = guildDoc(db, guildId).collection('encounters');
+
+  let progPoints = 0;
+
+  for (const encounter of source.docs) {
+    const legacyProgPoints = await encounter.ref
+      .collection('prog-points')
+      .get();
+    progPoints += legacyProgPoints.size;
+
+    if (dryRun) continue;
+
+    const targetEncounter = target.doc(encounter.id);
+
+    await applyPlan(
+      db,
+      {
+        source: [encounter],
+        destination: () => targetEncounter,
+      },
+      !!deleteSource,
+    );
+
+    await applyPlan(
+      db,
+      {
+        source: legacyProgPoints.docs,
+        destination: (doc) =>
+          targetEncounter.collection('prog-points').doc(doc.id),
+      },
+      !!deleteSource,
+    );
+  }
+
+  return { encounters: source.size, progPoints };
+}
+
+async function runMigrate(
+  db: Firestore,
+  guildId: string,
+  opts: MigrateCommandOptions,
+): Promise<void> {
+  clack.intro('Migrate to guild-scoped collections');
+
+  clack.log.info(
+    `Target: guilds/${guildId}\n` +
+      'Root `signups` and `encounters` documents carry no guild marker, so every\n' +
+      'one of them will be assigned to this guild.',
+  );
+
+  if (!opts.dryRun && !opts.yes) {
+    const confirmed = cancelIfCancel(
+      await clack.confirm({
+        message: opts.deleteSource
+          ? `Copy legacy data into guilds/${guildId} AND delete the originals?`
+          : `Copy legacy data into guilds/${guildId}?`,
+      }),
+    );
+    if (!confirmed) {
+      clack.outro('Aborted — no changes applied.');
+      return;
+    }
+  }
+
+  const spinner = clack.spinner();
+  spinner.start(opts.dryRun ? 'Counting legacy documents...' : 'Migrating...');
+
+  try {
+    const settings = await migrateSettings(db, guildId, opts);
+    const signups = await migrateSignups(db, guildId, opts);
+    const blacklist = await migrateBlacklist(db, guildId, opts);
+    const { encounters, progPoints } = await migrateEncounters(
+      db,
+      guildId,
+      opts,
+    );
+
+    spinner.stop(opts.dryRun ? 'Counted' : 'Migrated');
+
+    const verb = opts.dryRun ? 'Would copy' : 'Copied';
+    clack.log.info(
+      [
+        `${verb}:`,
+        `  settings     ${settings} document(s) -> guilds/${guildId}`,
+        `  signups      ${signups} document(s)`,
+        `  blacklist    ${blacklist} document(s)`,
+        `  encounters   ${encounters} document(s)`,
+        `  prog-points  ${progPoints} document(s)`,
+      ].join('\n'),
+    );
+  } catch (error) {
+    spinner.stop('Failed');
+    clack.log.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (opts.dryRun) {
+    clack.outro('Dry-run complete — no changes applied.');
+    return;
+  }
+
+  clack.outro(
+    opts.deleteSource
+      ? 'Done — legacy documents removed.'
+      : 'Done — legacy documents left in place. Re-run with --delete-source once the bot is verified healthy.',
+  );
+}
+
+export function registerMigrateCommand(program: Command): void {
+  const migrateCmd = program
+    .command('migrate')
+    .description('One-off data migrations');
+
+  migrateCmd
+    .command('guild-scope')
+    .description(
+      'Copy legacy settings/signups/blacklist/encounters under guilds/<guildId>',
+    )
+    .option('--dry-run', 'Report what would be copied without writing')
+    .option(
+      '--delete-source',
+      'Delete the legacy documents after copying them (off by default)',
+    )
+    .option('--yes', 'Skip confirmation prompts')
+    .action(async (opts: MigrateCommandOptions) => {
+      await runMigrate(ctx.db, ctx.guildId, opts);
+    });
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -9,17 +9,19 @@ const cliConfigSchema = z.object({
   GCP_PROJECT_ID: z.string(),
   FIRESTORE_DATABASE_ID: z.string().optional(),
   FFLOGS_API_ACCESS_TOKEN: z.string().optional(),
+  GUILD_ID: z.string().optional(),
 });
 
 export interface CliContext {
   db: Firestore;
   fflogsToken: string | undefined;
+  guildId: string;
 }
 
 // Initialized by main.ts preAction hook before any command action runs.
 export let ctx!: CliContext;
 
-export function initCtx(): void {
+export function initCtx(guildOverride?: string): void {
   const result = cliConfigSchema.safeParse(process.env);
   if (!result.success) {
     clack.log.error(
@@ -28,6 +30,15 @@ export function initCtx(): void {
     process.exit(1);
   }
   const config = result.data;
+
+  const guildId = guildOverride ?? config.GUILD_ID;
+  if (!guildId) {
+    clack.log.error(
+      'No guild selected. Pass --guild <guildId> or set GUILD_ID in your env file.',
+    );
+    process.exit(1);
+  }
+
   const db = createFirestore({
     clientEmail: config.GCP_ACCOUNT_EMAIL,
     privateKey: config.GCP_PRIVATE_KEY,
@@ -35,5 +46,5 @@ export function initCtx(): void {
     databaseId: config.FIRESTORE_DATABASE_ID,
     appName: 'cli',
   });
-  ctx = { db, fflogsToken: config.FFLOGS_API_ACCESS_TOKEN };
+  ctx = { db, fflogsToken: config.FFLOGS_API_ACCESS_TOKEN, guildId };
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,17 +1,23 @@
 import * as clack from '@clack/prompts';
 import { Command } from 'commander';
 import { registerEncountersCommand } from './commands/encounters/index.js';
+import { registerMigrateCommand } from './commands/migrate/index.js';
 import { initCtx } from './config.js';
 
 const program = new Command()
   .name('pnpm cli')
-  .description('Ulti-Project management CLI');
+  .description('Ulti-Project management CLI')
+  .option(
+    '--guild <guildId>',
+    'Guild to operate on (defaults to $GUILD_ID). All data is scoped to guilds/<guildId>.',
+  );
 
 program.hook('preAction', () => {
-  initCtx();
+  initCtx(program.opts().guild);
 });
 
 registerEncountersCommand(program);
+registerMigrateCommand(program);
 
 await program.parseAsync().catch((error: unknown) => {
   clack.log.error(error instanceof Error ? error.message : String(error));

--- a/src/cli/utils/firestore.ts
+++ b/src/cli/utils/firestore.ts
@@ -1,60 +1,74 @@
 import type { CollectionReference, Firestore } from 'firebase-admin/firestore';
+import { guildCollection } from '../../firebase/firebase.paths.js';
 import type {
   EncounterDocument,
   ProgPointDocument,
 } from '../../firebase/models/encounter.model.js';
 
-function encountersRef(db: Firestore): CollectionReference<EncounterDocument> {
-  return db.collection('encounters') as CollectionReference<EncounterDocument>;
+function encountersRef(
+  db: Firestore,
+  guildId: string,
+): CollectionReference<EncounterDocument> {
+  return guildCollection<EncounterDocument>(db, guildId, 'encounters');
 }
 
 function progPointsRef(
   db: Firestore,
+  guildId: string,
   encounterId: string,
 ): CollectionReference<ProgPointDocument> {
-  return encountersRef(db)
+  return encountersRef(db, guildId)
     .doc(encounterId)
     .collection('prog-points') as CollectionReference<ProgPointDocument>;
 }
 
 export async function getEncounter(
   db: Firestore,
+  guildId: string,
   encounterId: string,
 ): Promise<(EncounterDocument & { id: string }) | undefined> {
-  const doc = await encountersRef(db).doc(encounterId).get();
+  const doc = await encountersRef(db, guildId).doc(encounterId).get();
   const data = doc.data();
   return data ? { ...data, id: doc.id } : undefined;
 }
 
 export async function getAllActiveEncounters(
   db: Firestore,
+  guildId: string,
 ): Promise<(EncounterDocument & { id: string })[]> {
-  const snapshot = await encountersRef(db).where('active', '==', true).get();
+  const snapshot = await encountersRef(db, guildId)
+    .where('active', '==', true)
+    .get();
   return snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
 }
 
 export async function upsertEncounter(
   db: Firestore,
+  guildId: string,
   encounterId: string,
   data: Partial<EncounterDocument>,
 ): Promise<void> {
-  await encountersRef(db).doc(encounterId).set(data, { merge: true });
+  await encountersRef(db, guildId).doc(encounterId).set(data, { merge: true });
 }
 
 export async function getAllProgPoints(
   db: Firestore,
+  guildId: string,
   encounterId: string,
 ): Promise<ProgPointDocument[]> {
-  const snapshot = await progPointsRef(db, encounterId).orderBy('order').get();
+  const snapshot = await progPointsRef(db, guildId, encounterId)
+    .orderBy('order')
+    .get();
   return snapshot.docs.map((doc) => doc.data());
 }
 
 export async function replaceProgPoints(
   db: Firestore,
+  guildId: string,
   encounterId: string,
   progPoints: ProgPointDocument[],
 ): Promise<void> {
-  const ref = progPointsRef(db, encounterId);
+  const ref = progPointsRef(db, guildId, encounterId);
   const existing = await ref.get();
 
   const batch = db.batch();
@@ -69,8 +83,11 @@ export async function replaceProgPoints(
 
 export async function addProgPoint(
   db: Firestore,
+  guildId: string,
   encounterId: string,
   progPoint: ProgPointDocument,
 ): Promise<void> {
-  await progPointsRef(db, encounterId).doc(progPoint.id).set(progPoint);
+  await progPointsRef(db, guildId, encounterId)
+    .doc(progPoint.id)
+    .set(progPoint);
 }

--- a/src/encounters/encounters-components.service.spec.ts
+++ b/src/encounters/encounters-components.service.spec.ts
@@ -41,7 +41,10 @@ describe('EncountersComponentsService', () => {
   });
 
   it('builds a single-select menu with the cleared option by default', async () => {
-    const menu = await service.createProgPointSelectMenu(Encounter.TOP);
+    const menu = await service.createProgPointSelectMenu(
+      'test-guild',
+      Encounter.TOP,
+    );
 
     expect(menu.data.custom_id).toBe(PROG_POINT_SELECT_ID);
     expect(menu.options.map((o) => o.data.value)).toEqual([
@@ -53,11 +56,15 @@ describe('EncountersComponentsService', () => {
   });
 
   it('builds a multi-select menu without cleared when configured', async () => {
-    const menu = await service.createProgPointSelectMenu(Encounter.TOP, {
-      customId: 'customSelect',
-      includeCleared: false,
-      multiSelect: true,
-    });
+    const menu = await service.createProgPointSelectMenu(
+      'test-guild',
+      Encounter.TOP,
+      {
+        customId: 'customSelect',
+        includeCleared: false,
+        multiSelect: true,
+      },
+    );
 
     expect(menu.data.custom_id).toBe('customSelect');
     expect(menu.options.map((o) => o.data.value)).toEqual(['P1', 'P2']);

--- a/src/encounters/encounters-components.service.ts
+++ b/src/encounters/encounters-components.service.ts
@@ -21,6 +21,7 @@ export class EncountersComponentsService {
   constructor(private readonly encountersService: EncountersService) {}
 
   async createProgPointSelectMenu(
+    guildId: string,
     encounter: Encounter,
     {
       customId = PROG_POINT_SELECT_ID,
@@ -28,7 +29,10 @@ export class EncountersComponentsService {
       multiSelect = false,
     }: ProgPointSelectMenuOptions = {},
   ): Promise<StringSelectMenuBuilder> {
-    const progPoints = await this.encountersService.getProgPoints(encounter);
+    const progPoints = await this.encountersService.getProgPoints(
+      guildId,
+      encounter,
+    );
 
     const options: SelectMenuComponentOptionData[] = progPoints.map(
       (progPoint) => ({
@@ -53,9 +57,13 @@ export class EncountersComponentsService {
   }
 
   async getProgPointOptions(
+    guildId: string,
     encounter: Encounter,
   ): Promise<SelectMenuComponentOptionData[]> {
-    const progPoints = await this.encountersService.getProgPoints(encounter);
+    const progPoints = await this.encountersService.getProgPoints(
+      guildId,
+      encounter,
+    );
 
     const options: SelectMenuComponentOptionData[] = progPoints.map(
       (progPoint) => ({

--- a/src/encounters/encounters.components.spec.ts
+++ b/src/encounters/encounters.components.spec.ts
@@ -46,7 +46,10 @@ describe('EncountersComponentsService', () => {
 
       mockEncountersService.getProgPoints.mockResolvedValue(mockProgPoints);
 
-      const menu = await service.createProgPointSelectMenu(Encounter.DSR);
+      const menu = await service.createProgPointSelectMenu(
+        'test-guild',
+        Encounter.DSR,
+      );
 
       expect(menu.options).toHaveLength(3); // 2 prog points + cleared option
       expect(menu.options[0].data.label).toBe('Phase 1');
@@ -77,7 +80,10 @@ describe('EncountersComponentsService', () => {
 
       mockEncountersService.getProgPoints.mockResolvedValue(mockProgPoints);
 
-      const options = await service.getProgPointOptions(Encounter.TOP);
+      const options = await service.getProgPointOptions(
+        'test-guild',
+        Encounter.TOP,
+      );
 
       expect(options).toHaveLength(3);
       expect(options).toEqual([

--- a/src/encounters/encounters.service.spec.ts
+++ b/src/encounters/encounters.service.spec.ts
@@ -12,6 +12,7 @@ import { EncountersService } from './encounters.service.js';
 describe('EncountersService', () => {
   let service: EncountersService;
   let mockEncountersCollection: Mocked<EncountersCollection>;
+  const guildId = 'test-guild';
 
   beforeEach(async () => {
     mockEncountersCollection =
@@ -81,7 +82,11 @@ describe('EncountersService', () => {
       mockEncountersCollection.getProgPoints.mockResolvedValue([]);
 
       await expect(
-        service.getPartyStatusForProgPoint('test-encounter', 'non-existent'),
+        service.getPartyStatusForProgPoint(
+          guildId,
+          'test-encounter',
+          'non-existent',
+        ),
       ).rejects.toThrow(
         'Prog point not found: non-existent for encounter: test-encounter',
       );
@@ -99,6 +104,7 @@ describe('EncountersService', () => {
       mockEncountersCollection.getProgPoints.mockResolvedValue(mockProgPoints);
 
       const result = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'prog1',
       );
@@ -111,6 +117,7 @@ describe('EncountersService', () => {
       mockEncountersCollection.getProgPoints.mockResolvedValue(mockProgPoints);
 
       const result = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'clear1',
       );
@@ -132,6 +139,7 @@ describe('EncountersService', () => {
 
       // Test early prog party (before prog threshold)
       const earlyResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'early1',
       );
@@ -139,6 +147,7 @@ describe('EncountersService', () => {
 
       // Test prog party (at prog threshold)
       const progResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'prog1',
       );
@@ -146,6 +155,7 @@ describe('EncountersService', () => {
 
       // Test prog party (between prog and clear threshold)
       const progResult2 = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'prog2',
       );
@@ -153,6 +163,7 @@ describe('EncountersService', () => {
 
       // Test clear party (at clear threshold)
       const clearResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'clear1',
       );
@@ -160,6 +171,7 @@ describe('EncountersService', () => {
 
       // Test clear party (after clear threshold)
       const clearResult2 = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'clear2',
       );
@@ -171,18 +183,21 @@ describe('EncountersService', () => {
 
       // Should return the direct party status from each prog point
       const earlyResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'early1',
       );
       expect(earlyResult).toBe(PartyStatus.EarlyProgParty);
 
       const progResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'prog1',
       );
       expect(progResult).toBe(PartyStatus.ProgParty);
 
       const clearResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'clear1',
       );
@@ -194,18 +209,21 @@ describe('EncountersService', () => {
 
       // Should return the direct party status from each prog point
       const earlyResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'early1',
       );
       expect(earlyResult).toBe(PartyStatus.EarlyProgParty);
 
       const progResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'prog1',
       );
       expect(progResult).toBe(PartyStatus.ProgParty);
 
       const clearResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'clear1',
       );
@@ -243,18 +261,21 @@ describe('EncountersService', () => {
 
       // Should return the direct party status from each prog point
       const earlyResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'point1',
       );
       expect(earlyResult).toBe(PartyStatus.EarlyProgParty);
 
       const progResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'point2',
       );
       expect(progResult).toBe(PartyStatus.EarlyProgParty);
 
       const clearResult = await service.getPartyStatusForProgPoint(
+        guildId,
         'test-encounter',
         'point3',
       );
@@ -290,9 +311,13 @@ describe('EncountersService', () => {
 
       mockEncountersCollection.getProgPoints.mockResolvedValue(mockProgPoints);
 
-      const result = await service.getProgPointsAsOptions('test-encounter');
+      const result = await service.getProgPointsAsOptions(
+        guildId,
+        'test-encounter',
+      );
 
       expect(mockEncountersCollection.getProgPoints).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
       );
       expect(result).toEqual({
@@ -314,7 +339,10 @@ describe('EncountersService', () => {
     it('should return empty object when no prog points exist', async () => {
       mockEncountersCollection.getProgPoints.mockResolvedValue([]);
 
-      const result = await service.getProgPointsAsOptions('test-encounter');
+      const result = await service.getProgPointsAsOptions(
+        guildId,
+        'test-encounter',
+      );
 
       expect(result).toEqual({});
     });
@@ -330,9 +358,13 @@ describe('EncountersService', () => {
       };
       mockEncountersCollection.getEncounter.mockResolvedValue(mockEncounter);
 
-      const result = await service.getProgPartyThreshold('test-encounter');
+      const result = await service.getProgPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(mockEncountersCollection.getEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
       );
       expect(result).toBe('prog-point-1');
@@ -346,7 +378,10 @@ describe('EncountersService', () => {
       };
       mockEncountersCollection.getEncounter.mockResolvedValue(mockEncounter);
 
-      const result = await service.getProgPartyThreshold('test-encounter');
+      const result = await service.getProgPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(result).toBeUndefined();
     });
@@ -354,7 +389,10 @@ describe('EncountersService', () => {
     it('should return undefined when encounter does not exist for prog party threshold', async () => {
       mockEncountersCollection.getEncounter.mockResolvedValue(undefined);
 
-      const result = await service.getProgPartyThreshold('test-encounter');
+      const result = await service.getProgPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(result).toBeUndefined();
     });
@@ -368,9 +406,13 @@ describe('EncountersService', () => {
       };
       mockEncountersCollection.getEncounter.mockResolvedValue(mockEncounter);
 
-      const result = await service.getClearPartyThreshold('test-encounter');
+      const result = await service.getClearPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(mockEncountersCollection.getEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
       );
       expect(result).toBe('clear-point-1');
@@ -384,7 +426,10 @@ describe('EncountersService', () => {
       };
       mockEncountersCollection.getEncounter.mockResolvedValue(mockEncounter);
 
-      const result = await service.getClearPartyThreshold('test-encounter');
+      const result = await service.getClearPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(result).toBeUndefined();
     });
@@ -392,7 +437,10 @@ describe('EncountersService', () => {
     it('should return undefined when encounter does not exist for clear party threshold', async () => {
       mockEncountersCollection.getEncounter.mockResolvedValue(undefined);
 
-      const result = await service.getClearPartyThreshold('test-encounter');
+      const result = await service.getClearPartyThreshold(
+        guildId,
+        'test-encounter',
+      );
 
       expect(result).toBeUndefined();
     });
@@ -402,9 +450,10 @@ describe('EncountersService', () => {
     it('should reorder prog points with correct order indices', async () => {
       const progPointIds = ['point3', 'point1', 'point2'];
 
-      await service.reorderProgPoints('test-encounter', progPointIds);
+      await service.reorderProgPoints(guildId, 'test-encounter', progPointIds);
 
       expect(mockEncountersCollection.reorderProgPoints).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         [
           { id: 'point3', order: 0 },
@@ -417,9 +466,10 @@ describe('EncountersService', () => {
     it('should handle empty prog point array', async () => {
       const progPointIds: string[] = [];
 
-      await service.reorderProgPoints('test-encounter', progPointIds);
+      await service.reorderProgPoints(guildId, 'test-encounter', progPointIds);
 
       expect(mockEncountersCollection.reorderProgPoints).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         [],
       );
@@ -428,9 +478,10 @@ describe('EncountersService', () => {
     it('should handle single prog point', async () => {
       const progPointIds = ['single-point'];
 
-      await service.reorderProgPoints('test-encounter', progPointIds);
+      await service.reorderProgPoints(guildId, 'test-encounter', progPointIds);
 
       expect(mockEncountersCollection.reorderProgPoints).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         [{ id: 'single-point', order: 0 }],
       );
@@ -463,10 +514,15 @@ describe('EncountersService', () => {
         clearPartyThreshold: 'clear1',
       };
 
-      await service.initializeEncounter('test-encounter', encounterData);
+      await service.initializeEncounter(
+        guildId,
+        'test-encounter',
+        encounterData,
+      );
 
       // Verify encounter document creation
       expect(mockEncountersCollection.upsertEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           name: 'Ultimate Test Encounter',
@@ -481,6 +537,7 @@ describe('EncountersService', () => {
       expect(mockEncountersCollection.addProgPoint).toHaveBeenCalledTimes(3);
       expect(mockEncountersCollection.addProgPoint).toHaveBeenNthCalledWith(
         1,
+        guildId,
         'test-encounter',
         {
           id: 'early1',
@@ -492,6 +549,7 @@ describe('EncountersService', () => {
       );
       expect(mockEncountersCollection.addProgPoint).toHaveBeenNthCalledWith(
         2,
+        guildId,
         'test-encounter',
         {
           id: 'prog1',
@@ -503,6 +561,7 @@ describe('EncountersService', () => {
       );
       expect(mockEncountersCollection.addProgPoint).toHaveBeenNthCalledWith(
         3,
+        guildId,
         'test-encounter',
         {
           id: 'clear1',
@@ -527,9 +586,14 @@ describe('EncountersService', () => {
         ],
       };
 
-      await service.initializeEncounter('test-encounter', encounterData);
+      await service.initializeEncounter(
+        guildId,
+        'test-encounter',
+        encounterData,
+      );
 
       expect(mockEncountersCollection.upsertEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           name: 'Simple Encounter',
@@ -541,6 +605,7 @@ describe('EncountersService', () => {
       );
 
       expect(mockEncountersCollection.addProgPoint).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           id: 'point1',
@@ -559,9 +624,14 @@ describe('EncountersService', () => {
         progPoints: [],
       };
 
-      await service.initializeEncounter('test-encounter', encounterData);
+      await service.initializeEncounter(
+        guildId,
+        'test-encounter',
+        encounterData,
+      );
 
       expect(mockEncountersCollection.upsertEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           name: 'Empty Encounter',
@@ -585,9 +655,10 @@ describe('EncountersService', () => {
       };
       mockEncountersCollection.getEncounter.mockResolvedValue(mockEncounter);
 
-      const result = await service.getEncounter('test-id');
+      const result = await service.getEncounter(guildId, 'test-id');
 
       expect(mockEncountersCollection.getEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-id',
       );
       expect(result).toBe(mockEncounter);
@@ -605,9 +676,10 @@ describe('EncountersService', () => {
       ];
       mockEncountersCollection.getProgPoints.mockResolvedValue(mockProgPoints);
 
-      const result = await service.getProgPoints('test-id');
+      const result = await service.getProgPoints(guildId, 'test-id');
 
       expect(mockEncountersCollection.getProgPoints).toHaveBeenCalledWith(
+        guildId,
         'test-id',
       );
       expect(result).toBe(mockProgPoints);
@@ -623,12 +695,13 @@ describe('EncountersService', () => {
       // Mock the getNextProgPointOrder method
       mockEncountersCollection.getNextProgPointOrder.mockResolvedValue(5);
 
-      await service.addProgPoint('test-encounter', progPointData);
+      await service.addProgPoint(guildId, 'test-encounter', progPointData);
 
       expect(
         mockEncountersCollection.getNextProgPointOrder,
-      ).toHaveBeenCalledWith('test-encounter');
+      ).toHaveBeenCalledWith(guildId, 'test-encounter');
       expect(mockEncountersCollection.addProgPoint).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           id: 'test1',
@@ -644,12 +717,14 @@ describe('EncountersService', () => {
       const updates = { label: 'Updated Label' };
 
       await service.updateProgPoint(
+        guildId,
         'test-encounter',
         'test-prog-point',
         updates,
       );
 
       expect(mockEncountersCollection.updateProgPoint).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         'test-prog-point',
         updates,
@@ -657,18 +732,28 @@ describe('EncountersService', () => {
     });
 
     it('should delegate deactivateProgPoint to collection', async () => {
-      await service.deactivateProgPoint('test-encounter', 'test-prog-point');
+      await service.deactivateProgPoint(
+        guildId,
+        'test-encounter',
+        'test-prog-point',
+      );
 
       expect(mockEncountersCollection.deactivateProgPoint).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         'test-prog-point',
       );
     });
 
     it('should delegate setProgPartyThreshold to collection', async () => {
-      await service.setProgPartyThreshold('test-encounter', 'test-prog-point');
+      await service.setProgPartyThreshold(
+        guildId,
+        'test-encounter',
+        'test-prog-point',
+      );
 
       expect(mockEncountersCollection.upsertEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           progPartyThreshold: 'test-prog-point',
@@ -677,9 +762,14 @@ describe('EncountersService', () => {
     });
 
     it('should delegate setClearPartyThreshold to collection', async () => {
-      await service.setClearPartyThreshold('test-encounter', 'test-prog-point');
+      await service.setClearPartyThreshold(
+        guildId,
+        'test-encounter',
+        'test-prog-point',
+      );
 
       expect(mockEncountersCollection.upsertEncounter).toHaveBeenCalledWith(
+        guildId,
         'test-encounter',
         {
           clearPartyThreshold: 'test-prog-point',

--- a/src/encounters/encounters.service.ts
+++ b/src/encounters/encounters.service.ts
@@ -14,18 +14,25 @@ export class EncountersService {
 
   constructor(private readonly encountersCollection: EncountersCollection) {}
 
-  public getProgPoints(encounterId: string): Promise<ProgPointDocument[]> {
-    return this.encountersCollection.getProgPoints(encounterId);
+  public getProgPoints(
+    guildId: string,
+    encounterId: string,
+  ): Promise<ProgPointDocument[]> {
+    return this.encountersCollection.getProgPoints(guildId, encounterId);
   }
 
-  public getAllProgPoints(encounterId: string): Promise<ProgPointDocument[]> {
-    return this.encountersCollection.getAllProgPoints(encounterId);
+  public getAllProgPoints(
+    guildId: string,
+    encounterId: string,
+  ): Promise<ProgPointDocument[]> {
+    return this.encountersCollection.getAllProgPoints(guildId, encounterId);
   }
 
   public async getProgPointsAsOptions(
+    guildId: string,
     encounterId: string,
   ): Promise<Record<string, ProgPointOption>> {
-    const progPoints = await this.getProgPoints(encounterId);
+    const progPoints = await this.getProgPoints(guildId, encounterId);
 
     return progPoints.reduce(
       (acc, progPoint) => {
@@ -40,12 +47,14 @@ export class EncountersService {
   }
 
   public getEncounter(
+    guildId: string,
     encounterId: string,
   ): Promise<EncounterDocument | undefined> {
-    return this.encountersCollection.getEncounter(encounterId);
+    return this.encountersCollection.getEncounter(guildId, encounterId);
   }
 
   public async addProgPoint(
+    guildId: string,
     encounterId: string,
     progPointData: {
       id: string;
@@ -53,8 +62,10 @@ export class EncountersService {
       partyStatus: PartyStatus;
     },
   ): Promise<void> {
-    const nextOrder =
-      await this.encountersCollection.getNextProgPointOrder(encounterId);
+    const nextOrder = await this.encountersCollection.getNextProgPointOrder(
+      guildId,
+      encounterId,
+    );
 
     const progPoint: ProgPointDocument = {
       ...progPointData,
@@ -62,18 +73,24 @@ export class EncountersService {
       active: true,
     };
 
-    await this.encountersCollection.addProgPoint(encounterId, progPoint);
+    await this.encountersCollection.addProgPoint(
+      guildId,
+      encounterId,
+      progPoint,
+    );
     this.logger.log(
       `Added prog point ${progPointData.id} to encounter ${encounterId}`,
     );
   }
 
   public async updateProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
     updates: Partial<Pick<ProgPointDocument, 'label' | 'partyStatus'>>,
   ): Promise<void> {
     await this.encountersCollection.updateProgPoint(
+      guildId,
       encounterId,
       progPointId,
       updates,
@@ -84,10 +101,12 @@ export class EncountersService {
   }
 
   public async deactivateProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
     await this.encountersCollection.deactivateProgPoint(
+      guildId,
       encounterId,
       progPointId,
     );
@@ -97,12 +116,16 @@ export class EncountersService {
   }
 
   public async deleteProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
     // Enhanced validation for deletion - check threshold dependencies
-    const encounter = await this.encountersCollection.getEncounter(encounterId);
-    const allProgPoints = await this.getAllProgPoints(encounterId);
+    const encounter = await this.encountersCollection.getEncounter(
+      guildId,
+      encounterId,
+    );
+    const allProgPoints = await this.getAllProgPoints(guildId, encounterId);
     const progPoint = allProgPoints.find((p) => p.id === progPointId);
 
     if (!progPoint) {
@@ -121,19 +144,27 @@ export class EncountersService {
       }
     }
 
-    await this.encountersCollection.deleteProgPoint(encounterId, progPointId);
+    await this.encountersCollection.deleteProgPoint(
+      guildId,
+      encounterId,
+      progPointId,
+    );
     this.logger.log(
       `Permanently deleted prog point ${progPointId} from encounter ${encounterId}`,
     );
   }
 
   public async toggleProgPointActive(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
     // Check if prog point is used as a threshold before deactivating
-    const encounter = await this.encountersCollection.getEncounter(encounterId);
-    const allProgPoints = await this.getAllProgPoints(encounterId);
+    const encounter = await this.encountersCollection.getEncounter(
+      guildId,
+      encounterId,
+    );
+    const allProgPoints = await this.getAllProgPoints(guildId, encounterId);
     const progPoint = allProgPoints.find((p) => p.id === progPointId);
 
     if (!progPoint) {
@@ -164,6 +195,7 @@ export class EncountersService {
     }
 
     await this.encountersCollection.toggleProgPointActive(
+      guildId,
       encounterId,
       progPointId,
     );
@@ -175,6 +207,7 @@ export class EncountersService {
   }
 
   public async reorderProgPoints(
+    guildId: string,
     encounterId: string,
     progPointIds: string[],
   ): Promise<void> {
@@ -184,6 +217,7 @@ export class EncountersService {
     }));
 
     await this.encountersCollection.reorderProgPoints(
+      guildId,
       encounterId,
       progPointsWithNewOrder,
     );
@@ -191,10 +225,11 @@ export class EncountersService {
   }
 
   public async setProgPartyThreshold(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
-    await this.encountersCollection.upsertEncounter(encounterId, {
+    await this.encountersCollection.upsertEncounter(guildId, encounterId, {
       progPartyThreshold: progPointId,
     });
     this.logger.log(
@@ -203,10 +238,11 @@ export class EncountersService {
   }
 
   public async setClearPartyThreshold(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
-    await this.encountersCollection.upsertEncounter(encounterId, {
+    await this.encountersCollection.upsertEncounter(guildId, encounterId, {
       clearPartyThreshold: progPointId,
     });
     this.logger.log(
@@ -215,24 +251,27 @@ export class EncountersService {
   }
 
   public async getProgPartyThreshold(
+    guildId: string,
     encounterId: string,
   ): Promise<string | undefined> {
-    const encounter = await this.getEncounter(encounterId);
+    const encounter = await this.getEncounter(guildId, encounterId);
     return encounter?.progPartyThreshold;
   }
 
   public async getClearPartyThreshold(
+    guildId: string,
     encounterId: string,
   ): Promise<string | undefined> {
-    const encounter = await this.getEncounter(encounterId);
+    const encounter = await this.getEncounter(guildId, encounterId);
     return encounter?.clearPartyThreshold;
   }
 
   public async getPartyStatusForProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<PartyStatus> {
-    const progPoints = await this.getProgPoints(encounterId);
+    const progPoints = await this.getProgPoints(guildId, encounterId);
 
     const progPoint = progPoints.find((p) => p.id === progPointId);
     if (!progPoint) {
@@ -253,6 +292,7 @@ export class EncountersService {
   }
 
   public async initializeEncounter(
+    guildId: string,
     encounterId: string,
     encounterData: {
       name: string;
@@ -267,7 +307,7 @@ export class EncountersService {
     },
   ): Promise<void> {
     // Create or update the encounter document
-    await this.encountersCollection.upsertEncounter(encounterId, {
+    await this.encountersCollection.upsertEncounter(guildId, encounterId, {
       name: encounterData.name,
       description: encounterData.description,
       active: true,
@@ -284,7 +324,11 @@ export class EncountersService {
         active: true,
       };
 
-      await this.encountersCollection.addProgPoint(encounterId, progPoint);
+      await this.encountersCollection.addProgPoint(
+        guildId,
+        encounterId,
+        progPoint,
+      );
     }
 
     this.logger.log(

--- a/src/firebase/collections/blacklist-collection.ts
+++ b/src/firebase/collections/blacklist-collection.ts
@@ -8,6 +8,7 @@ import {
   type QueryDocumentSnapshot,
 } from 'firebase-admin/firestore';
 import { InjectFirestore } from '../firebase.decorators.js';
+import { guildCollection } from '../firebase.paths.js';
 import type { BlacklistDocument } from '../models/blacklist.model.js';
 
 type BlacklistDocumentKeys = Pick<
@@ -108,9 +109,11 @@ class BlacklistCollection {
   private getCollection(
     guildId: string,
   ): CollectionReference<BlacklistDocument> {
-    return this.firestore.collection(
-      `blacklist/${guildId}/documents`,
-    ) as CollectionReference<BlacklistDocument>;
+    return guildCollection<BlacklistDocument>(
+      this.firestore,
+      guildId,
+      'blacklist',
+    );
   }
 }
 

--- a/src/firebase/collections/encounters-collection.spec.ts
+++ b/src/firebase/collections/encounters-collection.spec.ts
@@ -1,0 +1,86 @@
+import { Test } from '@nestjs/testing';
+import type { Firestore } from 'firebase-admin/firestore';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAutoMock } from '../../test-utils/mock-factory.js';
+import { FIRESTORE } from '../firebase.consts.js';
+import type { ProgPointDocument } from '../models/encounter.model.js';
+import { PartyStatus } from '../models/signup.model.js';
+import { EncountersCollection } from './encounters-collection.js';
+
+const progPoint = (id: string, order: number): ProgPointDocument => ({
+  id,
+  label: id,
+  partyStatus: PartyStatus.ProgParty,
+  order,
+  active: true,
+});
+
+describe('EncountersCollection', () => {
+  let collection: EncountersCollection;
+  let firestoreCollection: ReturnType<typeof vi.fn>;
+  let guildsDoc: ReturnType<typeof vi.fn>;
+  let guildSubcollection: ReturnType<typeof vi.fn>;
+  /** prog points keyed by the guild that owns them */
+  let progPointsByGuild: Map<string, ProgPointDocument[]>;
+
+  beforeEach(async () => {
+    progPointsByGuild = new Map();
+
+    // Models guilds/{guildId}/encounters/{encounterId}/prog-points, remembering
+    // which guild the current chain started from so each one gets its own data.
+    const progPointsRef = (guildId: string) => ({
+      orderBy: () => ({
+        get: () =>
+          Promise.resolve({
+            docs: (progPointsByGuild.get(guildId) ?? []).map((data) => ({
+              data: () => data,
+            })),
+          }),
+      }),
+    });
+
+    guildSubcollection = vi.fn();
+    guildsDoc = vi.fn((guildId: string) => {
+      guildSubcollection.mockReturnValue({
+        doc: () => ({ collection: () => progPointsRef(guildId) }),
+      });
+      return { collection: guildSubcollection };
+    });
+    firestoreCollection = vi.fn().mockReturnValue({ doc: guildsDoc });
+
+    const firestore = {
+      collection: firestoreCollection,
+    } as unknown as Firestore;
+
+    const fixture = await Test.createTestingModule({
+      providers: [
+        EncountersCollection,
+        { provide: FIRESTORE, useValue: firestore },
+      ],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    collection = fixture.get(EncountersCollection);
+  });
+
+  it('scopes the collection to guilds/{guildId}/encounters', async () => {
+    await collection.getAllProgPoints('guild-1', 'FRU');
+
+    expect(firestoreCollection).toHaveBeenCalledWith('guilds');
+    expect(guildsDoc).toHaveBeenCalledWith('guild-1');
+    expect(guildSubcollection).toHaveBeenCalledWith('encounters');
+  });
+
+  it('does not serve one guild the cached prog points of another', async () => {
+    progPointsByGuild.set('guild-1', [progPoint('P1', 0)]);
+    progPointsByGuild.set('guild-2', [progPoint('P1', 0), progPoint('P2', 1)]);
+
+    // guild-1 populates the cache first; guild-2 must not read through to it
+    const first = await collection.getAllProgPoints('guild-1', 'FRU');
+    const second = await collection.getAllProgPoints('guild-2', 'FRU');
+
+    expect(first.map((p) => p.id)).toEqual(['P1']);
+    expect(second.map((p) => p.id)).toEqual(['P1', 'P2']);
+  });
+});

--- a/src/firebase/collections/encounters-collection.ts
+++ b/src/firebase/collections/encounters-collection.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SentryTraced } from '@sentry/nestjs';
 import { CollectionReference, Firestore } from 'firebase-admin/firestore';
 import { InjectFirestore } from '../firebase.decorators.js';
+import { guildCollection } from '../firebase.paths.js';
 import type {
   EncounterDocument,
   ProgPointDocument,
@@ -9,35 +10,35 @@ import type {
 
 @Injectable()
 class EncountersCollection {
-  private readonly collection: CollectionReference<EncounterDocument>;
   private readonly logger = new Logger(EncountersCollection.name);
   private readonly cache = new Map<string, unknown>();
 
-  constructor(@InjectFirestore() private readonly firestore: Firestore) {
-    this.collection = firestore.collection(
-      'encounters',
-    ) as CollectionReference<EncounterDocument>;
-  }
+  constructor(@InjectFirestore() private readonly firestore: Firestore) {}
 
   @SentryTraced()
-  async getActiveEncounters(): Promise<(EncounterDocument & { id: string })[]> {
+  async getActiveEncounters(
+    guildId: string,
+  ): Promise<(EncounterDocument & { id: string })[]> {
     // TODO: strengthen this type to be use the typesafe Encounters somehow?
-    const snapshot = await this.collection.where('active', '==', true).get();
+    const snapshot = await this.getCollection(guildId)
+      .where('active', '==', true)
+      .get();
     return snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
   }
 
   @SentryTraced()
   async getEncounter(
+    guildId: string,
     encounterId: string,
   ): Promise<EncounterDocument | undefined> {
-    const cacheKey = this.encounterCacheKey(encounterId);
+    const cacheKey = this.encounterCacheKey(guildId, encounterId);
     const cached = this.cache.get(cacheKey) as EncounterDocument | undefined;
 
     if (cached) {
       return { ...cached, id: encounterId };
     }
 
-    const doc = await this.collection.doc(encounterId).get();
+    const doc = await this.getCollection(guildId).doc(encounterId).get();
     const data = doc.data();
 
     if (data) {
@@ -51,37 +52,40 @@ class EncountersCollection {
 
   @SentryTraced()
   public async upsertEncounter(
+    guildId: string,
     encounterId: string,
     encounter: Partial<EncounterDocument>,
   ): Promise<void> {
-    await this.collection.doc(encounterId).set(encounter, { merge: true });
-    await this.updateEncounterCache(encounterId);
+    await this.getCollection(guildId)
+      .doc(encounterId)
+      .set(encounter, { merge: true });
+    await this.updateEncounterCache(guildId, encounterId);
   }
 
   @SentryTraced()
   public async getProgPoints(
+    guildId: string,
     encounterId: string,
   ): Promise<ProgPointDocument[]> {
-    const allProgPoints = await this.getAllProgPoints(encounterId);
+    const allProgPoints = await this.getAllProgPoints(guildId, encounterId);
     return allProgPoints.filter((p) => p.active);
   }
 
   @SentryTraced()
   public async getAllProgPoints(
+    guildId: string,
     encounterId: string,
   ): Promise<ProgPointDocument[]> {
-    const cacheKey = this.progPointsCacheKey(encounterId);
+    const cacheKey = this.progPointsCacheKey(guildId, encounterId);
     const cached = this.cache.get(cacheKey) as ProgPointDocument[] | undefined;
 
     if (cached) {
       return cached;
     }
 
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
-    const snapshot = await progPointsCollection.orderBy('order').get();
+    const snapshot = await this.getProgPointsCollection(guildId, encounterId)
+      .orderBy('order')
+      .get();
 
     const progPoints = snapshot.docs.map((doc) => doc.data());
 
@@ -92,47 +96,50 @@ class EncountersCollection {
 
   @SentryTraced()
   public async addProgPoint(
+    guildId: string,
     encounterId: string,
     progPoint: ProgPointDocument,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
-    await progPointsCollection.doc(progPoint.id).set(progPoint);
-    await this.updateProgPointsCache(encounterId);
+    await this.getProgPointsCollection(guildId, encounterId)
+      .doc(progPoint.id)
+      .set(progPoint);
+    await this.updateProgPointsCache(guildId, encounterId);
   }
 
   @SentryTraced()
   public async updateProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
     updates: Partial<ProgPointDocument>,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
-    await progPointsCollection.doc(progPointId).set(updates, { merge: true });
-    await this.updateProgPointsCache(encounterId);
+    await this.getProgPointsCollection(guildId, encounterId)
+      .doc(progPointId)
+      .set(updates, { merge: true });
+    await this.updateProgPointsCache(guildId, encounterId);
   }
 
   @SentryTraced()
   public async deactivateProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
-    await this.updateProgPoint(encounterId, progPointId, { active: false });
+    await this.updateProgPoint(guildId, encounterId, progPointId, {
+      active: false,
+    });
   }
 
   @SentryTraced()
   public async deleteProgPoint(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
+    const progPointsCollection = this.getProgPointsCollection(
+      guildId,
+      encounterId,
+    );
 
     // Get the prog point to delete to find its order
     const progPointDoc = await progPointsCollection.doc(progPointId).get();
@@ -146,19 +153,25 @@ class EncountersCollection {
     await progPointsCollection.doc(progPointId).delete();
 
     // Reorder remaining prog points to fill the gap
-    await this.reorderAfterDeletion(encounterId, progPointToDelete.order);
+    await this.reorderAfterDeletion(
+      guildId,
+      encounterId,
+      progPointToDelete.order,
+    );
 
-    await this.updateProgPointsCache(encounterId);
+    await this.updateProgPointsCache(guildId, encounterId);
   }
 
   @SentryTraced()
   public async toggleProgPointActive(
+    guildId: string,
     encounterId: string,
     progPointId: string,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
+    const progPointsCollection = this.getProgPointsCollection(
+      guildId,
+      encounterId,
+    );
 
     const doc = await progPointsCollection.doc(progPointId).get();
     const progPoint = doc.data();
@@ -171,17 +184,19 @@ class EncountersCollection {
       .doc(progPointId)
       .update({ active: !progPoint.active });
 
-    await this.updateProgPointsCache(encounterId);
+    await this.updateProgPointsCache(guildId, encounterId);
   }
 
   @SentryTraced()
   public async reorderProgPoints(
+    guildId: string,
     encounterId: string,
     progPointsWithNewOrder: Array<{ id: string; order: number }>,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
+    const progPointsCollection = this.getProgPointsCollection(
+      guildId,
+      encounterId,
+    );
 
     const batch = this.firestore.batch();
 
@@ -191,16 +206,15 @@ class EncountersCollection {
     }
 
     await batch.commit();
-    await this.updateProgPointsCache(encounterId);
+    await this.updateProgPointsCache(guildId, encounterId);
   }
 
   @SentryTraced()
-  public async getNextProgPointOrder(encounterId: string): Promise<number> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
-    const snapshot = await progPointsCollection
+  public async getNextProgPointOrder(
+    guildId: string,
+    encounterId: string,
+  ): Promise<number> {
+    const snapshot = await this.getProgPointsCollection(guildId, encounterId)
       .orderBy('order', 'desc')
       .limit(1)
       .get();
@@ -215,15 +229,12 @@ class EncountersCollection {
 
   @SentryTraced()
   private async reorderAfterDeletion(
+    guildId: string,
     encounterId: string,
     deletedOrder: number,
   ): Promise<void> {
-    const progPointsCollection = this.collection
-      .doc(encounterId)
-      .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
     // Get all prog points with order greater than the deleted one
-    const snapshot = await progPointsCollection
+    const snapshot = await this.getProgPointsCollection(guildId, encounterId)
       .where('order', '>', deletedOrder)
       .get();
 
@@ -242,10 +253,13 @@ class EncountersCollection {
     await batch.commit();
   }
 
-  private async updateEncounterCache(encounterId: string): Promise<void> {
-    const cacheKey = this.encounterCacheKey(encounterId);
+  private async updateEncounterCache(
+    guildId: string,
+    encounterId: string,
+  ): Promise<void> {
+    const cacheKey = this.encounterCacheKey(guildId, encounterId);
     try {
-      const doc = await this.collection.doc(encounterId).get();
+      const doc = await this.getCollection(guildId).doc(encounterId).get();
       const data = doc.data();
       if (data) {
         this.cache.set(cacheKey, { ...data, id: doc.id });
@@ -259,17 +273,18 @@ class EncountersCollection {
     }
   }
 
-  private async updateProgPointsCache(encounterId: string): Promise<void> {
-    const cacheKey = this.progPointsCacheKey(encounterId);
+  private async updateProgPointsCache(
+    guildId: string,
+    encounterId: string,
+  ): Promise<void> {
+    const cacheKey = this.progPointsCacheKey(guildId, encounterId);
     try {
       // Clear cache first to avoid infinite recursion
       this.cache.delete(cacheKey);
 
-      const progPointsCollection = this.collection
-        .doc(encounterId)
-        .collection('prog-points') as CollectionReference<ProgPointDocument>;
-
-      const snapshot = await progPointsCollection.orderBy('order').get();
+      const snapshot = await this.getProgPointsCollection(guildId, encounterId)
+        .orderBy('order')
+        .get();
 
       const progPoints = snapshot.docs.map((doc) => doc.data());
       this.cache.set(cacheKey, progPoints);
@@ -282,10 +297,31 @@ class EncountersCollection {
     }
   }
 
-  private encounterCacheKey = (encounterId: string) =>
-    `encounter:${encounterId}`;
-  private progPointsCacheKey = (encounterId: string) =>
-    `progpoints:${encounterId}`;
+  private getCollection(
+    guildId: string,
+  ): CollectionReference<EncounterDocument> {
+    return guildCollection<EncounterDocument>(
+      this.firestore,
+      guildId,
+      'encounters',
+    );
+  }
+
+  private getProgPointsCollection(
+    guildId: string,
+    encounterId: string,
+  ): CollectionReference<ProgPointDocument> {
+    return this.getCollection(guildId)
+      .doc(encounterId)
+      .collection('prog-points') as CollectionReference<ProgPointDocument>;
+  }
+
+  // Cache keys are guild-scoped so two guilds that share an encounter id don't
+  // serve each other's prog points.
+  private encounterCacheKey = (guildId: string, encounterId: string) =>
+    `encounter:${guildId}:${encounterId}`;
+  private progPointsCacheKey = (guildId: string, encounterId: string) =>
+    `progpoints:${guildId}:${encounterId}`;
 }
 
 export { EncountersCollection };

--- a/src/firebase/collections/job/job.collection.ts
+++ b/src/firebase/collections/job/job.collection.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import type { CollectionReference, Firestore } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
 import type { JobType } from '../../../jobs/jobs.consts.js';
 import { InjectFirestore } from '../../firebase.decorators.js';
+import { guildCollection } from '../../firebase.paths.js';
 import type { JobDocument } from './job.model.js';
 
 @Injectable()
@@ -26,9 +27,7 @@ class JobCollection {
   }
 
   private getCollection(guildId: string) {
-    return this.firestore.collection(
-      `guilds/${guildId}/jobs`,
-    ) as CollectionReference<JobDocument>;
+    return guildCollection<JobDocument>(this.firestore, guildId, 'jobs');
   }
 }
 

--- a/src/firebase/collections/settings-collection.spec.ts
+++ b/src/firebase/collections/settings-collection.spec.ts
@@ -61,18 +61,19 @@ describe.each([{ cache: true }, { cache: false }])(
 
       await service.upsert(guildId, settings);
 
-      expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
+      // settings live on the guild document itself, not a subcollection
+      expect(firestoreMock.collection).toHaveBeenCalledWith('guilds');
       expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
       expect(docMock.set).toHaveBeenCalledWith(settings, { merge: true });
     });
 
     it('should call getReviewChannel with correct arguments', async () => {
       await service.getReviewChannel(guildId);
-      expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
 
       if (cache) {
         expect(collectionMock.doc).not.toHaveBeenCalled();
       } else {
+        expect(firestoreMock.collection).toHaveBeenCalledWith('guilds');
         expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
         expect(docMock.get).toHaveBeenCalled();
       }
@@ -80,11 +81,11 @@ describe.each([{ cache: true }, { cache: false }])(
 
     it('should call getSettings with correct arguments', async () => {
       await service.getSettings(guildId);
-      expect(firestoreMock.collection).toHaveBeenCalledWith('settings');
 
       if (cache) {
         expect(collectionMock.doc).not.toHaveBeenCalled();
       } else {
+        expect(firestoreMock.collection).toHaveBeenCalledWith('guilds');
         expect(collectionMock.doc).toHaveBeenCalledWith(guildId);
         expect(docMock.get).toHaveBeenCalled();
       }

--- a/src/firebase/collections/settings-collection.ts
+++ b/src/firebase/collections/settings-collection.ts
@@ -1,25 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { SentryTraced } from '@sentry/nestjs';
 import {
-  CollectionReference,
+  type DocumentReference,
   FieldPath,
   Firestore,
 } from 'firebase-admin/firestore';
 import type { Encounter } from '../../encounters/encounters.consts.js';
 import { InjectFirestore } from '../firebase.decorators.js';
+import { guildDoc } from '../firebase.paths.js';
 import type { SettingsDocument } from '../models/settings.model.js';
 
 @Injectable()
 class SettingsCollection {
-  private readonly collection: CollectionReference<SettingsDocument>;
   private readonly logger = new Logger(SettingsCollection.name);
   private readonly cache = new Map<string, unknown>();
 
-  constructor(@InjectFirestore() firestore: Firestore) {
-    this.collection = firestore.collection(
-      'settings',
-    ) as CollectionReference<SettingsDocument>;
-  }
+  constructor(@InjectFirestore() private readonly firestore: Firestore) {}
 
   @SentryTraced()
   public async upsert(
@@ -36,7 +32,7 @@ class SettingsCollection {
         ? undefined
         : clearRoles;
 
-    await this.collection.doc(guildId).set(
+    await this.getDocument(guildId).set(
       {
         ...settings,
         progRoles: progRolesUpdate,
@@ -56,12 +52,10 @@ class SettingsCollection {
   ) {
     // mergeFields replaces exactly this encounter's map, so removed
     // prog point keys don't linger the way they would with { merge: true }
-    await this.collection
-      .doc(guildId)
-      .set(
-        { progPointRoles: { [encounter]: progPointRoles } },
-        { mergeFields: [new FieldPath('progPointRoles', encounter)] },
-      );
+    await this.getDocument(guildId).set(
+      { progPointRoles: { [encounter]: progPointRoles } },
+      { mergeFields: [new FieldPath('progPointRoles', encounter)] },
+    );
 
     await this.updateCache(guildId);
   }
@@ -75,7 +69,7 @@ class SettingsCollection {
       return Promise.resolve(cachedValue);
     }
 
-    const doc = await this.collection.doc(guildId).get();
+    const doc = await this.getDocument(guildId).get();
 
     this.cache.set(key, doc.data());
 
@@ -91,13 +85,24 @@ class SettingsCollection {
   private async updateCache(guildId: string) {
     const key = this.cacheKey(guildId);
     try {
-      const settings = await this.collection.doc(guildId).get();
+      const settings = await this.getDocument(guildId).get();
       this.cache.set(key, settings.data());
     } catch (e: unknown) {
       this.logger.warn(`failed to update cache: invalidating key ${key}`);
       this.logger.error(e);
       this.cache.delete(this.cacheKey(guildId));
     }
+  }
+
+  /**
+   * Settings are stored as fields on the guild document itself rather than in a
+   * subcollection, so reading them costs a single document get.
+   */
+  private getDocument(guildId: string): DocumentReference<SettingsDocument> {
+    return guildDoc(
+      this.firestore,
+      guildId,
+    ) as DocumentReference<SettingsDocument>;
   }
 
   private cacheKey = (guildId: string) => `settings:${guildId}`;

--- a/src/firebase/collections/signup.collection.spec.ts
+++ b/src/firebase/collections/signup.collection.spec.ts
@@ -25,6 +25,10 @@ describe('Signup Repository', () => {
   let repository: SignupCollection;
   let collection: Mocked<CollectionReference<DocumentData>>;
   let doc: Mocked<DocumentReference<DocumentData>>;
+  let firestoreCollection: ReturnType<typeof vi.fn>;
+  let guildsDoc: ReturnType<typeof vi.fn>;
+  let guildSubcollection: ReturnType<typeof vi.fn>;
+  const guildId = 'guildId';
   const signupRequest = SIGNUP_KEY as unknown as SignupSchema;
 
   beforeEach(async () => {
@@ -39,8 +43,13 @@ describe('Signup Repository', () => {
       doc: vi.fn().mockReturnValue(doc),
     } as unknown as Mocked<CollectionReference<DocumentData>>;
 
+    // guilds/{guildId}/signups
+    guildSubcollection = vi.fn().mockReturnValue(collection);
+    guildsDoc = vi.fn().mockReturnValue({ collection: guildSubcollection });
+    firestoreCollection = vi.fn().mockReturnValue({ doc: guildsDoc });
+
     const firestore = {
-      collection: vi.fn().mockReturnValue(collection),
+      collection: firestoreCollection,
     } as unknown as Firestore;
 
     const fixture = await Test.createTestingModule({
@@ -55,6 +64,14 @@ describe('Signup Repository', () => {
     repository = fixture.get(SignupCollection);
   });
 
+  it('scopes the collection to guilds/{guildId}/signups', async () => {
+    await repository.setReviewMessageId(guildId, SIGNUP_KEY, 'messageId');
+
+    expect(firestoreCollection).toHaveBeenCalledWith('guilds');
+    expect(guildsDoc).toHaveBeenCalledWith(guildId);
+    expect(guildSubcollection).toHaveBeenCalledWith('signups');
+  });
+
   it('should call update if document exists', async () => {
     const existingData = {
       ...signupRequest,
@@ -66,7 +83,7 @@ describe('Signup Repository', () => {
       data: () => existingData,
     } as unknown as DocumentSnapshot);
 
-    const result = await repository.upsert(signupRequest);
+    const result = await repository.upsert(guildId, signupRequest);
 
     expect(doc.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -97,7 +114,7 @@ describe('Signup Repository', () => {
       data: () => existingData,
     } as unknown as DocumentSnapshot);
 
-    const result = await repository.upsert(signupRequest);
+    const result = await repository.upsert(guildId, signupRequest);
 
     expect(doc.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -117,7 +134,7 @@ describe('Signup Repository', () => {
       data: () => null,
     } as unknown as DocumentSnapshot);
 
-    const result = await repository.upsert(signupRequest);
+    const result = await repository.upsert(guildId, signupRequest);
 
     expect(doc.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -135,6 +152,7 @@ describe('Signup Repository', () => {
 
   it('should call updateSignupStatus with the correct arguments', async () => {
     await repository.updateSignupStatus(
+      guildId,
       SignupStatus.APPROVED,
       SIGNUP_KEY,
       'reviewedBy',
@@ -147,7 +165,7 @@ describe('Signup Repository', () => {
   });
 
   it('should call setReviewMessageId with the correct arguments', async () => {
-    await repository.setReviewMessageId(SIGNUP_KEY, 'messageId');
+    await repository.setReviewMessageId(guildId, SIGNUP_KEY, 'messageId');
 
     expect(doc.update).toHaveBeenCalledWith({
       reviewMessageId: 'messageId',
@@ -177,7 +195,7 @@ describe('Signup Repository', () => {
 
       mockFetch(false, signup);
 
-      const result = await repository.findByReviewId(reviewMessageId);
+      const result = await repository.findByReviewId(guildId, reviewMessageId);
 
       expect(result).toEqual(signup);
     });
@@ -186,7 +204,7 @@ describe('Signup Repository', () => {
       mockFetch(true, {} as SignupDocument);
 
       return expect(
-        repository.findByReviewId('reviewMessageId'),
+        repository.findByReviewId(guildId, 'reviewMessageId'),
       ).rejects.toThrow(DocumentNotFoundException);
     });
   });

--- a/src/firebase/collections/signup.collection.ts
+++ b/src/firebase/collections/signup.collection.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase-admin/firestore';
 import { InjectFirestore } from '../firebase.decorators.js';
 import { DocumentNotFoundException } from '../firebase.exceptions.js';
+import { guildCollection } from '../firebase.paths.js';
 import {
   type CreateSignupDocumentProps,
   type SignupCompositeKeyProps as SignupCompositeKey,
@@ -18,13 +19,7 @@ import {
 
 @Injectable()
 class SignupCollection {
-  private readonly collection: CollectionReference<SignupDocument>;
-
-  constructor(@InjectFirestore() private readonly firestore: Firestore) {
-    this.collection = this.firestore.collection(
-      'signups',
-    ) as CollectionReference<SignupDocument>;
-  }
+  constructor(@InjectFirestore() private readonly firestore: Firestore) {}
 
   @SentryTraced()
   public static getKeyForSignup({ discordId, encounter }: SignupCompositeKey) {
@@ -37,10 +32,11 @@ class SignupCollection {
    */
   @SentryTraced()
   public async upsert(
+    guildId: string,
     props: CreateSignupDocumentProps,
   ): Promise<SignupDocument> {
     const key = SignupCollection.getKeyForSignup(props);
-    const document = this.collection.doc(key);
+    const document = this.getCollection(guildId).doc(key);
     const expiresAt = Timestamp.fromMillis(
       Temporal.Now.zonedDateTimeISO().add({ days: 28 }).epochMilliseconds,
     );
@@ -75,24 +71,29 @@ class SignupCollection {
   }
 
   @SentryTraced()
-  public async findById(id: string): Promise<SignupDocument | undefined> {
-    const snapshot = await this.collection.doc(id).get();
+  public async findById(
+    guildId: string,
+    id: string,
+  ): Promise<SignupDocument | undefined> {
+    const snapshot = await this.getCollection(guildId).doc(id).get();
     return snapshot.data();
   }
 
   @SentryTraced()
   public async findOne(
+    guildId: string,
     query: Partial<SignupDocument>,
   ): Promise<SignupDocument | undefined> {
-    const snapshot = await this.where(query).limit(1).get();
+    const snapshot = await this.where(guildId, query).limit(1).get();
     return snapshot.docs.at(0)?.data();
   }
 
   @SentryTraced()
   public async findOneOrFail(
+    guildId: string,
     query: Partial<SignupDocument>,
   ): Promise<SignupDocument> {
-    const signup = await this.findOne(query);
+    const signup = await this.findOne(guildId, query);
 
     if (!signup) {
       throw new DocumentNotFoundException(query);
@@ -103,25 +104,29 @@ class SignupCollection {
 
   @SentryTraced()
   public async findAll(
+    guildId: string,
     query: Partial<SignupDocument>,
   ): Promise<SignupDocument[]> {
-    const snapshot = await this.where(query).get();
+    const snapshot = await this.where(guildId, query).get();
     return snapshot.docs.map((doc) => doc.data() as SignupDocument);
   }
 
   @SentryTraced()
   public async findByStatusIn(
+    guildId: string,
     statuses: SignupStatus[],
   ): Promise<SignupDocument[]> {
-    const snapshot = await this.collection
+    const snapshot = await this.getCollection(guildId)
       .where('status', 'in', statuses)
       .get();
     return snapshot.docs.map((doc) => doc.data() as SignupDocument);
   }
 
   @SentryTraced()
-  public async findByReviewId(reviewMessageId: string) {
-    const snapshot = await this.where({ reviewMessageId }).limit(1).get();
+  public async findByReviewId(guildId: string, reviewMessageId: string) {
+    const snapshot = await this.where(guildId, { reviewMessageId })
+      .limit(1)
+      .get();
 
     if (snapshot.empty) {
       throw new DocumentNotFoundException({ reviewMessageId });
@@ -139,6 +144,7 @@ class SignupCollection {
    */
   @SentryTraced()
   public updateSignupStatus(
+    guildId: string,
     status: SignupStatus,
     {
       partyStatus,
@@ -147,12 +153,14 @@ class SignupCollection {
     }: SignupCompositeKey & Pick<SignupDocument, 'progPoint' | 'partyStatus'>,
     reviewedBy: string,
   ) {
-    return this.collection.doc(SignupCollection.getKeyForSignup(key)).update({
-      status,
-      progPoint,
-      reviewedBy,
-      partyStatus,
-    });
+    return this.getCollection(guildId)
+      .doc(SignupCollection.getKeyForSignup(key))
+      .update({
+        status,
+        progPoint,
+        reviewedBy,
+        partyStatus,
+      });
   }
 
   /**
@@ -162,33 +170,45 @@ class SignupCollection {
    * @returns
    */
   @SentryTraced()
-  public setReviewMessageId(signup: SignupCompositeKey, messageId: string) {
+  public setReviewMessageId(
+    guildId: string,
+    signup: SignupCompositeKey,
+    messageId: string,
+  ) {
     const key = SignupCollection.getKeyForSignup(signup);
 
-    return this.collection.doc(key).update({
+    return this.getCollection(guildId).doc(key).update({
       reviewMessageId: messageId,
     });
   }
 
   @SentryTraced()
   public updateDeclineReason(
+    guildId: string,
     signup: SignupCompositeKey,
     declineReason: string,
   ) {
     const key = SignupCollection.getKeyForSignup(signup);
 
-    return this.collection.doc(key).update({
+    return this.getCollection(guildId).doc(key).update({
       declineReason,
     });
   }
 
   @SentryTraced()
-  public async removeSignup<T>({
-    character,
-    world,
-    encounter,
-  }: Exact<T, Pick<SignupDocument, 'character' | 'encounter' | 'world'>>) {
-    const snapshot = await this.where({ character, encounter, world }).get();
+  public async removeSignup<T>(
+    guildId: string,
+    {
+      character,
+      world,
+      encounter,
+    }: Exact<T, Pick<SignupDocument, 'character' | 'encounter' | 'world'>>,
+  ) {
+    const snapshot = await this.where(guildId, {
+      character,
+      encounter,
+      world,
+    }).get();
     return Promise.all(snapshot.docs.map((doc) => doc.ref.delete()));
   }
 
@@ -197,8 +217,8 @@ class SignupCollection {
    * @param props
    * @returns
    */
-  private where(props: Partial<SignupDocument>) {
-    let query: Query = this.collection;
+  private where(guildId: string, props: Partial<SignupDocument>) {
+    let query: Query = this.getCollection(guildId);
 
     for (const [key, value] of Object.entries(props)) {
       if (!value) continue;
@@ -206,6 +226,10 @@ class SignupCollection {
     }
 
     return query as Query<SignupDocument, DocumentData>;
+  }
+
+  private getCollection(guildId: string): CollectionReference<SignupDocument> {
+    return guildCollection<SignupDocument>(this.firestore, guildId, 'signups');
   }
 }
 

--- a/src/firebase/firebase.paths.ts
+++ b/src/firebase/firebase.paths.ts
@@ -1,0 +1,28 @@
+import type {
+  CollectionReference,
+  DocumentReference,
+  Firestore,
+} from 'firebase-admin/firestore';
+
+const GUILDS_COLLECTION = 'guilds';
+
+/**
+ * The document that scopes everything the bot stores for a guild. Settings live
+ * directly on this document; every other collection hangs off it as a subcollection.
+ */
+export function guildDoc(
+  firestore: Firestore,
+  guildId: string,
+): DocumentReference {
+  return firestore.collection(GUILDS_COLLECTION).doc(guildId);
+}
+
+export function guildCollection<T>(
+  firestore: Firestore,
+  guildId: string,
+  name: string,
+): CollectionReference<T> {
+  return guildDoc(firestore, guildId).collection(
+    name,
+  ) as CollectionReference<T>;
+}

--- a/src/jobs/clear-checker/clear-checker.job.spec.ts
+++ b/src/jobs/clear-checker/clear-checker.job.spec.ts
@@ -160,6 +160,7 @@ describe('ClearCheckerJob', () => {
       );
       expect(signupsCollection.removeSignup).toHaveBeenCalledTimes(1);
       expect(signupsCollection.removeSignup).toHaveBeenCalledWith(
+        GUILD_ID,
         expect.objectContaining({ character: 'Active Char' }),
       );
     });
@@ -196,6 +197,7 @@ describe('ClearCheckerJob', () => {
       expect(errorService.captureError).toHaveBeenCalledTimes(1);
       expect(signupsCollection.removeSignup).toHaveBeenCalledTimes(1);
       expect(signupsCollection.removeSignup).toHaveBeenCalledWith(
+        GUILD_ID,
         expect.objectContaining({ character: 'Cleared Char' }),
       );
     });
@@ -224,7 +226,7 @@ describe('ClearCheckerJob', () => {
         REVIEW_CHANNEL,
         'review-message-1',
       );
-      expect(signupsCollection.removeSignup).toHaveBeenCalledWith({
+      expect(signupsCollection.removeSignup).toHaveBeenCalledWith(GUILD_ID, {
         character: 'Test Character',
         world: 'Jenova',
         encounter: Encounter.TOP,
@@ -280,6 +282,20 @@ describe('ClearCheckerJob', () => {
       await job.checkClears();
 
       expect(signupsCollection.findAll).toHaveBeenCalledTimes(2);
+    });
+
+    it('reads signups and encounters scoped to each guild', async () => {
+      discordService.getGuilds.mockReturnValue([GUILD_ID, OTHER_GUILD_ID]);
+      signupsCollection.findAll.mockResolvedValue([]);
+
+      await job.checkClears();
+
+      for (const guildId of [GUILD_ID, OTHER_GUILD_ID]) {
+        expect(signupsCollection.findAll).toHaveBeenCalledWith(guildId, {});
+        expect(encountersCollection.getActiveEncounters).toHaveBeenCalledWith(
+          guildId,
+        );
+      }
     });
   });
 

--- a/src/jobs/clear-checker/clear-checker.job.ts
+++ b/src/jobs/clear-checker/clear-checker.job.ts
@@ -156,8 +156,8 @@ class ClearCheckerJob implements OnApplicationBootstrap, OnApplicationShutdown {
 
   private processGuild(guildId: string) {
     return forkJoin({
-      signups: this.signupsCollection.findAll({}),
-      encounters: this.encountersCollection.getActiveEncounters(),
+      signups: this.signupsCollection.findAll(guildId, {}),
+      encounters: this.encountersCollection.getActiveEncounters(guildId),
     }).pipe(
       mergeMap(({ signups, encounters }) => {
         const encounterIds = new Set<Encounter>(
@@ -268,7 +268,7 @@ class ClearCheckerJob implements OnApplicationBootstrap, OnApplicationShutdown {
           reviewMessageId: signup.reviewMessageId,
           character: signup.character,
         }),
-        this.removeSignupFromDatabase(signup),
+        this.removeSignupFromDatabase(guildId, signup),
       ]);
 
       this.logger.log(
@@ -301,9 +301,9 @@ class ClearCheckerJob implements OnApplicationBootstrap, OnApplicationShutdown {
       });
   }
 
-  private removeSignupFromDatabase(signup: SignupDocument) {
+  private removeSignupFromDatabase(guildId: string, signup: SignupDocument) {
     return this.signupsCollection
-      .removeSignup({
+      .removeSignup(guildId, {
         character: signup.character,
         world: signup.world,
         encounter: signup.encounter,

--- a/src/jobs/sheet-cleaner/sheet-cleaner.job.ts
+++ b/src/jobs/sheet-cleaner/sheet-cleaner.job.ts
@@ -83,11 +83,14 @@ class SheetCleanerJob implements OnApplicationBootstrap, OnApplicationShutdown {
             // but nothing else uses that right now. Encounters in the signup slash command
             // are still hardcoded. They ideally should be managed dynamically as well, but require runtime
             // changes to update the slash command.
-            return from(this.encountersCollection.getActiveEncounters()).pipe(
+            return from(
+              this.encountersCollection.getActiveEncounters(guild),
+            ).pipe(
               mergeMap((encounters) => encounters),
               concatMap((encounter) =>
                 this.sheetsService
                   .cleanSheet({
+                    guildId: guild,
                     spreadsheetId,
                     encounter: encounter.id as Encounter,
                   })

--- a/src/sheets/sheets.service.ts
+++ b/src/sheets/sheets.service.ts
@@ -61,12 +61,14 @@ class SheetsService implements OnApplicationShutdown {
 
   /**
    * Upsert a signup into the spreadsheet. If the character is already signed up, it will update the row
+   * @param guildId
    * @param signup
    * @param spreadsheetId
    * @returns
    */
   @SentryTraced()
   public upsertSignup(
+    guildId: string,
     { partyStatus, ...signup }: SignupDocument,
     spreadsheetId: string,
   ) {
@@ -78,11 +80,11 @@ class SheetsService implements OnApplicationShutdown {
       case PartyStatus.ProgParty:
       case PartyStatus.EarlyProgParty:
         return this.signupQueue.add(() =>
-          this.upsertRow(signup, spreadsheetId, partyStatus),
+          this.upsertRow(guildId, signup, spreadsheetId, partyStatus),
         );
       case PartyStatus.Cleared:
         return this.signupQueue.add(() =>
-          this.removeSignup(signup, spreadsheetId),
+          this.removeSignup(guildId, signup, spreadsheetId),
         );
       default: {
         const msg = `unknown party type: ${partyStatus} for character: ${signup.character}`;
@@ -164,6 +166,7 @@ class SheetsService implements OnApplicationShutdown {
 
   @SentryTraced()
   public async removeSignup(
+    guildId: string,
     {
       encounter,
       character,
@@ -172,7 +175,8 @@ class SheetsService implements OnApplicationShutdown {
     spreadsheetId: string,
     partyTypes?: PartyTypes,
   ) {
-    const types = partyTypes || (await this.getDefaultPartyTypes(encounter));
+    const types =
+      partyTypes || (await this.getDefaultPartyTypes(guildId, encounter));
     const ranges = types.map((range) => SheetRanges[range]);
 
     const requests = await Promise.all(
@@ -443,6 +447,7 @@ class SheetsService implements OnApplicationShutdown {
 
   @SentryTraced()
   private async upsertRow(
+    guildId: string,
     signup: Omit<SignupDocument, 'partyStatus'>,
     spreadsheetId: string,
     partyStatus:
@@ -453,10 +458,12 @@ class SheetsService implements OnApplicationShutdown {
     const { encounter, character, world } = signup;
     const cellValues = this.getCellValues(signup);
 
-    const isProgEncounter = await this.isProgEncounter(encounter);
+    const isProgEncounter = await this.isProgEncounter(guildId, encounter);
     if (isProgEncounter && partyStatus === PartyStatus.ClearParty) {
       // if its a clear party we need to check if we are moving them from prog to clear
-      await this.removeSignup(signup, spreadsheetId, [PartyStatus.ProgParty]);
+      await this.removeSignup(guildId, signup, spreadsheetId, [
+        PartyStatus.ProgParty,
+      ]);
     }
 
     const ranges = SheetRanges[partyStatus];
@@ -518,9 +525,15 @@ class SheetsService implements OnApplicationShutdown {
     return [titleCase(character), titleCase(world), role, progPoint];
   }
 
-  private async isProgEncounter(encounter: Encounter): Promise<boolean> {
+  private async isProgEncounter(
+    guildId: string,
+    encounter: Encounter,
+  ): Promise<boolean> {
     try {
-      const progPoints = await this.encountersService.getProgPoints(encounter);
+      const progPoints = await this.encountersService.getProgPoints(
+        guildId,
+        encounter,
+      );
       // An encounter is considered a "prog encounter" if it has multiple prog points
       // indicating different stages of progression
       return progPoints.length > 1;
@@ -531,6 +544,7 @@ class SheetsService implements OnApplicationShutdown {
   }
 
   private async getDefaultPartyTypes(
+    guildId: string,
     encounter: Encounter,
   ): Promise<
     (
@@ -539,7 +553,7 @@ class SheetsService implements OnApplicationShutdown {
       | PartyStatus.EarlyProgParty
     )[]
   > {
-    const isProgEncounter = await this.isProgEncounter(encounter);
+    const isProgEncounter = await this.isProgEncounter(guildId, encounter);
     return isProgEncounter
       ? [PartyStatus.ProgParty, PartyStatus.ClearParty]
       : [PartyStatus.ClearParty];
@@ -547,9 +561,11 @@ class SheetsService implements OnApplicationShutdown {
 
   @SentryTraced()
   public async cleanSheet({
+    guildId,
     spreadsheetId,
     encounter,
   }: {
+    guildId: string;
     spreadsheetId: string;
     encounter: Encounter;
   }): Promise<void> {
@@ -585,8 +601,10 @@ class SheetsService implements OnApplicationShutdown {
         row.values.some((cell) => cell),
       );
 
-      const progPointsFromDB =
-        await this.encountersService.getProgPoints(encounter);
+      const progPointsFromDB = await this.encountersService.getProgPoints(
+        guildId,
+        encounter,
+      );
       const progPoints = progPointsFromDB
         .sort((a, b) => a.order - b.order)
         .map((p) => p.id);

--- a/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.spec.ts
+++ b/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.spec.ts
@@ -217,10 +217,10 @@ describe('CleanRolesCommandHandler', () => {
       expect(deferReply).toHaveBeenCalledWith({
         flags: MessageFlags.Ephemeral,
       });
-      expect(signupCollection.findByStatusIn).toHaveBeenCalledWith([
-        SignupStatus.APPROVED,
-        SignupStatus.UPDATE_PENDING,
-      ]);
+      expect(signupCollection.findByStatusIn).toHaveBeenCalledWith(
+        'guild-123',
+        [SignupStatus.APPROVED, SignupStatus.UPDATE_PENDING],
+      );
       expect(editReply).toHaveBeenCalledWith(
         expect.stringContaining('Clean Roles Summary'),
       );

--- a/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.ts
+++ b/src/slash-commands/clean-roles/handlers/clean-roles.command-handler.ts
@@ -153,7 +153,7 @@ class CleanRolesCommandHandler implements ISlashCommand {
     const guild = await this.discordService.client.guilds.fetch(guildId);
     await guild.members.fetch();
 
-    const activeSignups = await this.signupCollection.findByStatusIn([
+    const activeSignups = await this.signupCollection.findByStatusIn(guildId, [
       SignupStatus.APPROVED,
       SignupStatus.UPDATE_PENDING,
     ]);

--- a/src/slash-commands/encounters/handlers/view-encounter.command-handler.ts
+++ b/src/slash-commands/encounters/handlers/view-encounter.command-handler.ts
@@ -43,12 +43,12 @@ export class ViewEncounterCommandHandler implements ISlashCommand {
   }
 
   private async showSingleEncounter(
-    interaction: ChatInputCommandInteraction,
+    interaction: ChatInputCommandInteraction<'cached'>,
     encounterId: string,
   ): Promise<void> {
     const [encounter, progPoints] = await Promise.all([
-      this.encountersService.getEncounter(encounterId),
-      this.encountersService.getAllProgPoints(encounterId),
+      this.encountersService.getEncounter(interaction.guildId, encounterId),
+      this.encountersService.getAllProgPoints(interaction.guildId, encounterId),
     ]);
 
     if (!encounter) {
@@ -122,7 +122,7 @@ export class ViewEncounterCommandHandler implements ISlashCommand {
   }
 
   private async showAllEncounters(
-    interaction: ChatInputCommandInteraction,
+    interaction: ChatInputCommandInteraction<'cached'>,
   ): Promise<void> {
     const embed = new EmbedBuilder()
       .setTitle('All Encounters Overview')
@@ -133,8 +133,14 @@ export class ViewEncounterCommandHandler implements ISlashCommand {
       async ([key, encounterId]) => {
         try {
           const [encounter, progPoints] = await Promise.all([
-            this.encountersService.getEncounter(encounterId),
-            this.encountersService.getAllProgPoints(encounterId),
+            this.encountersService.getEncounter(
+              interaction.guildId,
+              encounterId,
+            ),
+            this.encountersService.getAllProgPoints(
+              interaction.guildId,
+              encounterId,
+            ),
           ]);
 
           return {

--- a/src/slash-commands/lookup/handlers/lookup.command-handler.ts
+++ b/src/slash-commands/lookup/handlers/lookup.command-handler.ts
@@ -65,7 +65,7 @@ class LookupCommandHandler implements ISlashCommand {
         world: dto.world,
       });
 
-      const results = await this.signupsCollection.findAll(dto);
+      const results = await this.signupsCollection.findAll(guildId, dto);
 
       const withBlacklistInfo = await Promise.all(
         results.map((r) => this.mapBlacklistInfo(guildId, r)),

--- a/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.ts
+++ b/src/slash-commands/remove-signup/handlers/remove-signup.command-handler.ts
@@ -166,6 +166,7 @@ class RemoveSignupCommandHandler implements ISlashCommand {
 
     if (spreadsheetId && validStatus) {
       const response = await this.sheetsService.removeSignup(
+        guildId,
         dto,
         spreadsheetId,
       );
@@ -197,7 +198,7 @@ class RemoveSignupCommandHandler implements ISlashCommand {
       }
     }
 
-    await this.signupsRepository.removeSignup(dto);
+    await this.signupsRepository.removeSignup(guildId, dto);
     return description;
   }
 
@@ -253,7 +254,7 @@ class RemoveSignupCommandHandler implements ISlashCommand {
       guildId,
     });
 
-    const signup = await this.signupsRepository.findOneOrFail({
+    const signup = await this.signupsRepository.findOneOrFail(guildId, {
       character,
       encounter,
       world,

--- a/src/slash-commands/search/handlers/search.command-handler.spec.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.spec.ts
@@ -314,11 +314,11 @@ describe('SearchCommandHandler', () => {
     await collectorCallback!(mockProgPointSelect);
 
     // Verify the search was performed for at least the selected prog point
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'P6 Enrage',
     });
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'Clear',
     });
@@ -362,7 +362,7 @@ describe('SearchCommandHandler', () => {
 
     // Mock findAll to return different signups based on prog point
     mockSignupsCollection.findAll.mockImplementation(
-      ({ progPoint }: { progPoint?: string }) => {
+      (_guildId: string, { progPoint }: { progPoint?: string }) => {
         if (progPoint === 'P6 Enrage') {
           return Promise.resolve(p6SignupsMock as any);
         }
@@ -396,11 +396,11 @@ describe('SearchCommandHandler', () => {
     await collectorCallback!(mockProgPointSelect);
 
     // Verify the search was performed for at least the selected prog point
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'P6 Enrage',
     });
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'Clear',
     });
@@ -472,7 +472,7 @@ describe('SearchCommandHandler', () => {
     }));
 
     mockSignupsCollection.findAll.mockImplementation(
-      ({ progPoint }: { progPoint?: string }) =>
+      (_guildId: string, { progPoint }: { progPoint?: string }) =>
         progPoint === 'Clear'
           ? Promise.resolve(manySignups as any)
           : Promise.resolve([]),
@@ -638,7 +638,7 @@ describe('SearchCommandHandler', () => {
 
     // Mock findAll to return different results for different prog points
     mockSignupsCollection.findAll.mockImplementation(
-      ({ progPoint }: { progPoint?: string }) => {
+      (_guildId: string, { progPoint }: { progPoint?: string }) => {
         if (progPoint === 'P6 Enrage') return Promise.resolve(p6Signups as any);
         if (progPoint === 'Clear') return Promise.resolve(clearSignups as any);
         return Promise.resolve([]);
@@ -694,11 +694,11 @@ describe('SearchCommandHandler', () => {
     await collectorCallback!(mockProgPointSelect);
 
     // Verify the search was performed for all prog points >= P6 Enrage (order 1)
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'P6 Enrage',
     });
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'Clear',
     });
@@ -756,7 +756,7 @@ describe('SearchCommandHandler', () => {
     await collectorCallback!(mockProgPointSelect);
 
     // Verify the search was performed only for Clear (highest order)
-    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith({
+    expect(mockSignupsCollection.findAll).toHaveBeenCalledWith('guild123', {
       encounter: Encounter.TOP,
       progPoint: 'Clear',
     });

--- a/src/slash-commands/search/handlers/search.command-handler.ts
+++ b/src/slash-commands/search/handlers/search.command-handler.ts
@@ -100,6 +100,7 @@ class SearchCommandHandler implements ISlashCommand {
         // Create a row with the prog point selection menu
         const progPointOptions =
           await this.encountersService.getProgPointsAsOptions(
+            interaction.guildId,
             selectedEncounter,
           );
 
@@ -128,6 +129,7 @@ class SearchCommandHandler implements ISlashCommand {
 
         // Search for signups matching the encounter and prog point
         const searchResults = await this.searchSignups(
+          interaction.guildId,
           selectedEncounter as Encounter,
           selectedProgPoint,
         );
@@ -197,9 +199,16 @@ class SearchCommandHandler implements ISlashCommand {
   /**
    * Search for signups matching the encounter and prog point (at least)
    */
-  private async searchSignups(encounter: Encounter, progPoint: string) {
+  private async searchSignups(
+    guildId: string,
+    encounter: Encounter,
+    progPoint: string,
+  ) {
     // Get all prog points for the encounter
-    const allProgPoints = await this.encountersService.getProgPoints(encounter);
+    const allProgPoints = await this.encountersService.getProgPoints(
+      guildId,
+      encounter,
+    );
 
     // Find the order of the selected prog point
     const selectedOrder = allProgPoints.find((p) => p.id === progPoint)?.order;
@@ -224,7 +233,7 @@ class SearchCommandHandler implements ISlashCommand {
     // Query for signups with any of the eligible prog points
     // Using multiple queries since Firestore has limitations on complex queries
     const signupPromises = eligibleProgPoints.map((progPointId) =>
-      this.signupsCollection.findAll({
+      this.signupsCollection.findAll(guildId, {
         encounter,
         progPoint: progPointId,
       }),

--- a/src/slash-commands/settings/subcommands/prog-point-roles/edit-prog-point-roles.command-handler.spec.ts
+++ b/src/slash-commands/settings/subcommands/prog-point-roles/edit-prog-point-roles.command-handler.spec.ts
@@ -114,7 +114,7 @@ describe('EditProgPointRolesCommandHandler', () => {
 
     expect(
       encountersComponentsService.createProgPointSelectMenu,
-    ).toHaveBeenCalledWith(Encounter.TOP, {
+    ).toHaveBeenCalledWith(guildId, Encounter.TOP, {
       customId: PROG_POINT_ROLES_SELECT_ID,
       includeCleared: false,
       multiSelect: true,

--- a/src/slash-commands/settings/subcommands/prog-point-roles/edit-prog-point-roles.command-handler.ts
+++ b/src/slash-commands/settings/subcommands/prog-point-roles/edit-prog-point-roles.command-handler.ts
@@ -42,6 +42,7 @@ class EditProgPointRolesCommandHandler implements ISlashCommand {
 
       const menu =
         await this.encountersComponentsService.createProgPointSelectMenu(
+          interaction.guildId,
           encounter,
           {
             customId: PROG_POINT_ROLES_SELECT_ID,

--- a/src/slash-commands/signup/decline-reason-request.service.ts
+++ b/src/slash-commands/signup/decline-reason-request.service.ts
@@ -243,6 +243,7 @@ export class DeclineReasonRequestService {
   ): Promise<void> {
     try {
       await this.signupCollection.updateDeclineReason(
+        reviewMessage.guildId,
         { discordId: signup.discordId, encounter: signup.encounter },
         declineReason,
       );

--- a/src/slash-commands/signup/handlers/send-signup-review.command-handler.ts
+++ b/src/slash-commands/signup/handlers/send-signup-review.command-handler.ts
@@ -92,7 +92,7 @@ class SendSignupReviewCommandHandler
     ]);
 
     // update firebase with the message that correlates to this signup
-    await this.repository.setReviewMessageId(signup, message.id);
+    await this.repository.setReviewMessageId(guildId, signup, message.id);
     return message.id;
   }
 

--- a/src/slash-commands/signup/handlers/signup.command-handler.ts
+++ b/src/slash-commands/signup/handlers/signup.command-handler.ts
@@ -131,7 +131,7 @@ class SignupCommandHandler implements ISlashCommand {
     interaction: ChatInputCommandInteraction<'cached'>,
   ): Promise<SignupDocument | undefined> {
     const [signup, reviewChannelId] = await Promise.all([
-      this.repository.upsert(request),
+      this.repository.upsert(interaction.guildId, request),
       this.settingsService.getReviewChannel(interaction.guildId),
     ]);
 

--- a/src/slash-commands/signup/signup.service.ts
+++ b/src/slash-commands/signup/signup.service.ts
@@ -185,7 +185,10 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
 
     // TODO: If for some reason this throws and there is no signup, we should inform the person performing the interaction
     // that there is no associated signup anymore
-    const signup = await this.repository.findByReviewId(message.id);
+    const signup = await this.repository.findByReviewId(
+      message.guildId,
+      message.id,
+    );
 
     if (signup.reviewedBy) {
       this.logger.log(
@@ -247,8 +250,17 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
     settings: SettingsDocument,
   ): Promise<SignupApprovedEvent> {
     const progPoint = await this.confirmProgPoint(signup, message, user);
-    const confirmedSignup = await this.buildConfirmedSignup(signup, progPoint);
-    await this.persistApprovedSignup(confirmedSignup, settings, user);
+    const confirmedSignup = await this.buildConfirmedSignup(
+      message.guildId,
+      signup,
+      progPoint,
+    );
+    await this.persistApprovedSignup(
+      message.guildId,
+      confirmedSignup,
+      settings,
+      user,
+    );
 
     return new SignupApprovedEvent(confirmedSignup, settings, user, message);
   }
@@ -260,15 +272,21 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   ): Promise<string | undefined> {
     const sourceEmbed = getFirstEmbed(message);
 
-    return await this.requestProgPointConfirmation(signup, sourceEmbed, user);
+    return await this.requestProgPointConfirmation(
+      message.guildId,
+      signup,
+      sourceEmbed,
+      user,
+    );
   }
 
   private async buildConfirmedSignup(
+    guildId: string,
     signup: SignupDocument,
     progPoint: string | undefined,
   ): Promise<SignupDocument> {
     const partyStatus = progPoint
-      ? await this.getPartyStatus(signup.encounter, progPoint)
+      ? await this.getPartyStatus(guildId, signup.encounter, progPoint)
       : undefined;
 
     return {
@@ -279,12 +297,14 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async persistApprovedSignup(
+    guildId: string,
     confirmedSignup: SignupDocument,
     settings: SettingsDocument,
     user: User,
   ): Promise<void> {
     if (settings.spreadsheetId) {
       await this.sheetsService.upsertSignup(
+        guildId,
         confirmedSignup,
         settings.spreadsheetId,
       );
@@ -293,13 +313,14 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
     const hasCleared = confirmedSignup.partyStatus === PartyStatus.Cleared;
 
     if (hasCleared) {
-      await this.repository.removeSignup({
+      await this.repository.removeSignup(guildId, {
         character: confirmedSignup.character,
         world: confirmedSignup.world,
         encounter: confirmedSignup.encounter,
       });
     } else {
       await this.repository.updateSignupStatus(
+        guildId,
         SignupStatus.APPROVED,
         confirmedSignup,
         user.username,
@@ -314,6 +335,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   ): Promise<SignupDeclinedEvent> {
     // Update signup status immediately (for sequential reaction processing)
     await this.repository.updateSignupStatus(
+      message.guildId,
       SignupStatus.DECLINED,
       signup,
       user.username,
@@ -357,11 +379,12 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
 
   @SentryTraced()
   private async requestProgPointConfirmation(
+    guildId: string,
     signup: SignupDocument,
     sourceEmbed: Embed,
     user: User,
   ): Promise<string | undefined> {
-    const menu = await this.createProgPointMenu(signup.encounter);
+    const menu = await this.createProgPointMenu(guildId, signup.encounter);
     const embed = buildProgPointConfirmationEmbed(
       sourceEmbed,
       signup.progPoint,
@@ -377,10 +400,12 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async createProgPointMenu(
+    guildId: string,
     encounter: Encounter,
   ): Promise<ActionRowBuilder<StringSelectMenuBuilder>> {
     const menu =
       await this.encountersComponentsService.createProgPointSelectMenu(
+        guildId,
         encounter,
       );
     return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
@@ -424,6 +449,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   private async getPartyStatus(
+    guildId: string,
     encounter: Encounter,
     progPoint: string,
   ): Promise<PartyStatus> {
@@ -432,6 +458,7 @@ class SignupService implements OnApplicationBootstrap, OnModuleDestroy {
     }
 
     return await this.encountersService.getPartyStatusForProgPoint(
+      guildId,
       encounter,
       progPoint,
     );

--- a/src/slash-commands/sync-prog-roles/handlers/sync-prog-roles.command-handler.spec.ts
+++ b/src/slash-commands/sync-prog-roles/handlers/sync-prog-roles.command-handler.spec.ts
@@ -112,7 +112,7 @@ describe('SyncProgRolesCommandHandler', () => {
 
     await handler.execute(interaction);
 
-    expect(signupCollection.findByStatusIn).toHaveBeenCalledWith([
+    expect(signupCollection.findByStatusIn).toHaveBeenCalledWith(guildId, [
       SignupStatus.APPROVED,
       SignupStatus.UPDATE_PENDING,
     ]);

--- a/src/slash-commands/sync-prog-roles/handlers/sync-prog-roles.command-handler.ts
+++ b/src/slash-commands/sync-prog-roles/handlers/sync-prog-roles.command-handler.ts
@@ -175,10 +175,10 @@ class SyncProgRolesCommandHandler implements ISlashCommand {
         return;
       }
 
-      const signups = await this.signupCollection.findByStatusIn([
-        SignupStatus.APPROVED,
-        SignupStatus.UPDATE_PENDING,
-      ]);
+      const signups = await this.signupCollection.findByStatusIn(
+        interaction.guildId,
+        [SignupStatus.APPROVED, SignupStatus.UPDATE_PENDING],
+      );
 
       const guild = await this.discordService.client.guilds.fetch(
         interaction.guildId,

--- a/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.ts
+++ b/src/slash-commands/turboprog/handlers/turbo-prog.command-handler.ts
@@ -74,7 +74,7 @@ class TurboProgCommandHandler implements ISlashCommand {
 
     if (settings.spreadsheetId && settings.turboProgSpreadsheetId) {
       // Find signup by discordId and encounter instead of character name
-      const signup = await this.signupCollection.findOne({
+      const signup = await this.signupCollection.findOne(interaction.guildId, {
         discordId: interaction.user.id,
         encounter: options.encounter,
       });


### PR DESCRIPTION
Settings, signups, blacklist and encounters each used their own ad-hoc
layout; only jobs was already guild-scoped. Standardize on
guilds/{guildId}/<collection>, with settings stored as fields on the
guild document itself.

Signups and encounters previously relied on one-database-per-guild for
isolation rather than on the data model. Threading guildId through as
the first parameter of every collection and service method removes that
assumption - clear-checker now reads only the guild it is processing,
and the encounters cache is keyed by guild so two guilds sharing an
encounter id can't serve each other's prog points.

The CLI gains a global --guild flag (falling back to $GUILD_ID) and a
`migrate guild-scope` command that copies legacy documents into the new
paths, with --dry-run and an opt-in --delete-source.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VVfXJ33JDqnKDQKhN8Vmw6