### PR TITLE
feat(slash-commands): graceful shutdown for rolling deploys

### DIFF
--- a/docs/superpowers/plans/2026-08-12-graceful-slash-command-shutdown.md
+++ b/docs/superpowers/plans/2026-08-12-graceful-slash-command-shutdown.md
@@ -1,0 +1,546 @@
+# Graceful Slash Command Shutdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On SIGTERM/SIGINT, stop dispatching new slash commands (reply with a friendly "restarting" message instead) and let in-flight command handlers finish before the process exits, bounded by a timeout.
+
+**Architecture:** A new `SlashCommandDrainService` tracks in-flight command promises in a `Set` and implements `OnModuleDestroy` to flip a `draining` flag and await the set draining (with a timeout), before Nest proceeds to the rest of the shutdown sequence. `SlashCommandsService.listenToCommands()` consults `isDraining()` before dispatching and wraps dispatch in `track()`.
+
+**Tech Stack:** NestJS (`OnModuleDestroy` lifecycle hook, DI), discord.js (`EmbedBuilder`, `Colors`), Vitest (fake timers for the timeout test).
+
+## Global Constraints
+
+- Scope is slash commands only — do not touch other event subscriptions (reaction handling, jobs, etc.).
+- In-app drain timeout is a hardcoded constant (`SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000`), not env-configurable.
+- Use the global `setTimeout` (callback-based), never `node:timers/promises`' `setTimeout` — Vitest's fake timers don't mock the `timers/promises` module (see `src/common/async-queue/async-queue.spec.ts` comment), so a promises-based timer would make the timeout test impossible to run deterministically.
+- When tracking a promise, attach cleanup via `.then(onFulfilled, onRejected)` with **both** callbacks — never `.finally()`. `.finally()` returns a new derived promise; if the original rejects and nothing observes the derived one, Node emits an unhandled rejection, and `main.ts`'s `process.on('unhandledRejection', ...)` handler calls `process.exit(1)`, crashing the process on any failed slash command.
+- Follow existing file conventions: `class Foo { ... }` + `export { Foo };` at the bottom (not `export class Foo`), `.js` import extensions (project uses `"module": "nodenext"`).
+
+---
+
+### Task 1: `SlashCommandDrainService`
+
+**Files:**
+- Create: `src/slash-commands/slash-command-drain.service.ts`
+- Test: `src/slash-commands/slash-command-drain.service.spec.ts`
+
+**Interfaces:**
+- Produces: `class SlashCommandDrainService implements OnModuleDestroy` with `isDraining(): boolean`, `track<T>(promise: Promise<T>): Promise<T>`, and `onModuleDestroy(): Promise<void>`. Also exports `const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000`. Both are named exports from `./slash-command-drain.service.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/slash-commands/slash-command-drain.service.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SHUTDOWN_DRAIN_TIMEOUT_MS,
+  SlashCommandDrainService,
+} from './slash-command-drain.service.js';
+
+describe('SlashCommandDrainService', () => {
+  let service: SlashCommandDrainService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    const fixture = await Test.createTestingModule({
+      providers: [SlashCommandDrainService],
+    }).compile();
+
+    service = fixture.get(SlashCommandDrainService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is not draining before shutdown begins', () => {
+    expect(service.isDraining()).toBe(false);
+  });
+
+  it('flips to draining synchronously when onModuleDestroy is called', () => {
+    void service.onModuleDestroy();
+
+    expect(service.isDraining()).toBe(true);
+  });
+
+  it('resolves immediately when nothing is in flight', async () => {
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+
+  it('waits for a tracked promise to settle before resolving', async () => {
+    let resolveTask!: () => void;
+    const task = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    service.track(task);
+
+    let destroyed = false;
+    const destroyPromise = service.onModuleDestroy().then(() => {
+      destroyed = true;
+    });
+
+    // let the synchronous part of onModuleDestroy run without resolving anything
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(destroyed).toBe(false);
+
+    resolveTask();
+    await destroyPromise;
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('resolves after the timeout even if a tracked promise never settles', async () => {
+    const straggler = new Promise<void>(() => {
+      // never resolves
+    });
+    service.track(straggler);
+
+    const destroyPromise = service.onModuleDestroy();
+
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_DRAIN_TIMEOUT_MS);
+
+    await expect(destroyPromise).resolves.toBeUndefined();
+  });
+
+  it('treats a rejected tracked promise as settled and does not throw', async () => {
+    const failing = Promise.reject(new Error('boom'));
+    service.track(failing).catch(() => {
+      // caller is expected to handle rejection; drain must not hang or throw
+    });
+
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+
+  it('removes a tracked promise from the in-flight set once it settles', async () => {
+    const task = Promise.resolve('done');
+    service.track(task);
+    await task;
+
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/slash-commands/slash-command-drain.service.spec.ts`
+Expected: FAIL — `Cannot find module './slash-command-drain.service.js'` (file doesn't exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/slash-commands/slash-command-drain.service.ts`:
+
+```typescript
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
+
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+
+@Injectable()
+class SlashCommandDrainService implements OnModuleDestroy {
+  private readonly logger = new Logger(SlashCommandDrainService.name);
+  private draining = false;
+  private readonly inFlight = new Set<Promise<unknown>>();
+
+  isDraining(): boolean {
+    return this.draining;
+  }
+
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.inFlight.add(promise);
+    const untrack = () => this.inFlight.delete(promise);
+    promise.then(untrack, untrack);
+    return promise;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.draining = true;
+
+    if (this.inFlight.size === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `Draining ${this.inFlight.size} in-flight slash command(s)...`,
+    );
+
+    const drained = Promise.allSettled([...this.inFlight]).then(
+      () => true as const,
+    );
+    const timedOut = new Promise<false>((resolve) => {
+      setTimeout(() => resolve(false), SHUTDOWN_DRAIN_TIMEOUT_MS);
+    });
+
+    const finishedInTime = await Promise.race([drained, timedOut]);
+
+    if (!finishedInTime) {
+      this.logger.warn(
+        `Shutdown drain timed out after ${SHUTDOWN_DRAIN_TIMEOUT_MS}ms with ${this.inFlight.size} command(s) still in flight`,
+      );
+    }
+  }
+}
+
+export { SHUTDOWN_DRAIN_TIMEOUT_MS, SlashCommandDrainService };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/slash-commands/slash-command-drain.service.spec.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/slash-commands/slash-command-drain.service.ts src/slash-commands/slash-command-drain.service.spec.ts
+git commit -m "feat(slash-commands): add SlashCommandDrainService for graceful shutdown"
+```
+
+---
+
+### Task 2: Wire draining into `SlashCommandsService`
+
+**Files:**
+- Modify: `src/slash-commands/slash-commands.service.ts`
+- Modify: `src/slash-commands/slash-commands.module.ts`
+- Test: `src/slash-commands/slash-commands.service.spec.ts` (new file)
+
+**Interfaces:**
+- Consumes: `SlashCommandDrainService.isDraining(): boolean` and `SlashCommandDrainService.track<T>(promise: Promise<T>): Promise<T>` from Task 1.
+- Produces: no new public exports — `SlashCommandsService`'s public API is unchanged. Adds a private `createRestartingEmbed(): EmbedBuilder` method.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/slash-commands/slash-commands.service.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { ChatInputCommandInteraction, Events } from 'discord.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DISCORD_CLIENT } from '../discord/discord.decorators.js';
+import { createAutoMock } from '../test-utils/mock-factory.js';
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
+import { SlashCommandRegistry } from './slash-command-registry.service.js';
+import { SlashCommandsService } from './slash-commands.service.js';
+
+vi.mock('@sentry/nestjs', () => ({
+  startNewTrace: (fn: () => unknown) => fn(),
+  startSpanManual: (_opts: unknown, fn: (span: unknown) => unknown) =>
+    fn({ setStatus: vi.fn(), end: vi.fn() }),
+  withScope: (fn: (scope: unknown) => unknown) =>
+    fn({ setUser: vi.fn(), setTag: vi.fn() }),
+}));
+
+describe('SlashCommandsService', () => {
+  let service: SlashCommandsService;
+  let client: { on: ReturnType<typeof vi.fn> };
+  let registry: SlashCommandRegistry;
+  let drainService: SlashCommandDrainService;
+
+  const createInteractionMock = (
+    overrides: Partial<ChatInputCommandInteraction<'cached'>> = {},
+  ) =>
+    ({
+      isChatInputCommand: () => true,
+      inGuild: () => true,
+      commandName: 'test-command',
+      user: { id: 'user-1', username: 'tester' },
+      guildId: 'guild-1',
+      deferred: false,
+      replied: false,
+      reply: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    }) as unknown as ChatInputCommandInteraction<'cached'>;
+
+  beforeEach(async () => {
+    client = { on: vi.fn() };
+
+    const fixture = await Test.createTestingModule({
+      providers: [SlashCommandsService],
+    })
+      .useMocker(createAutoMock)
+      .overrideProvider(DISCORD_CLIENT)
+      .useValue(client)
+      .compile();
+
+    service = fixture.get(SlashCommandsService);
+    registry = fixture.get(SlashCommandRegistry);
+    drainService = fixture.get(SlashCommandDrainService);
+  });
+
+  describe('listenToCommands', () => {
+    const getInteractionHandler = () => {
+      service.listenToCommands();
+      const call = client.on.mock.calls.find(
+        ([event]) => event === Events.InteractionCreate,
+      ) as [string, (interaction: unknown) => unknown];
+      return call[1];
+    };
+
+    it('rejects new commands with a restarting reply while draining', async () => {
+      drainService.isDraining = vi.fn().mockReturnValue(true);
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock();
+
+      await handler(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: [
+            expect.objectContaining({
+              data: expect.objectContaining({ title: 'Restarting' }),
+            }),
+          ],
+        }),
+      );
+      expect(registry.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches and tracks the command when not draining', async () => {
+      drainService.isDraining = vi.fn().mockReturnValue(false);
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock();
+
+      await handler(interaction);
+
+      expect(registry.dispatch).toHaveBeenCalledWith(interaction);
+      expect(drainService.track).toHaveBeenCalledTimes(1);
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it('ignores interactions that are not chat input commands', async () => {
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock({
+        isChatInputCommand: () => false,
+      });
+
+      await handler(interaction);
+
+      expect(registry.dispatch).not.toHaveBeenCalled();
+      expect(drainService.track).not.toHaveBeenCalled();
+    });
+
+    it('ignores interactions that are not in a guild', async () => {
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock({
+        inGuild: () => false,
+      });
+
+      await handler(interaction);
+
+      expect(registry.dispatch).not.toHaveBeenCalled();
+      expect(drainService.track).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/slash-commands/slash-commands.service.spec.ts`
+Expected: FAIL — `drainService.isDraining` is `undefined`/not called as expected because `SlashCommandsService` doesn't consult it yet (TypeError or failed assertions on the "rejects"/"dispatches" tests).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/slash-commands/slash-commands.service.ts`, update the `discord.js` import to add `Colors` and `EmbedBuilder`:
+
+```typescript
+import {
+  ChatInputCommandInteraction,
+  Client,
+  Colors,
+  EmbedBuilder,
+  Events,
+  REST,
+  Routes,
+} from 'discord.js';
+```
+
+Add an import for the drain service, right after the `ErrorService` import:
+
+```typescript
+import { ErrorService } from '../error/error.service.js';
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
+import { SlashCommandRegistry } from './slash-command-registry.service.js';
+```
+
+Add `drainService` to the constructor:
+
+```typescript
+  constructor(
+    @InjectDiscordClient() private readonly client: Client,
+    private readonly registry: SlashCommandRegistry,
+    private readonly errorService: ErrorService,
+    private readonly drainService: SlashCommandDrainService,
+  ) {}
+```
+
+Replace the body of `listenToCommands()` so the interaction handler checks `isDraining()` before dispatching, and wraps the dispatch call in `track()`:
+
+```typescript
+  listenToCommands() {
+    this.client.on(Events.InteractionCreate, (interaction) => {
+      if (!(interaction.isChatInputCommand() && interaction.inGuild())) {
+        return;
+      }
+
+      if (this.drainService.isDraining()) {
+        this.logger.debug(
+          `rejecting command during shutdown: ${interaction.commandName}`,
+        );
+        return safeReply(interaction, {
+          embeds: [this.createRestartingEmbed()],
+        });
+      }
+
+      return this.drainService.track(
+        Sentry.startNewTrace(() => {
+          return Sentry.startSpanManual(
+            { name: interaction.commandName, op: 'command' },
+            (span) => {
+              return Sentry.withScope(async (scope) => {
+                scope.setUser({
+                  userId: interaction.user.id,
+                  username: interaction.user.username,
+                });
+
+                scope.setTag('command', interaction.commandName);
+                scope.setTag('guild_id', interaction.guildId);
+
+                try {
+                  this.logger.debug(
+                    `dispatching command: ${interaction.commandName}`,
+                  );
+
+                  await this.registry.dispatch(
+                    interaction as ChatInputCommandInteraction<'cached'>,
+                  );
+                  span.setStatus({ code: 1 });
+                } catch (err) {
+                  await this.handleCommandError(err, interaction);
+                  span.setStatus({ code: 2 });
+                } finally {
+                  span.end();
+                }
+              });
+            },
+          );
+        }),
+      );
+    });
+  }
+```
+
+Add a new private method after `handleCommandError`, right before the closing brace of the class:
+
+```typescript
+  private createRestartingEmbed(): EmbedBuilder {
+    return new EmbedBuilder()
+      .setColor(Colors.Blurple)
+      .setTitle('Restarting')
+      .setDescription(
+        'The bot is restarting to deploy an update. Please try again in a few seconds.',
+      )
+      .setTimestamp();
+  }
+```
+
+In `src/slash-commands/slash-commands.module.ts`, register the new provider — add the import and add it to the `providers` array:
+
+```typescript
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
+```
+
+```typescript
+  providers: [SlashCommandsService, SlashCommandRegistry, SlashCommandDrainService],
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/slash-commands/slash-commands.service.spec.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/slash-commands/slash-commands.service.ts src/slash-commands/slash-commands.module.ts src/slash-commands/slash-commands.service.spec.ts
+git commit -m "feat(slash-commands): reject new commands and drain in-flight ones on shutdown"
+```
+
+---
+
+### Task 3: Make the Fly.io kill timeout explicit
+
+**Files:**
+- Modify: `fly.toml`
+
+**Interfaces:**
+- Consumes: none.
+- Produces: none (deployment config only).
+
+- [ ] **Step 1: Add explicit `kill_timeout` to the `[[vm]]` section**
+
+In `fly.toml`, the current `[[vm]]` section is:
+
+```toml
+[[vm]]
+cpu_kind = 'shared'
+cpus = 1
+memory_mb = 1024
+```
+
+Change it to:
+
+```toml
+[[vm]]
+cpu_kind = 'shared'
+cpus = 1
+memory_mb = 1024
+kill_timeout = '30s'
+```
+
+This is a config-only change; there's no test to run. `kill_timeout` gives Fly's shutdown grace period 5s of headroom over `SHUTDOWN_DRAIN_TIMEOUT_MS` (25s from Task 1), so the app controls its own exit instead of getting SIGKILLed mid-drain.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add fly.toml
+git commit -m "chore(deploy): set explicit 30s kill_timeout for graceful shutdown"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test:ci`
+Expected: all tests pass, including the new `slash-command-drain.service.spec.ts` and `slash-commands.service.spec.ts`.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm build:check`
+Expected: no errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `pnpm exec biome check --fix .`
+Expected: no errors (auto-fixes formatting/import order if needed — review any changes before the next commit).
+
+- [ ] **Step 4: Commit any lint auto-fixes, if there were any**
+
+```bash
+git status
+```
+
+If `biome check --fix` changed anything beyond Tasks 1–3's files, review the diff, then:
+
+```bash
+git add -A
+git commit -m "chore: apply biome formatting fixes"
+```

--- a/docs/superpowers/specs/2026-08-12-graceful-slash-command-shutdown-design.md
+++ b/docs/superpowers/specs/2026-08-12-graceful-slash-command-shutdown-design.md
@@ -1,0 +1,66 @@
+# Graceful shutdown for slash commands
+
+**Date:** 2026-08-12
+**Status:** Approved
+
+## Problem
+
+The bot is deployed on Fly.io (`fly.toml`, single machine — `min_machines_running = 1`). On a rolling restart/deploy, Fly sends SIGTERM. `main.ts` already calls `app.enableShutdownHooks()`, but `DiscordModule.onApplicationShutdown()` just does `client.removeAllListeners()` immediately — there's no draining. This means:
+
+- New slash command interactions can still be dispatched right up until the process dies mid-handler.
+- In-flight command handlers can be cut off before they finish (no reply sent, external side effects half-done).
+
+Goal: once shutdown begins, stop accepting new slash commands (reply with a friendly "restarting" message instead of dispatching) and let in-flight commands finish before the process exits, bounded by a timeout so we don't get SIGKILLed.
+
+Scope is explicitly slash commands only (`SlashCommandsService.listenToCommands`) — other event-driven subscriptions (e.g. reaction handling in `signup.service.ts`) are out of scope for this change.
+
+## Architecture
+
+A new `SlashCommandDrainService` (`src/slash-commands/slash-command-drain.service.ts`) owns all shutdown-draining state, kept separate from `SlashCommandsService` so the shutdown-timing logic is isolated and independently unit-testable:
+
+- `isDraining(): boolean` — synchronous check, `false` until shutdown begins.
+- `track<T>(promise: Promise<T>): Promise<T>` — registers a promise as in-flight (adds to an internal `Set`), removes it once settled (success or failure), returns the original promise untouched.
+- `implements OnModuleDestroy` — Nest awaits all `onModuleDestroy` hooks across every provider before `beforeApplicationShutdown`/`onApplicationShutdown` run. On destroy: set `draining = true` synchronously, then wait for the in-flight set to drain via `Promise.allSettled([...inFlight])`, raced against a timeout.
+
+`SlashCommandsService.listenToCommands()` changes minimally: at the top of the `InteractionCreate` handler, if `drainService.isDraining()`, reply immediately with a small "restarting" embed and return — `registry.dispatch` is never called. Otherwise, the existing dispatch logic is wrapped in `drainService.track(...)`.
+
+`fly.toml` gets an explicit `kill_timeout = '30s'` (currently unset, so Fly's undocumented default applies) — makes the infra-level grace period explicit and gives headroom over the in-app timeout below.
+
+## Data flow
+
+**Normal operation:** interaction arrives → `isDraining()` is `false` → dispatch wrapped in `drainService.track(...)` → runs to completion (success, or the existing `handleCommandError` catch path on failure) → removed from the in-flight set on settle.
+
+**Shutdown (SIGTERM/SIGINT):**
+1. Nest's `enableShutdownHooks()` catches the signal.
+2. Calls `onModuleDestroy()` across all providers, including `SlashCommandDrainService`.
+3. `SlashCommandDrainService` sets `draining = true` immediately (synchronous), then awaits `Promise.allSettled([...inFlight])` raced against a 25s timeout.
+4. Any interaction arriving during this window sees `isDraining() === true` → gets the friendly "restarting" reply, never dispatched.
+5. Once all in-flight settle (or the timeout fires) → `onModuleDestroy` resolves.
+6. Nest proceeds to `DiscordModule.onApplicationShutdown()` (existing `client.removeAllListeners()`).
+7. Process exits via Nest's normal signal re-raise (`process.kill(process.pid, signal)`).
+
+## Timeout
+
+25s in-app drain timeout, hardcoded as an exported constant next to `SlashCommandDrainService` (e.g. `SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000`) — not deployment-specific, so no need for env/appConfig surface. Kept a bit under `fly.toml`'s new 30s `kill_timeout` so the app controls its own exit rather than getting SIGKILLed mid-drain.
+
+## Error handling
+
+- **Timeout hit with commands still running:** log a warning (count of abandoned in-flight commands) and proceed with shutdown anyway — can't block forever, Fly will SIGKILL regardless of what we do.
+- **A tracked command throws:** already handled by the existing try/catch in `listenToCommands` (`handleCommandError` → Sentry + user reply). `track()` relies on `allSettled` semantics so a failing command doesn't hang or fail the drain wait.
+- **Rejected new interaction during drain:** logged at debug level only, not sent to Sentry — this is expected, deliberate behavior, not an error condition.
+
+## Testing
+
+- Unit tests for `SlashCommandDrainService`:
+  - `track()` + drain resolves once the tracked count hits zero.
+  - Drain resolves anyway after the timeout elapses, with a still-pending straggler promise.
+  - `isDraining()` flips synchronously and immediately when `onModuleDestroy()` is invoked, before the drain wait resolves.
+- Unit tests for `SlashCommandsService`:
+  - While draining: friendly reply is sent, `registry.dispatch` is never called.
+  - While not draining: dispatches and tracks normally (existing dispatch tests should be largely unaffected; `createAutoMock` covers the new `SlashCommandDrainService` dependency).
+
+## Out of scope
+
+- Draining non-slash-command event handlers (reaction listeners, jobs, etc.).
+- Making the in-app timeout env-configurable.
+- Any changes to `DiscordModule.onApplicationShutdown()` beyond ordering (it already runs after the drain completes, since `onModuleDestroy` hooks are awaited first).

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'ulti-project-bot'
 primary_region = 'lax'
+kill_timeout = 30
 
 [build]
 
@@ -19,7 +20,6 @@ processes = ['app']
 cpu_kind = 'shared'
 cpus = 1
 memory_mb = 1024
-kill_timeout = '30s'
 
 [env]
 GCP_PROJECT_ID = "ulti-project-407621"

--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,7 @@ processes = ['app']
 cpu_kind = 'shared'
 cpus = 1
 memory_mb = 1024
+kill_timeout = '30s'
 
 [env]
 GCP_PROJECT_ID = "ulti-project-407621"

--- a/src/slash-commands/slash-command-drain.service.spec.ts
+++ b/src/slash-commands/slash-command-drain.service.spec.ts
@@ -88,4 +88,14 @@ describe('SlashCommandDrainService', () => {
 
     await expect(service.onModuleDestroy()).resolves.toBeUndefined();
   });
+
+  it('clears the timeout timer when drain completes before timeout', async () => {
+    const task = Promise.resolve('done');
+    service.track(task);
+
+    await service.onModuleDestroy();
+
+    // Verify no timers are pending (the 25s timeout should have been cleared)
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/src/slash-commands/slash-command-drain.service.spec.ts
+++ b/src/slash-commands/slash-command-drain.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test } from '@nestjs/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SHUTDOWN_DRAIN_TIMEOUT_MS,
+  SlashCommandDrainService,
+} from './slash-command-drain.service.js';
+
+describe('SlashCommandDrainService', () => {
+  let service: SlashCommandDrainService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    const fixture = await Test.createTestingModule({
+      providers: [SlashCommandDrainService],
+    }).compile();
+
+    service = fixture.get(SlashCommandDrainService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is not draining before shutdown begins', () => {
+    expect(service.isDraining()).toBe(false);
+  });
+
+  it('flips to draining synchronously when onModuleDestroy is called', () => {
+    void service.onModuleDestroy();
+
+    expect(service.isDraining()).toBe(true);
+  });
+
+  it('resolves immediately when nothing is in flight', async () => {
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+
+  it('waits for a tracked promise to settle before resolving', async () => {
+    let resolveTask!: () => void;
+    const task = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    service.track(task);
+
+    let destroyed = false;
+    const destroyPromise = service.onModuleDestroy().then(() => {
+      destroyed = true;
+    });
+
+    // let the synchronous part of onModuleDestroy run without resolving anything
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(destroyed).toBe(false);
+
+    resolveTask();
+    await destroyPromise;
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('resolves after the timeout even if a tracked promise never settles', async () => {
+    const straggler = new Promise<void>(() => {
+      // never resolves
+    });
+    service.track(straggler);
+
+    const destroyPromise = service.onModuleDestroy();
+
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_DRAIN_TIMEOUT_MS);
+
+    await expect(destroyPromise).resolves.toBeUndefined();
+  });
+
+  it('treats a rejected tracked promise as settled and does not throw', async () => {
+    const failing = Promise.reject(new Error('boom'));
+    service.track(failing).catch(() => {
+      // caller is expected to handle rejection; drain must not hang or throw
+    });
+
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+
+  it('removes a tracked promise from the in-flight set once it settles', async () => {
+    const task = Promise.resolve('done');
+    service.track(task);
+    await task;
+
+    await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+  });
+});

--- a/src/slash-commands/slash-command-drain.service.ts
+++ b/src/slash-commands/slash-command-drain.service.ts
@@ -33,11 +33,14 @@ class SlashCommandDrainService implements OnModuleDestroy {
     const drained = Promise.allSettled([...this.inFlight]).then(
       () => true as const,
     );
+
+    let timerId: ReturnType<typeof setTimeout>;
     const timedOut = new Promise<false>((resolve) => {
-      setTimeout(() => resolve(false), SHUTDOWN_DRAIN_TIMEOUT_MS);
+      timerId = setTimeout(() => resolve(false), SHUTDOWN_DRAIN_TIMEOUT_MS);
     });
 
     const finishedInTime = await Promise.race([drained, timedOut]);
+    clearTimeout(timerId!);
 
     if (!finishedInTime) {
       this.logger.warn(

--- a/src/slash-commands/slash-command-drain.service.ts
+++ b/src/slash-commands/slash-command-drain.service.ts
@@ -34,13 +34,15 @@ class SlashCommandDrainService implements OnModuleDestroy {
       () => true as const,
     );
 
-    let timerId: ReturnType<typeof setTimeout>;
+    let timerId: ReturnType<typeof setTimeout> | undefined;
     const timedOut = new Promise<false>((resolve) => {
       timerId = setTimeout(() => resolve(false), SHUTDOWN_DRAIN_TIMEOUT_MS);
     });
 
     const finishedInTime = await Promise.race([drained, timedOut]);
-    clearTimeout(timerId!);
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
 
     if (!finishedInTime) {
       this.logger.warn(

--- a/src/slash-commands/slash-command-drain.service.ts
+++ b/src/slash-commands/slash-command-drain.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
+
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+
+@Injectable()
+class SlashCommandDrainService implements OnModuleDestroy {
+  private readonly logger = new Logger(SlashCommandDrainService.name);
+  private draining = false;
+  private readonly inFlight = new Set<Promise<unknown>>();
+
+  isDraining(): boolean {
+    return this.draining;
+  }
+
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.inFlight.add(promise);
+    const untrack = () => this.inFlight.delete(promise);
+    promise.then(untrack, untrack);
+    return promise;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.draining = true;
+
+    if (this.inFlight.size === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `Draining ${this.inFlight.size} in-flight slash command(s)...`,
+    );
+
+    const drained = Promise.allSettled([...this.inFlight]).then(
+      () => true as const,
+    );
+    const timedOut = new Promise<false>((resolve) => {
+      setTimeout(() => resolve(false), SHUTDOWN_DRAIN_TIMEOUT_MS);
+    });
+
+    const finishedInTime = await Promise.race([drained, timedOut]);
+
+    if (!finishedInTime) {
+      this.logger.warn(
+        `Shutdown drain timed out after ${SHUTDOWN_DRAIN_TIMEOUT_MS}ms with ${this.inFlight.size} command(s) still in flight`,
+      );
+    }
+  }
+}
+
+export { SHUTDOWN_DRAIN_TIMEOUT_MS, SlashCommandDrainService };

--- a/src/slash-commands/slash-commands.module.ts
+++ b/src/slash-commands/slash-commands.module.ts
@@ -15,6 +15,7 @@ import { RetireModule } from './retire/retire.module.js';
 import { SearchModule } from './search/search.module.js';
 import { SettingsModule } from './settings/settings.module.js';
 import { SignupModule } from './signup/signup.module.js';
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
 import { SlashCommandRegistry } from './slash-command-registry.service.js';
 import { SlashCommandsService } from './slash-commands.service.js';
 import { StatusModule } from './status/status.module.js';
@@ -42,7 +43,11 @@ import { TurboProgModule } from './turboprog/turbo-prog.module.js';
     SyncProgRolesModule,
     TurboProgModule,
   ],
-  providers: [SlashCommandsService, SlashCommandRegistry],
+  providers: [
+    SlashCommandsService,
+    SlashCommandRegistry,
+    SlashCommandDrainService,
+  ],
 })
 export class SlashCommandsModule implements OnApplicationBootstrap {
   constructor(private readonly service: SlashCommandsService) {}

--- a/src/slash-commands/slash-commands.service.spec.ts
+++ b/src/slash-commands/slash-commands.service.spec.ts
@@ -90,6 +90,19 @@ describe('SlashCommandsService', () => {
       expect(registry.dispatch).not.toHaveBeenCalled();
     });
 
+    it('does not let a failed restarting reply become an unhandled rejection while draining', async () => {
+      drainService.isDraining = vi.fn().mockReturnValue(true);
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock({
+        reply: vi.fn().mockRejectedValue(new Error('discord api error')),
+      });
+
+      await expect(handler(interaction)).resolves.not.toThrow();
+
+      expect(interaction.reply).toHaveBeenCalledTimes(1);
+      expect(registry.dispatch).not.toHaveBeenCalled();
+    });
+
     it('dispatches and tracks the command when not draining', async () => {
       drainService.isDraining = vi.fn().mockReturnValue(false);
       const handler = getInteractionHandler();

--- a/src/slash-commands/slash-commands.service.spec.ts
+++ b/src/slash-commands/slash-commands.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test } from '@nestjs/testing';
+import { ChatInputCommandInteraction, Events } from 'discord.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DISCORD_CLIENT } from '../discord/discord.decorators.js';
+import { createAutoMock } from '../test-utils/mock-factory.js';
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
+import { SlashCommandRegistry } from './slash-command-registry.service.js';
+import { SlashCommandsService } from './slash-commands.service.js';
+
+vi.mock('@sentry/nestjs', () => ({
+  startNewTrace: (fn: () => unknown) => fn(),
+  startSpanManual: (_opts: unknown, fn: (span: unknown) => unknown) =>
+    fn({ setStatus: vi.fn(), end: vi.fn() }),
+  withScope: (fn: (scope: unknown) => unknown) =>
+    fn({ setUser: vi.fn(), setTag: vi.fn() }),
+}));
+
+describe('SlashCommandsService', () => {
+  let service: SlashCommandsService;
+  let client: { on: ReturnType<typeof vi.fn> };
+  let registry: SlashCommandRegistry;
+  let drainService: SlashCommandDrainService;
+
+  interface MockInteractionOverrides {
+    isChatInputCommand?: () => boolean;
+    inGuild?: () => boolean;
+    commandName?: string;
+    user?: { id: string; username: string };
+    guildId?: string;
+    deferred?: boolean;
+    replied?: boolean;
+    reply?: ReturnType<typeof vi.fn>;
+  }
+
+  const createInteractionMock = (overrides: MockInteractionOverrides = {}) =>
+    ({
+      isChatInputCommand: () => true,
+      inGuild: () => true,
+      commandName: 'test-command',
+      user: { id: 'user-1', username: 'tester' },
+      guildId: 'guild-1',
+      deferred: false,
+      replied: false,
+      reply: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    }) as unknown as ChatInputCommandInteraction<'cached'>;
+
+  beforeEach(async () => {
+    client = { on: vi.fn() };
+
+    const fixture = await Test.createTestingModule({
+      providers: [
+        SlashCommandsService,
+        { provide: DISCORD_CLIENT, useValue: client },
+      ],
+    })
+      .useMocker(createAutoMock)
+      .compile();
+
+    service = fixture.get(SlashCommandsService);
+    registry = fixture.get(SlashCommandRegistry);
+    drainService = fixture.get(SlashCommandDrainService);
+  });
+
+  describe('listenToCommands', () => {
+    const getInteractionHandler = () => {
+      service.listenToCommands();
+      const call = client.on.mock.calls.find(
+        ([event]) => event === Events.InteractionCreate,
+      ) as [string, (interaction: unknown) => unknown];
+      return call[1];
+    };
+
+    it('rejects new commands with a restarting reply while draining', async () => {
+      drainService.isDraining = vi.fn().mockReturnValue(true);
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock();
+
+      await handler(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: [
+            expect.objectContaining({
+              data: expect.objectContaining({ title: 'Restarting' }),
+            }),
+          ],
+        }),
+      );
+      expect(registry.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches and tracks the command when not draining', async () => {
+      drainService.isDraining = vi.fn().mockReturnValue(false);
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock();
+
+      await handler(interaction);
+
+      expect(registry.dispatch).toHaveBeenCalledWith(interaction);
+      expect(drainService.track).toHaveBeenCalledTimes(1);
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it('ignores interactions that are not chat input commands', async () => {
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock({
+        isChatInputCommand: () => false,
+      });
+
+      await handler(interaction);
+
+      expect(registry.dispatch).not.toHaveBeenCalled();
+      expect(drainService.track).not.toHaveBeenCalled();
+    });
+
+    it('ignores interactions that are not in a guild', async () => {
+      const handler = getInteractionHandler();
+      const interaction = createInteractionMock({
+        inGuild: () => false,
+      });
+
+      await handler(interaction);
+
+      expect(registry.dispatch).not.toHaveBeenCalled();
+      expect(drainService.track).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/slash-commands/slash-commands.service.ts
+++ b/src/slash-commands/slash-commands.service.ts
@@ -38,7 +38,7 @@ class SlashCommandsService {
   ) {}
 
   listenToCommands() {
-    this.client.on(Events.InteractionCreate, (interaction) => {
+    this.client.on(Events.InteractionCreate, async (interaction) => {
       if (!(interaction.isChatInputCommand() && interaction.inGuild())) {
         return;
       }
@@ -47,9 +47,17 @@ class SlashCommandsService {
         this.logger.debug(
           `rejecting command during shutdown: ${interaction.commandName}`,
         );
-        return safeReply(interaction, {
-          embeds: [this.createRestartingEmbed()],
-        });
+        try {
+          await safeReply(interaction, {
+            embeds: [this.createRestartingEmbed()],
+          });
+        } catch (replyError) {
+          this.logger.debug(
+            { replyError },
+            'failed to send restarting reply during shutdown',
+          );
+        }
+        return;
       }
 
       return this.drainService.track(

--- a/src/slash-commands/slash-commands.service.ts
+++ b/src/slash-commands/slash-commands.service.ts
@@ -3,6 +3,8 @@ import * as Sentry from '@sentry/nestjs';
 import {
   ChatInputCommandInteraction,
   Client,
+  Colors,
+  EmbedBuilder,
   Events,
   REST,
   Routes,
@@ -21,6 +23,7 @@ import { appConfig } from '../config/app.js';
 import { InjectDiscordClient } from '../discord/discord.decorators.js';
 import { safeReply } from '../discord/discord.helpers.js';
 import { ErrorService } from '../error/error.service.js';
+import { SlashCommandDrainService } from './slash-command-drain.service.js';
 import { SlashCommandRegistry } from './slash-command-registry.service.js';
 
 @Injectable()
@@ -31,6 +34,7 @@ class SlashCommandsService {
     @InjectDiscordClient() private readonly client: Client,
     private readonly registry: SlashCommandRegistry,
     private readonly errorService: ErrorService,
+    private readonly drainService: SlashCommandDrainService,
   ) {}
 
   listenToCommands() {
@@ -39,38 +43,49 @@ class SlashCommandsService {
         return;
       }
 
-      return Sentry.startNewTrace(() => {
-        return Sentry.startSpanManual(
-          { name: interaction.commandName, op: 'command' },
-          (span) => {
-            return Sentry.withScope(async (scope) => {
-              scope.setUser({
-                userId: interaction.user.id,
-                username: interaction.user.username,
-              });
-
-              scope.setTag('command', interaction.commandName);
-              scope.setTag('guild_id', interaction.guildId);
-
-              try {
-                this.logger.debug(
-                  `dispatching command: ${interaction.commandName}`,
-                );
-
-                await this.registry.dispatch(
-                  interaction as ChatInputCommandInteraction<'cached'>,
-                );
-                span.setStatus({ code: 1 });
-              } catch (err) {
-                await this.handleCommandError(err, interaction);
-                span.setStatus({ code: 2 });
-              } finally {
-                span.end();
-              }
-            });
-          },
+      if (this.drainService.isDraining()) {
+        this.logger.debug(
+          `rejecting command during shutdown: ${interaction.commandName}`,
         );
-      });
+        return safeReply(interaction, {
+          embeds: [this.createRestartingEmbed()],
+        });
+      }
+
+      return this.drainService.track(
+        Sentry.startNewTrace(() => {
+          return Sentry.startSpanManual(
+            { name: interaction.commandName, op: 'command' },
+            (span) => {
+              return Sentry.withScope(async (scope) => {
+                scope.setUser({
+                  userId: interaction.user.id,
+                  username: interaction.user.username,
+                });
+
+                scope.setTag('command', interaction.commandName);
+                scope.setTag('guild_id', interaction.guildId);
+
+                try {
+                  this.logger.debug(
+                    `dispatching command: ${interaction.commandName}`,
+                  );
+
+                  await this.registry.dispatch(
+                    interaction as ChatInputCommandInteraction<'cached'>,
+                  );
+                  span.setStatus({ code: 1 });
+                } catch (err) {
+                  await this.handleCommandError(err, interaction);
+                  span.setStatus({ code: 2 });
+                } finally {
+                  span.end();
+                }
+              });
+            },
+          );
+        }),
+      );
     });
   }
 
@@ -137,6 +152,16 @@ class SlashCommandsService {
         'Failed to send error response',
       );
     }
+  }
+
+  private createRestartingEmbed(): EmbedBuilder {
+    return new EmbedBuilder()
+      .setColor(Colors.Blurple)
+      .setTitle('Restarting')
+      .setDescription(
+        'The bot is restarting to deploy an update. Please try again in a few seconds.',
+      )
+      .setTimestamp();
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `SlashCommandDrainService`, which tracks in-flight slash command dispatches and implements `OnModuleDestroy` to stop accepting new commands and drain in-flight ones (bounded by a 25s timeout) on SIGTERM/SIGINT.
- Wires it into `SlashCommandsService.listenToCommands()`: while draining, new interactions get a friendly "Restarting" reply instead of being dispatched (with the reply itself guarded against a rejected Discord API call crashing the process).
- Sets an explicit top-level `kill_timeout = 30` in `fly.toml` (previously unset, and a first attempt at this landed the key in the wrong TOML table where Fly silently drops it) so the infra-level grace period has headroom over the in-app timeout.

## Test plan
- [x] `pnpm test:ci` — 57 files / 477 tests passing
- [x] `pnpm build:check` — clean
- [x] `pnpm exec biome check --fix .` — clean
- [x] `flyctl config validate` / `flyctl config show --local --toml` — confirms `kill_timeout` now applies at the top level
- [x] Spec, plan, and full task-by-task + final whole-branch code review in `docs/superpowers/specs/` and `docs/superpowers/plans/`