### PR TITLE
fix(sheets): grow sheet by 50 rows on grid-limit error and retry

### DIFF
--- a/src/sheets/sheets.utils.spec.ts
+++ b/src/sheets/sheets.utils.spec.ts
@@ -1,0 +1,94 @@
+import type { sheets_v4 } from '@googleapis/sheets';
+import { describe, expect, it, vi } from 'vitest';
+import { updateSheet } from './sheets.utils.js';
+
+function createClient({
+  update,
+  append,
+}: {
+  update?: ReturnType<typeof vi.fn>;
+  append?: ReturnType<typeof vi.fn>;
+} = {}) {
+  return {
+    spreadsheets: {
+      get: vi.fn().mockResolvedValue({
+        data: { sheets: [{ properties: { title: 'DMU', sheetId: 42 } }] },
+      }),
+      batchUpdate: vi.fn().mockResolvedValue({ data: {}, status: 200 }),
+      values: {
+        update: update ?? vi.fn().mockResolvedValue({ data: {}, status: 200 }),
+        append: append ?? vi.fn().mockResolvedValue({ data: {}, status: 200 }),
+      },
+    },
+  } as unknown as sheets_v4.Sheets;
+}
+
+const GRID_LIMIT_ERROR = new Error(
+  'Range (DMU!I359:L) exceeds grid limits. Max rows: 358, max columns: 42',
+);
+
+describe('updateSheet', () => {
+  it('grows the sheet by 50 rows and retries when the update range exceeds grid limits', async () => {
+    const update = vi
+      .fn()
+      .mockRejectedValueOnce(GRID_LIMIT_ERROR)
+      .mockResolvedValueOnce({ data: { updatedRows: 1 }, status: 200 });
+    const client = createClient({ update });
+
+    const result = await updateSheet(client, {
+      spreadsheetId: 'sheet-id',
+      range: 'DMU!I359:L359',
+      type: 'update',
+      values: [['Character', 'World', 'Role', '']],
+    });
+
+    expect(client.spreadsheets.batchUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spreadsheetId: 'sheet-id',
+        requestBody: {
+          requests: [
+            { appendDimension: { sheetId: 42, dimension: 'ROWS', length: 50 } },
+          ],
+        },
+      }),
+      expect.anything(),
+    );
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(result.data).toEqual({ updatedRows: 1 });
+  });
+
+  it('grows the sheet and retries when an append range exceeds grid limits', async () => {
+    const append = vi
+      .fn()
+      .mockRejectedValueOnce(GRID_LIMIT_ERROR)
+      .mockResolvedValueOnce({ data: { updates: {} }, status: 200 });
+    const client = createClient({ append });
+
+    await updateSheet(client, {
+      spreadsheetId: 'sheet-id',
+      range: 'DMU!I359:L359',
+      type: 'append',
+      values: [['Character', 'World', 'Role', '']],
+    });
+
+    expect(client.spreadsheets.batchUpdate).toHaveBeenCalledTimes(1);
+    expect(append).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not swallow unrelated errors', async () => {
+    const otherError = new Error('some other API failure');
+    const update = vi.fn().mockRejectedValueOnce(otherError);
+    const client = createClient({ update });
+
+    await expect(
+      updateSheet(client, {
+        spreadsheetId: 'sheet-id',
+        range: 'DMU!I10:L10',
+        type: 'update',
+        values: [['Character', 'World', 'Role', '']],
+      }),
+    ).rejects.toThrow('some other API failure');
+
+    expect(client.spreadsheets.batchUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/sheets/sheets.utils.ts
+++ b/src/sheets/sheets.utils.ts
@@ -25,6 +25,43 @@ type UpdateSheetProps = {
  */
 type SheetsResponse<T> = { data: T; status: number };
 
+const GRID_LIMIT_EXCEEDED_PATTERN = /exceeds grid limits/i;
+const ROWS_TO_ADD_ON_GRID_LIMIT = 50;
+
+function isGridLimitExceededError(error: unknown): boolean {
+  return (
+    Error.isError(error) && GRID_LIMIT_EXCEEDED_PATTERN.test(error.message)
+  );
+}
+
+/**
+ * `values.update`/`values.append` reject any range past the sheet's current
+ * row count instead of growing it, so a full signup sheet throws
+ * "exceeds grid limits" rather than writing the row.
+ */
+async function growSheetRows(
+  client: sheets_v4.Sheets,
+  spreadsheetId: string,
+  range: string,
+): Promise<void> {
+  const sheetName = range.split('!')[0];
+  const sheetId = await getSheetIdByName(client, spreadsheetId, sheetName);
+
+  if (sheetId == null) {
+    return;
+  }
+
+  await batchUpdate(client, spreadsheetId, [
+    {
+      appendDimension: {
+        sheetId,
+        dimension: 'ROWS',
+        length: ROWS_TO_ADD_ON_GRID_LIMIT,
+      },
+    },
+  ]);
+}
+
 /**
  * Gets the row values of a given sheet and range
  * @param client
@@ -52,7 +89,7 @@ export async function getSheetValues(
  * @param props
  * @returns
  */
-export function updateSheet(
+export async function updateSheet(
   client: sheets_v4.Sheets,
   { spreadsheetId, type, values, range }: UpdateSheetProps,
   options?: MethodOptions,
@@ -71,9 +108,21 @@ export function updateSheet(
     },
   };
 
-  return type === 'update'
-    ? client.spreadsheets.values.update(payload, options)
-    : client.spreadsheets.values.append(payload, options);
+  const sendRequest = () =>
+    type === 'update'
+      ? client.spreadsheets.values.update(payload, options)
+      : client.spreadsheets.values.append(payload, options);
+
+  try {
+    return await sendRequest();
+  } catch (error) {
+    if (!isGridLimitExceededError(error)) {
+      throw error;
+    }
+
+    await growSheetRows(client, spreadsheetId, range);
+    return sendRequest();
+  }
 }
 
 export function batchUpdate(


### PR DESCRIPTION
## Summary
- `SheetsService` writes signups/TurboProg rows via `values.update`/`values.append`, which reject any range past the sheet's current row count with `Range (...) exceeds grid limits` instead of extending the sheet.
- When a signup sheet fills up, this surfaced as an unhandled error and the signup silently failed to write.
- `updateSheet` in `sheets.utils.ts` now detects that specific error, appends 50 rows to the sheet via `appendDimension`, and retries the original request once.

Fixes ULTI-PROJECT-BOT-6W

## Test plan
- [x] `pnpm vitest run src/sheets/` — new `sheets.utils.spec.ts` covers grid-limit-exceeded retry for both `update` and `append`, plus that unrelated errors are not swallowed
- [x] `pnpm vitest run` — full suite (467 tests) passes
- [x] `pnpm build:check` — typecheck clean
- [x] `pnpm exec biome check` — lint clean